### PR TITLE
Add Homebrew cask, badges, and Discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,10 @@ jobs:
             .build/AIBattery.zip
             .build/AIBattery.dmg
           generate_release_notes: true
+
+      - name: Update Homebrew cask
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: ./scripts/update-homebrew.sh "${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,29 @@ Rate limits, context health, and token usage — always visible in your macOS me
 [![macOS](https://img.shields.io/badge/macOS-13%2B-blue?logo=apple&logoColor=white)](https://www.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![CI](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml/badge.svg)](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml)
+[![GitHub stars](https://img.shields.io/github/stars/KyleNesium/AIBattery?style=social)](https://github.com/KyleNesium/AIBattery/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/KyleNesium/AIBattery/total?logo=github&label=Downloads)](https://github.com/KyleNesium/AIBattery/releases)
 
 <br/>
 
 <img src="screenshots/dashboard.png" width="240" alt="AI Battery dashboard" />
+
+<br/>
+
+<img src="screenshots/demo.gif" width="480" alt="AI Battery demo" />
 
 </div>
 
 ---
 
 ## Install
+
+**Homebrew** (recommended):
+
+```bash
+brew tap KyleNesium/tap
+brew install --cask aibattery
+```
 
 **Quick install** — paste in Terminal:
 
@@ -47,7 +60,13 @@ Requires **macOS 13+** and [Claude Code](https://docs.anthropic.com/en/docs/clau
 
 ## Update
 
-Re-run the quick install command — it overwrites the old version in place:
+**Homebrew:**
+
+```bash
+brew upgrade --cask aibattery
+```
+
+**Or** re-run the quick install command — it overwrites the old version in place:
 
 ```bash
 curl -sL https://github.com/KyleNesium/AIBattery/releases/latest/download/AIBattery.zip -o /tmp/AIBattery.zip && ditto -x -k /tmp/AIBattery.zip /Applications && xattr -cr /Applications/AIBattery.app && open /Applications/AIBattery.app
@@ -214,6 +233,14 @@ Detailed specs in [`spec/`](spec/):
 | [`CONSTANTS.md`](spec/CONSTANTS.md) | Every hardcoded value — thresholds, URLs, pricing, sizes |
 
 ## Uninstall
+
+**Homebrew:**
+
+```bash
+brew uninstall --cask aibattery
+```
+
+**Manual:**
 
 1. Right-click **AI Battery** in the menu bar → **Quit**
 2. Open **Applications** in Finder → drag **AI Battery** to the Trash

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Updates the Homebrew cask formula in KyleNesium/homebrew-tap after a release.
+# Called by the release GitHub Action — requires GH_TOKEN with repo scope.
+
+set -euo pipefail
+
+VERSION="${1:?Usage: update-homebrew.sh <version>}"
+VERSION="${VERSION#v}"  # Strip leading 'v' if present
+
+ZIP_URL="https://github.com/KyleNesium/AIBattery/releases/download/v${VERSION}/AIBattery.zip"
+
+echo "Downloading AIBattery.zip for v${VERSION}..."
+curl -sL "$ZIP_URL" -o /tmp/aibattery-release.zip
+SHA256=$(shasum -a 256 /tmp/aibattery-release.zip | awk '{print $1}')
+echo "SHA256: ${SHA256}"
+
+echo "Cloning homebrew-tap..."
+WORKDIR=$(mktemp -d)
+git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/KyleNesium/homebrew-tap.git" "$WORKDIR"
+
+CASK_FILE="$WORKDIR/Casks/aibattery.rb"
+
+# Update version and sha256
+sed -i '' "s/version \".*\"/version \"${VERSION}\"/" "$CASK_FILE"
+sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" "$CASK_FILE"
+
+echo "Updated cask formula:"
+head -5 "$CASK_FILE"
+
+cd "$WORKDIR"
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add Casks/aibattery.rb
+git commit -m "Update aibattery to v${VERSION}"
+git push
+
+echo "Homebrew cask updated to v${VERSION}"
+rm -rf "$WORKDIR" /tmp/aibattery-release.zip


### PR DESCRIPTION
## Summary
- **Homebrew cask**: Created [KyleNesium/homebrew-tap](https://github.com/KyleNesium/homebrew-tap) with `aibattery` cask formula — `brew tap KyleNesium/tap && brew install --cask aibattery`
- **README badges**: Added GitHub stars (social proof) and total download count
- **README install/update/uninstall**: Added Homebrew as the recommended method across all three sections
- **Demo GIF placeholder**: Added `screenshots/demo.gif` reference in hero section (GIF needs to be recorded and added separately)
- **Release automation**: Workflow now auto-updates the Homebrew cask SHA on new releases via `scripts/update-homebrew.sh` (requires `HOMEBREW_TAP_TOKEN` secret — skipped gracefully if not set)
- **GitHub Discussions**: Enabled with a pinned welcome post linking to Q&A, Ideas, and Show & Tell categories

## Setup required
- [ ] Add `HOMEBREW_TAP_TOKEN` repo secret (a PAT with `repo` scope for `KyleNesium/homebrew-tap`) to enable auto-updating the cask on release
- [ ] Record and add `screenshots/demo.gif` (~10s showing menu bar click → popover)
- [ ] Pin the [Welcome discussion](https://github.com/KyleNesium/AIBattery/discussions/10) via the web UI

## Test plan
- [ ] Verify `brew tap KyleNesium/tap && brew install --cask aibattery` installs correctly
- [ ] Verify badges render on GitHub README
- [ ] Verify release workflow still passes CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)