### PR TITLE
Replace update banner with persistent yellow button indicator

### DIFF
--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -90,10 +90,10 @@ Conditional states (mutually exclusive with content): Loading | Error | Empty
   - `.menuStyle(.borderlessButton)`, `.fixedSize()`
 - Gear button: `gearshape`, 11pt, toggles Settings panel
 - Loading spinner: ProgressView at 0.6 scale
-- **Update status indicator** (shown below title row, mutually exclusive with "Up to date"):
-  - If `viewModel.availableUpdate` exists: yellow `arrow.down.circle.fill` (9pt) + `"vX.Y.Z available"` (.caption2, .secondary, lineLimit 1) + "View" button (.caption2, .blue, opens release URL). Persistent until next check clears it.
-  - If `updateCheckMessage` set and no update: green `checkmark.circle.fill` (9pt) + message (.caption2, .secondary). Auto-dismisses after 2.5s.
-  - Both use `.transition(.opacity.combined(with: .move(edge: .top)))`, `.padding(.leading, 1)`
+- **Update button** (`arrow.up.circle`, 11pt): three color states, no banner
+  - **Update available** (`viewModel.availableUpdate` exists): button turns `.yellow`, stays yellow. Clicking opens release URL in browser. `.help("vX.Y.Z available")`.
+  - **Up to date** (`updateCheckMessage` set, no update): button turns `.green` for 2.5s, fades back to `.secondary`.
+  - **Default**: `.secondary` color. Clicking triggers `forceCheckForUpdate()`.
 - Padding: H 16, V 10
 
 ### ❶b Settings (`SettingsRow` — private struct)


### PR DESCRIPTION
## Summary

- **Update available**: button turns yellow and stays yellow — clicking opens the release page in the browser
- **Up to date**: button flashes green for 2.5s then fades back to gray
- **Default**: gray button that checks for updates on click
- Removes the "vX.Y.Z available" banner and "Up to date" text block below the header
- Updates UI spec to reflect the new behavior

## Test plan

- [ ] Build: `swift build -c release` passes
- [ ] Click update button when up to date → button turns green briefly, no banner
- [ ] Click update button when update available → button turns yellow, stays yellow
- [ ] Click yellow button again → opens release URL in browser
- [ ] No banner text appears in either case