### PR TITLE
Fix audit issues: race condition, cache, backoff, User-Agent

### DIFF
--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -28,6 +28,12 @@ final class RateLimitFetcher {
     /// Which model index to use (remembers last working model to avoid repeated fallbacks).
     private var currentModelIndex = 0
 
+    /// User-Agent string built from bundle version at startup.
+    private let userAgent: String = {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+        return "AIBattery/\(version) (macOS)"
+    }()
+
     /// Fetches rate limits + org profile in a single API call.
     func fetch() async -> APIFetchResult {
         guard let accessToken = await OAuthManager.shared.getAccessToken() else {
@@ -91,7 +97,7 @@ final class RateLimitFetcher {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("oauth-2025-04-20,interleaved-thinking-2025-05-14", forHTTPHeaderField: "anthropic-beta")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("AIBattery/1.0.2 (macOS)", forHTTPHeaderField: "User-Agent")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         request.timeoutInterval = 15
 
         let body: [String: Any] = [

--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -51,12 +51,14 @@ public final class UsageViewModel: ObservableObject {
             lastFreshFetch = api.fetchedAt
         }
 
-        // Aggregate on background thread — purely local, no timeout needed
+        // Aggregate on background thread — purely local, no timeout needed.
+        // Capture values directly from `api` (not self.apiResult) to avoid racing
+        // with a concurrent refresh that could overwrite the instance variable.
         let aggregator = self.aggregator
-        let currentResult = self.apiResult
-        let orgName = currentResult?.profile?.organizationName
+        let rateLimits = api.rateLimits
+        let orgName = api.profile?.organizationName
         let result = await Task.detached {
-            aggregator.aggregate(rateLimits: currentResult?.rateLimits, orgName: orgName)
+            aggregator.aggregate(rateLimits: rateLimits, orgName: orgName)
         }.value
 
         snapshot = result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ These aren't obvious from reading the code — know them before making changes:
 - `OAuthManager.exchangeCode()` returns `Result<Void, AuthError>` — callers handle typed errors. Validates state parameter for CSRF protection.
 - `APIFetchResult.isCached` distinguishes fresh API data from stale cache — always check before treating as fresh. Cache expires after 1 hour.
 - OAuth refresh: network errors keep `isAuthenticated` true (retry next cycle); only auth errors trigger logout
-- StatusChecker backs off 5 min after failures — no immediate retries
+- StatusChecker backs off 60s after failures — no immediate retries
 - SessionLogReader cache caps at 200 entries with LRU eviction; trailing JSONL lines without closing `}` are skipped
 - NotificationManager fires once per outage via `osascript`, deduplicates per component, resets on recovery
 - `~/.claude.json` oauthAccount may not match the OAuth token's org if user switched accounts

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Rate limits (5-hour / 7-day) always work immediately since they come from the AP
 
 - Reads local JSONL for token counts only — **never your message content**
 - Network calls: `api.anthropic.com` (rate limits) · `console.anthropic.com` (OAuth) · `status.claude.com` (status)
-- Status checks back off for 5 minutes after failures — no hammering downed services
+- Status checks back off for 60 seconds after failures — no hammering downed services
 - No analytics. No telemetry. No tracking.
 
 ## Architecture

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -12,7 +12,7 @@ Every hardcoded value in the app. When changing a threshold, URL, or price, upda
 | Fallback timer | 60 sec | FileWatcher |
 | API request timeout | 15 sec | RateLimitFetcher |
 | Status request timeout | 5 sec | StatusChecker |
-| Status backoff interval | 300 sec (5 min) | StatusChecker |
+| Status backoff interval | 60 sec | StatusChecker |
 | Rate limit cache max age | 3600 sec (1 hour) | RateLimitFetcher |
 | Menu bar staleness threshold | 300 sec (5 min) | MenuBarLabel |
 

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -228,7 +228,7 @@ JSONL line schema (Codable):
 - **Incident impact escalation**: when components report "operational" but active incidents exist, factors in incident `impact` field (`"none"`, `"minor"`, `"major"`, `"critical"`) to determine overall indicator. If impact is `"none"` but incidents are active, escalates to at least `.degradedPerformance` (yellow dot).
 - Checks for active incidents (status not `resolved` or `postmortem`)
 - Returns `.unknown` on any error
-- **Backoff**: on failure, skips fetches for 5 minutes (`backoffInterval = 300s`) to avoid noise; clears on success
+- **Backoff**: on failure, skips fetches for 60 seconds (`backoffInterval = 60`) to avoid noise; clears on success
 
 ### StatsCacheReader (`Services/StatsCacheReader.swift`)
 - Singleton: `.shared`


### PR DESCRIPTION
## Summary
Addresses 8 issues from the codebase audit:

**Bug fixes:**
- **Race condition in refresh** — `UsageViewModel` now captures values directly from `api` instead of re-reading `self.apiResult`, preventing concurrent refreshes from corrupting data
- **Cache eviction O(n²)** — `SessionLogReader.evictCache()` now batch-sorts once instead of calling `min(by:)` in a loop
- **StatusChecker 5-min backoff** → reduced to 60s so recovery is detected faster without hammering the endpoint
- **FileWatcher never-retry** — if stats-cache doesn't exist on startup, retries opening it every 60s instead of giving up forever

**Optimizations:**
- **Dynamic User-Agent** — reads version from `Bundle.main` instead of hardcoded `1.0.2`, so it auto-updates with version bumps
- **~/.claude.json caching** — mod-time check skips re-reading the file every refresh cycle if unchanged
- **JSONL marker search** — consolidated duplicate `assistantMarker`/`assistantMarkerSpaced` into a single array-based check

**Hardening:**
- **NotificationManager** — extracted `applescriptQuoted()` for clearer escaping (Process.arguments already bypasses shell, but the code is now more explicit about why)

## Test plan
- [x] `swift build -c release` passes
- [ ] Verify CI passes
- [ ] Manual: launch app, confirm rate limits + tokens display correctly
- [ ] Manual: quit and relaunch to verify Keychain + FileWatcher retry works