### PR TITLE
Bump version to 1.0.1 for release

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSUIElement</key>
 	<true/>
 </dict>

--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -91,7 +91,7 @@ final class RateLimitFetcher {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("oauth-2025-04-20,interleaved-thinking-2025-05-14", forHTTPHeaderField: "anthropic-beta")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("AIBattery/1.0.0 (macOS)", forHTTPHeaderField: "User-Agent")
+        request.setValue("AIBattery/1.0.1 (macOS)", forHTTPHeaderField: "User-Agent")
         request.timeoutInterval = 15
 
         let body: [String: Any] = [

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "1"
+        MARKETING_VERSION: "1.0.1"
+        CURRENT_PROJECT_VERSION: "2"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -41,9 +41,9 @@ cat > "$APP_DIR/Contents/Info.plist" << 'PLIST'
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -33,8 +33,8 @@ Every hardcoded value in the app. When changing a threshold, URL, or price, upda
 | Probe models (fallback order) | `claude-sonnet-4-5-20250929`, `claude-haiku-3-5-20241022` |
 | Probe content | `"."` |
 | Probe max_tokens | `1` |
-| User-Agent | `AIBattery/1.0.0 (macOS)` |
-| Keychain service | `"Claude Code"` |
+| User-Agent | `AIBattery/1.0.1 (macOS)` |
+| Keychain service (OAuth) | `"AIBattery"` |
 
 ## Statuspage Component IDs
 

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -209,7 +209,7 @@ JSONL line schema (Codable):
 - `fetch() async -> APIFetchResult` — returns both rate limits and org profile from a single API call
 - POST `/v1/messages?beta=true` with `max_tokens: 1`, content `"."`
 - Model fallback list: tries `claude-sonnet-4-5-20250929` first, falls back to `claude-haiku-3-5-20241022`. Remembers last working model index to avoid repeated fallbacks.
-- Headers: `Authorization: Bearer {token}`, `anthropic-version: 2023-06-01`, `anthropic-beta: oauth-2025-04-20,interleaved-thinking-2025-05-14`, `User-Agent: AIBattery/1.0.0 (macOS)`
+- Headers: `Authorization: Bearer {token}`, `anthropic-version: 2023-06-01`, `anthropic-beta: oauth-2025-04-20,interleaved-thinking-2025-05-14`, `User-Agent: AIBattery/1.0.1 (macOS)`
 - Gets access token from `OAuthManager.shared.getAccessToken()` (auto-refreshes if expired)
 - Timeout: 15 sec
 - Parses `anthropic-ratelimit-unified-*` response headers via `RateLimitUsage.parse(headers:)` and `APIProfile.parse(headers:)` from the same response


### PR DESCRIPTION
## Summary
- Bump version strings from 1.0.0 to 1.0.1 across all 6 locations (Info.plist, build script, User-Agent, project.yml, spec/CONSTANTS.md, spec/DATA_LAYER.md)
- Fix stale Keychain service reference in CONSTANTS.md ("Claude Code" → "AIBattery")

## Test plan
- [x] `swift build -c release` passes
- [ ] CI passes