### PR TITLE
v1.2.2: Header update indicator, inline trend, footer polish

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/AIBattery/Services/VersionChecker.swift
+++ b/AIBattery/Services/VersionChecker.swift
@@ -39,7 +39,6 @@ public final class VersionChecker {
             return cachedUpdate
         }
 
-        let skipVersion = UserDefaults.standard.string(forKey: UserDefaultsKeys.skipVersion)
         let currentVersion = Self.currentAppVersion
 
         do {
@@ -66,10 +65,6 @@ public final class VersionChecker {
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: UserDefaultsKeys.lastUpdateCheck)
 
             if Self.isNewer(latestVersion, than: currentVersion) {
-                if skipVersion == latestVersion {
-                    cachedUpdate = nil
-                    return nil
-                }
                 let update = UpdateInfo(version: latestVersion, url: htmlURL)
                 cachedUpdate = update
                 return update
@@ -89,12 +84,6 @@ public final class VersionChecker {
         lastCheck = nil
         cachedUpdate = nil
         return await checkForUpdate()
-    }
-
-    /// Dismiss the update for a specific version.
-    func skipVersion(_ version: String) {
-        UserDefaults.standard.set(version, forKey: UserDefaultsKeys.skipVersion)
-        cachedUpdate = nil
     }
 
     // MARK: - Semver Comparison

--- a/AIBattery/Utilities/UserDefaultsKeys.swift
+++ b/AIBattery/Utilities/UserDefaultsKeys.swift
@@ -18,7 +18,6 @@ enum UserDefaultsKeys {
     static let showTokens = "aibattery_showTokens"
     static let showActivity = "aibattery_showActivity"
     static let lastUpdateCheck = "aibattery_lastUpdateCheck"
-    static let skipVersion = "aibattery_skipVersion"
     static let colorblindMode = "aibattery_colorblindMode"
     static let hasSeenTutorial = "aibattery_hasSeenTutorial"
 }

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -187,8 +187,30 @@ public struct UsagePopoverView: View {
                 .accessibilityHint(showSettings ? "Close settings" : "Open settings")
             }
 
-            // "Up to date" feedback after manual check
-            if let msg = updateCheckMessage, viewModel.availableUpdate == nil {
+            // Update status indicator
+            if let update = viewModel.availableUpdate {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.yellow)
+                    Text("v\(update.version) available")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Button("View") {
+                        if let url = URL(string: update.url) {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                    .font(.caption2)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.blue)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Version \(update.version) available")
+                .transition(.opacity.combined(with: .move(edge: .top)))
+                .padding(.leading, 1)
+            } else if let msg = updateCheckMessage {
                 HStack(spacing: 4) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 9))
@@ -335,7 +357,7 @@ public struct UsagePopoverView: View {
     private var footerSection: some View {
         VStack(spacing: 6) {
             // Links row
-            HStack(spacing: 6) {
+            HStack(spacing: 10) {
                 // Usage Dashboard
                 Button(action: {
                     if let url = URL(string: "https://platform.claude.com/usage") {
@@ -416,37 +438,6 @@ public struct UsagePopoverView: View {
                 .accessibilityLabel("Quit AI Battery")
             }
 
-            // Update available banner
-            if let update = viewModel.availableUpdate {
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.blue)
-                    Text("v\(update.version) available")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    Spacer()
-                    Button("View") {
-                        if let url = URL(string: update.url) {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }
-                    .font(.caption2)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.blue)
-                    Button("Skip") {
-                        VersionChecker.shared.skipVersion(update.version)
-                        viewModel.availableUpdate = nil
-                    }
-                    .font(.caption2)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Version \(update.version) available. View or skip.")
-            }
-
             // Active incident banner (if any)
             if let incident = viewModel.systemStatus?.incidentName {
                 HStack(spacing: 4) {
@@ -463,7 +454,7 @@ public struct UsagePopoverView: View {
 
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 8)
+        .padding(.vertical, 10)
     }
 
     private var statusColor: Color {

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Contributions welcome! Please read the [contributing guide](CONTRIBUTING.md) fir
 
 ## 🧪 Test Coverage
 
-**338 tests** across 25 test files.
+**348 tests** across 25 test files.
 
 | Area | Tests | What's covered |
 |------|-------|----------------|

--- a/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
@@ -108,30 +108,6 @@ struct VersionCheckerTests {
         #expect(version == "0.0.0" || version.contains("."))
     }
 
-    // MARK: - skipVersion
-
-    @Test @MainActor func skipVersion_persistsToUserDefaults() {
-        let original = UserDefaults.standard.string(forKey: UserDefaultsKeys.skipVersion)
-        defer {
-            if let original { UserDefaults.standard.set(original, forKey: UserDefaultsKeys.skipVersion) }
-            else { UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.skipVersion) }
-        }
-
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!)
-        checker.skipVersion("2.0.0")
-
-        #expect(UserDefaults.standard.string(forKey: UserDefaultsKeys.skipVersion) == "2.0.0")
-    }
-
-    @Test @MainActor func skipVersion_clearsCachedUpdate() {
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!)
-        checker.cachedUpdate = VersionChecker.UpdateInfo(version: "2.0.0", url: "https://example.com")
-
-        checker.skipVersion("2.0.0")
-
-        #expect(checker.cachedUpdate == nil)
-    }
-
     // MARK: - Cache behavior
 
     @Test @MainActor func checkForUpdate_returnsCachedWithinInterval() async {

--- a/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
@@ -39,7 +39,6 @@ struct UserDefaultsKeysTests {
             UserDefaultsKeys.showTokens,
             UserDefaultsKeys.showActivity,
             UserDefaultsKeys.lastUpdateCheck,
-            UserDefaultsKeys.skipVersion,
             UserDefaultsKeys.colorblindMode,
             UserDefaultsKeys.hasSeenTutorial,
         ]

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -90,6 +90,10 @@ Conditional states (mutually exclusive with content): Loading | Error | Empty
   - `.menuStyle(.borderlessButton)`, `.fixedSize()`
 - Gear button: `gearshape`, 11pt, toggles Settings panel
 - Loading spinner: ProgressView at 0.6 scale
+- **Update status indicator** (shown below title row, mutually exclusive with "Up to date"):
+  - If `viewModel.availableUpdate` exists: yellow `arrow.down.circle.fill` (9pt) + `"vX.Y.Z available"` (.caption2, .secondary, lineLimit 1) + "View" button (.caption2, .blue, opens release URL). Persistent until next check clears it.
+  - If `updateCheckMessage` set and no update: green `checkmark.circle.fill` (9pt) + message (.caption2, .secondary). Auto-dismisses after 2.5s.
+  - Both use `.transition(.opacity.combined(with: .move(edge: .top)))`, `.padding(.leading, 1)`
 - Padding: H 16, V 10
 
 ### ❶b Settings (`SettingsRow` — private struct)
@@ -204,9 +208,7 @@ Padding: H 16, V 12
 ### ❻ Insights (`Views/InsightsSection.swift`)
 
 - Today: `"Today"` label (.caption, .secondary) + `"{msgs} msgs · {sessions} sessions · {tools} tools"` (.caption, monospaced)
-- **Trend arrow**: after today stats, trend direction indicator (↑ orange / ↓ green / → gray) with projected total when available
 - All Time: `"All Time"` label (.caption, .secondary) + `"{messages} msgs · {sessions} sessions"` (.caption, monospaced)
-- **Busiest day**: after all-time stats, shows `"Busiest: {dayName} avg {count}"` (.caption2, .tertiary) when available
 - Each row: label left, stats right (HStack with Spacer)
 
 Padding: H 16, V 12
@@ -238,7 +240,12 @@ Data per mode:
   - **7D**: `dailyActivity` last 7 days (rolling window) → daily message counts
   - **12M**: `dailyActivity` grouped by year-month, summed, rolling 12-month window
 
-Padding: H 16, V 8
+**Trend summary** (below chart, always visible when snapshot available):
+- Single HStack row: trend arrow (colored per `ThemeColors.trendColor`) + vs-yesterday change (monospaced, colored) + `·` separator + daily average (monospaced, .tertiary) + Spacer + busiest day label (.tertiary)
+- Example: `↑ +5 msgs  ·  42 avg/day          Tuesdays peak`
+- `.padding(.top, 2)`, `.help("Weekly trend: this week vs last week")`
+
+Padding: H 16, V 12
 
 ### ❼ Footer (`UsagePopoverView.footerSection`)
 
@@ -249,15 +256,11 @@ Links row in HStack (spacing 6):
 4. **Logout**: rectangle.portrait.and.arrow.right icon (9pt) + "Logout" → clears OAuth tokens
 5. **Quit**: xmark.circle icon (9pt) + "Quit" → terminates app
 
-Each button's inner HStack uses `.fixedSize()` to prevent text wrapping.
+Each button's inner HStack uses `.fixedSize()` to prevent text wrapping. Links row spacing: 10pt.
 
-**Update available banner** (if `viewModel.availableUpdate` exists, before incident banner):
-- HStack: arrow.down.circle.fill icon (.caption2, .blue) + "vX.Y.Z available" (.caption2, .secondary) + Spacer + "View" button (.blue, opens release URL) + "Skip" button (.secondary, persists skip version)
-- Accessible: combined label "Version X.Y.Z available. View or skip."
+Active incident banner (if `incidentName` exists): triangle icon + incident name
 
-Active incident banner below (if `incidentName` exists): triangle icon + incident name
-
-All text: .caption2, .secondary. Padding: H 16, V 8.
+All text: .caption2, .secondary. Padding: H 16, V 10.
 
 Status colors: operational=green, degraded=yellow, partial=orange, major=red, maintenance=blue, unknown=gray
 
@@ -298,7 +301,7 @@ HStack(spacing: 4): `MenuBarIcon` + percentage text (11pt, medium weight, monosp
 - **TokenUsageSection**: header ("Total tokens used across all models"), active indicator ("Active model in current session"), token type tags (input/output/cache read/cache write)
 - **TokenHealthSection**: context gauge ("Percentage of usable context window consumed"), turns label, safe minimum hint, expanded session details tooltip
 - **ActivityChartView**: mode picker ("Switch activity chart time range")
-- **InsightsSection**: today/all-time labels, trend arrow
+- **InsightsSection**: today/all-time labels
 - **UsagePopoverView**: metric mode picker
 
 ### Tutorial Overlay (`Views/TutorialOverlay.swift`)


### PR DESCRIPTION
## Summary
- **Update indicator moved to header** — yellow `arrow.down.circle.fill` + "vX.Y.Z available" + "View" button, matching the green "Up to date" checkmark placement. Removed footer banner and skip-version feature.
- **Trend summary inlined** — replaced collapsible disclosure with an always-visible single row: trend arrow + vs-yesterday change + daily average + busiest day peak.
- **Footer spacing improved** — wider link spacing (6→10pt) and increased vertical padding (8→10pt) for less cramped feel.
- **Spec & docs synced** — UI_SPEC updated for all changes, README test count corrected (338→348).

## Test plan
- [ ] Build succeeds (`swift build -c release`)
- [ ] Launch app, force-check for updates → yellow indicator in header if update available, green checkmark if up to date
- [ ] "View" button opens release URL in browser
- [ ] Activity chart trend row shows inline stats without needing to click
- [ ] Footer links (Usage, Status, Logout, Quit) have comfortable spacing
- [ ] CI passes (build + test)