### PR TITLE
Add multi-account support (up to 2 Claude accounts)

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
 	<key>LSUIElement</key>

--- a/AIBattery/Models/AccountRecord.swift
+++ b/AIBattery/Models/AccountRecord.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Persistent identity for a Claude account (one OAuth org).
+///
+/// Stored as a JSON array in UserDefaults (`aibattery_accounts`).
+/// The `id` starts as `"pending-<UUID>"` on initial auth and gets
+/// resolved to the real `anthropic-organization-id` after the first
+/// successful API call.
+public struct AccountRecord: Codable, Identifiable, Equatable {
+    /// Organization ID from the API, or `"pending-<UUID>"` before first fetch.
+    public var id: String
+    public var displayName: String?
+    public var organizationName: String?
+    public var billingType: String?
+    public var addedAt: Date
+
+    /// Whether this account's identity hasn't been confirmed by the API yet.
+    public var isPendingIdentity: Bool { id.hasPrefix("pending-") }
+}

--- a/AIBattery/Services/AccountStore.swift
+++ b/AIBattery/Services/AccountStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+import os
+
+/// Manages the list of authenticated Claude accounts and which one is active.
+///
+/// Persists to UserDefaults as a JSON array. Owned by `OAuthManager` and
+/// published so SwiftUI views react to account changes.
+@MainActor
+public final class AccountStore: ObservableObject {
+    /// Maximum number of accounts supported.
+    nonisolated static let maxAccounts = 2
+
+    @Published public private(set) var accounts: [AccountRecord] = []
+    @Published public var activeAccountId: String?
+
+    public var activeAccount: AccountRecord? {
+        accounts.first { $0.id == activeAccountId }
+    }
+
+    public var canAddAccount: Bool {
+        accounts.count < Self.maxAccounts
+    }
+
+    public init() {
+        load()
+    }
+
+    // MARK: - Mutations
+
+    public func add(_ record: AccountRecord) {
+        guard accounts.count < Self.maxAccounts else {
+            AppLogger.oauth.warning("Cannot add account — max \(Self.maxAccounts) reached")
+            return
+        }
+        guard !accounts.contains(where: { $0.id == record.id }) else {
+            AppLogger.oauth.warning("Account \(record.id, privacy: .public) already exists")
+            return
+        }
+        accounts.append(record)
+        if activeAccountId == nil {
+            activeAccountId = record.id
+        }
+        save()
+    }
+
+    public func remove(id: String) {
+        accounts.removeAll { $0.id == id }
+        if activeAccountId == id {
+            activeAccountId = accounts.first?.id
+        }
+        save()
+    }
+
+    public func setActive(id: String) {
+        guard accounts.contains(where: { $0.id == id }) else { return }
+        activeAccountId = id
+        save()
+    }
+
+    /// Replace an account record (e.g. resolve pending ID to real org ID).
+    /// Returns the old ID if it changed, nil otherwise.
+    @discardableResult
+    public func update(oldId: String, with newRecord: AccountRecord) -> String? {
+        guard let index = accounts.firstIndex(where: { $0.id == oldId }) else { return nil }
+
+        // Check for duplicate: another account already has this real org ID
+        if newRecord.id != oldId,
+           let existingIndex = accounts.firstIndex(where: { $0.id == newRecord.id }) {
+            // Merge: keep the newer record, remove the old duplicate
+            AppLogger.oauth.info("Merging duplicate account \(oldId, privacy: .public) → \(newRecord.id, privacy: .public)")
+            accounts[existingIndex] = newRecord
+            accounts.remove(at: index)
+            if activeAccountId == oldId {
+                activeAccountId = newRecord.id
+            }
+            save()
+            return oldId
+        }
+
+        accounts[index] = newRecord
+        if activeAccountId == oldId {
+            activeAccountId = newRecord.id
+        }
+        save()
+        return oldId != newRecord.id ? oldId : nil
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(accounts) else { return }
+        UserDefaults.standard.set(data, forKey: UserDefaultsKeys.accounts)
+        UserDefaults.standard.set(activeAccountId, forKey: UserDefaultsKeys.activeAccountId)
+    }
+
+    private func load() {
+        if let data = UserDefaults.standard.data(forKey: UserDefaultsKeys.accounts),
+           let decoded = try? JSONDecoder().decode([AccountRecord].self, from: data) {
+            accounts = decoded
+        }
+        activeAccountId = UserDefaults.standard.string(forKey: UserDefaultsKeys.activeAccountId)
+        // Fix active ID pointing at a removed account
+        if let active = activeAccountId, !accounts.contains(where: { $0.id == active }) {
+            activeAccountId = accounts.first?.id
+        }
+    }
+}

--- a/AIBattery/Utilities/UserDefaultsKeys.swift
+++ b/AIBattery/Utilities/UserDefaultsKeys.swift
@@ -11,4 +11,6 @@ enum UserDefaultsKeys {
     static let alertClaudeCode = "aibattery_alertClaudeCode"
     static let chartMode = "aibattery_chartMode"
     static let plan = "aibattery_plan"
+    static let accounts = "aibattery_accounts"
+    static let activeAccountId = "aibattery_activeAccountId"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.1.0] — 2026-02-21
+
+### Added
+- **Multi-account support** — connect up to 2 Claude accounts (separate orgs) and switch between them from the header dropdown
+- `AccountRecord` model and `AccountStore` service for per-account identity persistence
+- Per-account Keychain token storage (prefixed entries: `accessToken_{accountId}`, etc.)
+- Account picker dropdown in header — always visible, shows active account with switch and "Add Account" options
+- Per-account name editing in Settings (replaces global Name/Org fields)
+- Per-account rate limit caching and model fallback in `RateLimitFetcher`
+- Pending identity resolution — new accounts start as `"pending-<UUID>"` and resolve to real org ID after first API call
+- Duplicate account detection and merge (same org authed twice)
+- Legacy migration — existing single-account Keychain entries automatically migrate to the new prefixed format
+- Stale-result guard in `UsageViewModel` — discards API results if active account changed mid-flight
+- 35 new unit tests (AccountRecord, AccountStore)
+
+### Removed
+- Manual refresh button from header (data refreshes automatically via polling + file watchers)
+
 ## [1.0.3] — 2026-02-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,21 +78,25 @@ Your settings and OAuth session carry over automatically.
 
 ## Authentication
 
-OAuth 2.0 with PKCE — same protocol as Claude Code.
+OAuth 2.0 with PKCE — same protocol as Claude Code. Supports up to **2 accounts** (separate Claude orgs).
 
 1. Launch AI Battery — the auth screen appears on first run
 2. Click **Authenticate** → browser opens to Anthropic's sign-in page
 3. Sign in → copy the authorization code
 4. Paste into AI Battery → done
 
-Sessions auto-refresh (with a 5-minute buffer to avoid clock-skew issues). Temporary server errors retry automatically. Tokens stored in macOS Keychain (separate from Claude Code credentials). Error messages are specific — expired codes, invalid codes, server errors, and network errors each get a clear description.
+To add a second account, click the account name in the header → **Add Account**, or open Settings (⚙️) → **Add Account**.
+
+Switch between accounts by clicking the account name dropdown in the header. Each account has its own rate limits, tokens, and identity.
+
+Sessions auto-refresh (with a 5-minute buffer to avoid clock-skew issues). Temporary server errors retry automatically. Tokens stored in macOS Keychain per account (separate from Claude Code credentials). Error messages are specific — expired codes, invalid codes, server errors, and network errors each get a clear description.
 
 ### Why does macOS block the app or ask about Keychain access?
 
 AI Battery isn't notarized — there's no Apple Developer license behind this project, so macOS treats it as unidentified. Two prompts may appear on first launch:
 
 - **Gatekeeper block** — macOS prevents the app from opening. Fix: **System Settings → Privacy & Security → Open Anyway** (see [Install](#install))
-- **Keychain access** — the app stores a single OAuth token in macOS Keychain, Apple's encrypted credential store. This is the safest option — the same place Claude Code, browsers, and every other macOS app stores secrets. Click **Always Allow**.
+- **Keychain access** — the app stores OAuth tokens in macOS Keychain (one set per account), Apple's encrypted credential store. This is the safest option — the same place Claude Code, browsers, and every other macOS app stores secrets. Click **Always Allow**.
 
 Both are one-time prompts. Neither will appear again after the first launch.
 
@@ -174,8 +178,8 @@ Click ⚙️ in the header to configure:
 
 | Setting | What it does |
 |---|---|
-| **Name** | Display name shown in the header |
-| **Org** | Organization name (the API only returns a UUID) |
+| **Account names** | Per-account display name shown in the header and account picker |
+| **Add Account** | Connect a second Claude account (up to 2) |
 | **Refresh** | Poll interval: 10–60s · ~3 tokens per refresh |
 | **Models** | Only show models used within period: 1–7 days or All |
 | **Alerts** | Notify when Claude.ai or Claude Code goes down (separate toggles) |
@@ -197,13 +201,13 @@ Token usage, context health, and activity stats come from Claude Code's local se
 
 1. Run a few Claude Code sessions from the terminal
 2. Run `/stats` inside Claude Code — this generates the stats cache
-3. Click the refresh button in AI Battery
+3. AI Battery refreshes automatically every polling cycle
 
 Rate limits (5-hour / 7-day) always work immediately since they come from the API.
 
 **Green ✦ at 0%?** Credits just reset, or no usage yet — this is normal.
 
-**Wrong org?** Click ⚙️ → set it manually (the API only returns a UUID).
+**Wrong org?** Org names come from the API automatically. Click the account name to see which account is active.
 
 **What's "binding"?** Whichever rate limit window is currently the active constraint.
 
@@ -254,7 +258,7 @@ brew uninstall --cask aibattery
 To also remove stored settings, run in Terminal:
 
 ```bash
-security delete-generic-password -s "AIBattery" 2>/dev/null   # OAuth token
+security delete-generic-password -s "AIBattery" 2>/dev/null   # OAuth tokens (all accounts)
 defaults delete com.KyleNesium.AIBattery 2>/dev/null           # Preferences
 ```
 

--- a/Tests/AIBatteryCoreTests/Models/AccountRecordTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/AccountRecordTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import AIBatteryCore
+
+@Suite("AccountRecord")
+struct AccountRecordTests {
+
+    @Test func isPendingIdentity_trueForPendingPrefix() {
+        let record = AccountRecord(
+            id: "pending-ABC123",
+            displayName: nil,
+            organizationName: nil,
+            billingType: nil,
+            addedAt: Date()
+        )
+        #expect(record.isPendingIdentity)
+    }
+
+    @Test func isPendingIdentity_falseForRealOrgId() {
+        let record = AccountRecord(
+            id: "org-abc123def456",
+            displayName: "Kyle",
+            organizationName: "Acme Corp",
+            billingType: "pro",
+            addedAt: Date()
+        )
+        #expect(!record.isPendingIdentity)
+    }
+
+    @Test func codable_roundTrip() throws {
+        let original = AccountRecord(
+            id: "org-test",
+            displayName: "Test User",
+            organizationName: "Test Org",
+            billingType: "teams",
+            addedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AccountRecord.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func codable_arrayRoundTrip() throws {
+        let records = [
+            AccountRecord(id: "org-1", displayName: "User 1", organizationName: "Org 1", billingType: "pro", addedAt: Date()),
+            AccountRecord(id: "org-2", displayName: "User 2", organizationName: "Org 2", billingType: "teams", addedAt: Date()),
+        ]
+        let data = try JSONEncoder().encode(records)
+        let decoded = try JSONDecoder().decode([AccountRecord].self, from: data)
+        #expect(decoded.count == 2)
+        #expect(decoded[0].id == "org-1")
+        #expect(decoded[1].id == "org-2")
+    }
+
+    @Test func codable_nilFields() throws {
+        let original = AccountRecord(
+            id: "pending-xyz",
+            displayName: nil,
+            organizationName: nil,
+            billingType: nil,
+            addedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AccountRecord.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.displayName == nil)
+        #expect(decoded.organizationName == nil)
+        #expect(decoded.billingType == nil)
+    }
+
+    @Test func equatable_sameIdEqual() {
+        let a = AccountRecord(id: "org-1", displayName: "A", organizationName: nil, billingType: nil, addedAt: Date())
+        let b = AccountRecord(id: "org-1", displayName: "A", organizationName: nil, billingType: nil, addedAt: a.addedAt)
+        #expect(a == b)
+    }
+
+    @Test func equatable_differentIdNotEqual() {
+        let now = Date()
+        let a = AccountRecord(id: "org-1", displayName: "A", organizationName: nil, billingType: nil, addedAt: now)
+        let b = AccountRecord(id: "org-2", displayName: "A", organizationName: nil, billingType: nil, addedAt: now)
+        #expect(a != b)
+    }
+
+    @Test func identifiable_idIsOrgId() {
+        let record = AccountRecord(id: "org-test", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        #expect(record.id == "org-test")
+    }
+
+    // MARK: - isPendingIdentity edge cases
+
+    @Test func isPendingIdentity_falseForEmptyString() {
+        let record = AccountRecord(id: "", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        #expect(!record.isPendingIdentity)
+    }
+
+    @Test func isPendingIdentity_falseForPendingWithoutDash() {
+        let record = AccountRecord(id: "pending", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        #expect(!record.isPendingIdentity)
+    }
+
+    @Test func isPendingIdentity_trueForPendingDashEmpty() {
+        // "pending-" with nothing after the dash is still a valid prefix match
+        let record = AccountRecord(id: "pending-", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        #expect(record.isPendingIdentity)
+    }
+
+    @Test func isPendingIdentity_caseSensitive() {
+        let record = AccountRecord(id: "Pending-ABC", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        #expect(!record.isPendingIdentity) // case-sensitive: "Pending" != "pending"
+    }
+
+    @Test func equatable_differentMetadataSameOtherwise() {
+        let now = Date()
+        let a = AccountRecord(id: "org-1", displayName: "Alice", organizationName: "Org A", billingType: "pro", addedAt: now)
+        let b = AccountRecord(id: "org-1", displayName: "Bob", organizationName: "Org B", billingType: "teams", addedAt: now)
+        // Synthesized Equatable compares ALL fields — different metadata means not equal
+        #expect(a != b)
+    }
+}

--- a/Tests/AIBatteryCoreTests/Services/AccountStoreTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/AccountStoreTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import Testing
+@testable import AIBatteryCore
+
+@Suite("AccountStore")
+@MainActor
+struct AccountStoreTests {
+
+    /// Clean UserDefaults before each test to avoid cross-contamination.
+    private func makeCleanStore() -> AccountStore {
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.accounts)
+        UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.activeAccountId)
+        return AccountStore()
+    }
+
+    @Test func init_emptyByDefault() {
+        let store = makeCleanStore()
+        #expect(store.accounts.isEmpty)
+        #expect(store.activeAccountId == nil)
+        #expect(store.activeAccount == nil)
+        #expect(store.canAddAccount)
+    }
+
+    @Test func add_singleAccount() {
+        let store = makeCleanStore()
+        let record = AccountRecord(id: "org-1", displayName: "Kyle", organizationName: "Acme", billingType: "pro", addedAt: Date())
+        store.add(record)
+
+        #expect(store.accounts.count == 1)
+        #expect(store.accounts.first?.id == "org-1")
+        #expect(store.activeAccountId == "org-1")
+        #expect(store.activeAccount?.id == "org-1")
+        #expect(store.canAddAccount) // can still add one more
+    }
+
+    @Test func add_twoAccounts() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "org-2", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+
+        #expect(store.accounts.count == 2)
+        #expect(store.activeAccountId == "org-1") // first added stays active
+        #expect(!store.canAddAccount) // at max
+    }
+
+    @Test func add_rejectsOverMax() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "org-2", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r3 = AccountRecord(id: "org-3", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+        store.add(r3) // should be rejected
+
+        #expect(store.accounts.count == 2)
+    }
+
+    @Test func add_rejectsDuplicate() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r1) // same ID
+
+        #expect(store.accounts.count == 1)
+    }
+
+    @Test func remove_singleAccount() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.remove(id: "org-1")
+
+        #expect(store.accounts.isEmpty)
+        #expect(store.activeAccountId == nil)
+        #expect(store.canAddAccount)
+    }
+
+    @Test func remove_switchesToOther() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "org-2", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+        store.setActive(id: "org-1")
+        store.remove(id: "org-1")
+
+        #expect(store.accounts.count == 1)
+        #expect(store.activeAccountId == "org-2")
+    }
+
+    @Test func setActive_changesActiveAccount() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "org-2", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+
+        store.setActive(id: "org-2")
+        #expect(store.activeAccountId == "org-2")
+        #expect(store.activeAccount?.id == "org-2")
+    }
+
+    @Test func setActive_ignoresUnknownId() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+
+        store.setActive(id: "nonexistent")
+        #expect(store.activeAccountId == "org-1") // unchanged
+    }
+
+    @Test func update_changesMetadata() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: "Old", organizationName: "Old Org", billingType: "free", addedAt: Date())
+        store.add(r1)
+
+        var updated = r1
+        updated.displayName = "New"
+        updated.organizationName = "New Org"
+        updated.billingType = "pro"
+        store.update(oldId: "org-1", with: updated)
+
+        #expect(store.accounts.first?.displayName == "New")
+        #expect(store.accounts.first?.organizationName == "New Org")
+        #expect(store.accounts.first?.billingType == "pro")
+    }
+
+    @Test func update_resolvesIdentity() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "pending-abc", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.setActive(id: "pending-abc")
+
+        var resolved = r1
+        resolved.id = "org-real-123"
+        resolved.organizationName = "Acme Corp"
+        let oldId = store.update(oldId: "pending-abc", with: resolved)
+
+        #expect(oldId == "pending-abc")
+        #expect(store.accounts.first?.id == "org-real-123")
+        #expect(store.activeAccountId == "org-real-123")
+    }
+
+    @Test func update_mergesDuplicate() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-real", displayName: "First", organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "pending-abc", displayName: "Second", organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+        store.setActive(id: "pending-abc")
+
+        // Resolve pending to same org as first account — should merge
+        var resolved = r2
+        resolved.id = "org-real"
+        resolved.displayName = "Merged"
+        store.update(oldId: "pending-abc", with: resolved)
+
+        #expect(store.accounts.count == 1)
+        #expect(store.accounts.first?.id == "org-real")
+        #expect(store.accounts.first?.displayName == "Merged")
+        #expect(store.activeAccountId == "org-real")
+    }
+
+    @Test func persistence_surviesReinit() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: "Kyle", organizationName: "Test", billingType: "pro", addedAt: Date(timeIntervalSince1970: 1700000000))
+        store.add(r1)
+
+        // Create a new store — should load from UserDefaults
+        let store2 = AccountStore()
+        #expect(store2.accounts.count == 1)
+        #expect(store2.accounts.first?.id == "org-1")
+        #expect(store2.accounts.first?.displayName == "Kyle")
+        #expect(store2.activeAccountId == "org-1")
+    }
+
+    @Test func persistence_fixesDanglingActiveId() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+
+        // Manually set a bad active ID
+        UserDefaults.standard.set("nonexistent", forKey: UserDefaultsKeys.activeAccountId)
+
+        let store2 = AccountStore()
+        #expect(store2.activeAccountId == "org-1") // fixed to first available
+    }
+
+    @Test func maxAccounts_isTwo() {
+        #expect(AccountStore.maxAccounts == 2)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func update_unknownOldId_returnsNil() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+
+        var ghost = r1
+        ghost.id = "org-999"
+        let result = store.update(oldId: "nonexistent", with: ghost)
+
+        #expect(result == nil)
+        #expect(store.accounts.count == 1)
+        #expect(store.accounts.first?.id == "org-1")
+    }
+
+    @Test func update_sameIdReturnsNil() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: "Old", organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+
+        var updated = r1
+        updated.displayName = "New"
+        let result = store.update(oldId: "org-1", with: updated)
+
+        // ID didn't change, so oldId return should be nil
+        #expect(result == nil)
+        #expect(store.accounts.first?.displayName == "New")
+    }
+
+    @Test func update_mergeWhenExistingAtLowerIndex() {
+        let store = makeCleanStore()
+        // existing real account at index 0, pending at index 1
+        let r1 = AccountRecord(id: "org-real", displayName: "First", organizationName: "Org A", billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "pending-xyz", displayName: "Second", organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+
+        // Active is the first account
+        store.setActive(id: "org-real")
+
+        // Resolve pending → same org as r1 (existingIndex=0 < index=1)
+        var resolved = r2
+        resolved.id = "org-real"
+        resolved.displayName = "Merged"
+        resolved.organizationName = "Org B"
+        store.update(oldId: "pending-xyz", with: resolved)
+
+        #expect(store.accounts.count == 1)
+        #expect(store.accounts.first?.id == "org-real")
+        #expect(store.accounts.first?.displayName == "Merged")
+        #expect(store.accounts.first?.organizationName == "Org B")
+        // Active should remain org-real (unchanged since it wasn't the pending one)
+        #expect(store.activeAccountId == "org-real")
+    }
+
+    @Test func remove_nonActiveAccount_doesNotChangeActive() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        let r2 = AccountRecord(id: "org-2", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+        store.add(r2)
+        store.setActive(id: "org-1")
+
+        store.remove(id: "org-2")
+
+        #expect(store.accounts.count == 1)
+        #expect(store.activeAccountId == "org-1") // unchanged
+        #expect(store.canAddAccount)
+    }
+
+    @Test func remove_nonexistentId_isNoOp() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: nil, organizationName: nil, billingType: nil, addedAt: Date())
+        store.add(r1)
+
+        store.remove(id: "ghost")
+
+        #expect(store.accounts.count == 1)
+        #expect(store.activeAccountId == "org-1")
+    }
+
+    @Test func persistence_emptyAccountsArray() {
+        let store = makeCleanStore()
+        // Don't add anything — just re-init
+        let store2 = AccountStore()
+        #expect(store2.accounts.isEmpty)
+        #expect(store2.activeAccountId == nil)
+    }
+
+    @Test func persistence_twoAccountsSurviveReinit() {
+        let store = makeCleanStore()
+        let r1 = AccountRecord(id: "org-1", displayName: "A", organizationName: nil, billingType: nil, addedAt: Date(timeIntervalSince1970: 1700000000))
+        let r2 = AccountRecord(id: "org-2", displayName: "B", organizationName: nil, billingType: nil, addedAt: Date(timeIntervalSince1970: 1700000000))
+        store.add(r1)
+        store.add(r2)
+        store.setActive(id: "org-2")
+
+        let store2 = AccountStore()
+        #expect(store2.accounts.count == 2)
+        #expect(store2.activeAccountId == "org-2")
+        #expect(store2.accounts[0].id == "org-1")
+        #expect(store2.accounts[1].id == "org-2")
+    }
+}

--- a/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
@@ -16,6 +16,8 @@ struct UserDefaultsKeysTests {
             UserDefaultsKeys.alertClaudeCode,
             UserDefaultsKeys.chartMode,
             UserDefaultsKeys.plan,
+            UserDefaultsKeys.accounts,
+            UserDefaultsKeys.activeAccountId,
         ]
         for key in keys {
             #expect(key.hasPrefix("aibattery_"), "Key '\(key)' missing 'aibattery_' prefix")
@@ -34,6 +36,8 @@ struct UserDefaultsKeysTests {
             UserDefaultsKeys.alertClaudeCode,
             UserDefaultsKeys.chartMode,
             UserDefaultsKeys.plan,
+            UserDefaultsKeys.accounts,
+            UserDefaultsKeys.activeAccountId,
         ]
         let unique = Set(keys)
         #expect(unique.count == keys.count, "Duplicate UserDefaults key detected")


### PR DESCRIPTION
## Summary
- **Multi-account**: connect up to 2 Claude accounts (separate orgs) and switch between them from the header dropdown
- **Account picker**: always-visible dropdown in header with account switching + "Add Account" entry
- **Per-account storage**: Keychain tokens, rate limit cache, and model fallback all keyed per account
- **Identity resolution**: new accounts start as `pending-<UUID>`, resolve to real org ID after first API call, with duplicate detection/merge
- **Legacy migration**: existing single-account Keychain entries automatically migrate
- **Removed**: manual refresh button (auto-polling + file watchers handle it)
- **Version**: 1.1.0

## New files
- `AccountRecord.swift` — per-account identity model
- `AccountStore.swift` — account registry with CRUD, persistence, merge
- `AccountRecordTests.swift` — 13 tests
- `AccountStoreTests.swift` — 22 tests

## Test plan
- [ ] Fresh install: auth flow creates first account, picker shows single account with "Add Account"
- [ ] Add second account via header dropdown → "Add Account"
- [ ] Switch accounts via header dropdown — rate limits update for the selected account
- [ ] Remove account from Settings (x button) — auto-switches to remaining
- [ ] Legacy migration: existing users keep their session after upgrade
- [ ] CI passes (build + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)