### PR TITLE
Fix refresh race, merge data loss, stale counter, and retry backoff

### DIFF
--- a/AIBattery/Services/SessionLogReader.swift
+++ b/AIBattery/Services/SessionLogReader.swift
@@ -37,10 +37,10 @@ final class SessionLogReader {
     }
 
     func readAllUsageEntries() -> [AssistantUsageEntry] {
+        lastCorruptLineCount = 0
+
         // Return cached result if available (invalidated by FileWatcher)
         if let cached = cachedAllEntries { return cached }
-
-        lastCorruptLineCount = 0
         let jsonlFiles = discoverJSONLFiles()
         var allEntries: [AssistantUsageEntry] = []
         var seenMessageIds = Set<String>()

--- a/README.md
+++ b/README.md
@@ -400,12 +400,12 @@ Contributions welcome! Please read the [contributing guide](CONTRIBUTING.md) fir
 
 ## 🧪 Test Coverage
 
-**335 tests** across 25 test files.
+**338 tests** across 25 test files.
 
 | Area | Tests | What's covered |
 |------|-------|----------------|
 | Models | 140 | Token summaries, rate limit parsing, plan tiers, health status, metric modes, API profiles, session entries, account records, stats cache, usage snapshots (projections, trends, busiest day) |
-| Services | 132 | Version checker (semver comparison, tag stripping, cache behavior, force check, skip version), notification manager (alert thresholds, AppleScript quoting), token health monitor (band classification, warnings, anomalies, velocity), status checker (severity ordering, incident escalation, component IDs, status string parsing), session log reader (entry decoding, makeUsageEntry), account store (multi-account CRUD, persistence) |
+| Services | 135 | Version checker (semver comparison, tag stripping, cache behavior, force check), notification manager (alert thresholds, AppleScript quoting), token health monitor (band classification, warnings, anomalies, velocity), status checker (severity ordering, incident escalation, component IDs, status string parsing), session log reader (entry decoding, makeUsageEntry), account store (multi-account CRUD, persistence, merge metadata preservation) |
 | Utilities | 63 | Token formatter (K/M suffixes, boundaries), model name mapper (display names, versions, date stripping), Claude paths (suffixes, URLs), theme colors (standard + colorblind palettes, NSColor, semantic colors, danger), UserDefaults keys (prefix, uniqueness), model pricing (cost calculation, formatting) |
 
 ## 📄 License

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -10,6 +10,7 @@ Every hardcoded value in the app. When changing a threshold, URL, or price, upda
 | File watcher debounce | 2 sec | FileWatcher |
 | FSEvent latency | 2.0 sec | FileWatcher |
 | Fallback timer | 60 sec | FileWatcher |
+| Stats-cache retry (base) | 60 sec, exponential (doubles per retry), cap 300 sec, max 10 retries | FileWatcher |
 | API request timeout | 15 sec | RateLimitFetcher |
 | Status request timeout | 5 sec | StatusChecker |
 | Status backoff (base) | 60 sec, exponential (doubles per failure), cap 300 sec, ±20% jitter | StatusChecker |
@@ -163,7 +164,6 @@ Pricing per million tokens:
 | Check interval | 86400 sec (24 hours) |
 | Request timeout | 10 sec |
 | Last check key | `aibattery_lastUpdateCheck` (Double, Unix timestamp) |
-| Skip version key | `aibattery_skipVersion` (String, semver) |
 
 ## Token Window
 


### PR DESCRIPTION
## Summary

- **OAuthManager token refresh race**: `refreshTasks[accountId] = nil` ran inside the Task closure, allowing a third concurrent caller to start a duplicate refresh between cleanup and return. Fixed by moving cleanup after `await task.value` with a generation counter guard.
- **AccountStore merge loses metadata**: duplicate merge overwrote the existing record entirely, losing `addedAt` (earlier timestamp), `displayName`, and `billingType`. Also fixed index ordering bug when the old record precedes the existing one. Now preserves earliest `addedAt` and falls back to existing metadata when the new record has nil.
- **SessionLogReader stale corruption counter**: `lastCorruptLineCount` was only reset after the cache-hit early return, causing stale values on cache hits. Moved reset above the cache check.
- **FileWatcher unbounded retry**: stats-cache retry fired every 60s forever if the file never appeared. Now uses exponential backoff (60s → 120s → 240s → 300s cap, max 10 retries ≈ 30 min), resets on success or `stopWatching()`.

## Test plan

- [x] `swift build -c release` passes clean
- [ ] CI: all 338 tests pass (5 new AccountStore merge tests)
- [ ] Manual: launch with no `~/.claude/stats-cache.json`, confirm retry logs show increasing intervals and stop after ~30 min