### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.0] — 2026-02-25
+
+### Improved
+- **Update button indicator** — replaced the "vX.Y.Z available" banner below the header with persistent button color states: yellow when an update is available (click opens release page), green flash when up to date, gray default
+
+### Removed
+- Update banner and "Up to date" text block below header (button color now communicates state)
+
 ## [1.3.0] — 2026-02-23
 
 ### Added

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "1.0.2"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "1.4.0"
+        CURRENT_PROJECT_VERSION: "12"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- Bumps `CFBundleShortVersionString` → 1.4.0, `CFBundleVersion` → 12
- Syncs `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in project.yml
- Adds 1.4.0 changelog entry

## Test plan

- [ ] `swift build -c release` passes
- [ ] App shows v1.4.0 in header