### PR TITLE
Move Gatekeeper/Keychain FAQ under Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ OAuth 2.0 with PKCE — same protocol as Claude Code.
 
 Sessions auto-refresh. Tokens stored in macOS Keychain (separate from Claude Code credentials). Error messages are specific — expired codes, invalid codes, and network errors each get a clear description.
 
+### Why does macOS block the app or ask about Keychain access?
+
+AI Battery isn't notarized — there's no Apple Developer license behind this project, so macOS treats it as unidentified. Two prompts may appear on first launch:
+
+- **Gatekeeper block** — macOS prevents the app from opening. Fix: **System Settings → Privacy & Security → Open Anyway** (see [Install](#install))
+- **Keychain access** — the app stores a single OAuth token in macOS Keychain, Apple's encrypted credential store. This is the safest option — the same place Claude Code, browsers, and every other macOS app stores secrets. Click **Always Allow**.
+
+Both are one-time prompts. Neither will appear again after the first launch.
+
 ## How It Works
 
 AI Battery makes a minimal API call each refresh cycle to read your rate limit headers. It also reads local JSONL session logs for token counts and context health — **never your message content**.
@@ -162,15 +171,6 @@ Rate limits (5-hour / 7-day) always work immediately since they come from the AP
 **What's "binding"?** Whichever rate limit window is currently the active constraint.
 
 **What's ⚠️ "throttled"?** Anthropic is actively limiting your requests. Wait for the reset timer.
-
-**Why does macOS block the app or ask about Keychain access?**
-
-AI Battery isn't notarized — there's no Apple Developer license behind this project, so macOS treats it as unidentified. Two prompts may appear on first launch:
-
-- **Gatekeeper block** — macOS prevents the app from opening. Fix: **System Settings → Privacy & Security → Open Anyway** (see [Install](#install))
-- **Keychain access** — the app stores a single OAuth token in macOS Keychain, Apple's encrypted credential store. This is the safest option — the same place Claude Code, browsers, and every other macOS app stores secrets. Click **Always Allow**.
-
-Both are one-time prompts. Neither will appear again after the first launch.
 
 ## Privacy
 


### PR DESCRIPTION
Moves the macOS prompts explanation from FAQ to a subsection of Authentication, where users actually encounter it.