### PR TITLE
Fix layout jump by scoping animation to ForEach only

### DIFF
--- a/AIBattery/Views/TutorialOverlay.swift
+++ b/AIBattery/Views/TutorialOverlay.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// 3-step walkthrough overlay shown on first data load.
 struct TutorialOverlay: View {
+    let hasData: Bool
     @AppStorage(UserDefaultsKeys.hasSeenTutorial) private var hasSeenTutorial = false
     @State private var step = 0
 
@@ -24,6 +25,12 @@ struct TutorialOverlay: View {
     ]
 
     var body: some View {
+        if !hasSeenTutorial && hasData {
+            content
+        }
+    }
+
+    private var content: some View {
         ZStack {
             // Semi-transparent backdrop
             Color.black.opacity(0.4)


### PR DESCRIPTION
## Summary

Three root causes of the "jump to top-left" layout glitch fixed:

1. **`.animation()` on entire VStack** — scoped to `ForEach` block only (metric section reordering is the only intended animation target)
2. **`withAnimation(.repeatForever)` for auto-mode glow** — leaked a global repeating animation transaction that caused all views to oscillate. Replaced with scoped `.animation()` modifiers on the stroke/shadow views only
3. **`withAnimation` wrapping `updateCheckMessage`** — caused global animation of all views when the update button color changed. Removed; color changes instantly now

Also:
- Extracted `TokenUsageGate` and `ActivityChartGate` private gate views that own their `@AppStorage` toggles — prevents parent view redraws when display settings change
- Moved `hasSeenTutorial` into `TutorialOverlay` (now accepts `hasData: Bool`) so the parent never re-evaluates for tutorial state
- Updated UI spec: view hierarchy, animation docs, gate views section, auto-mode glow description, tutorial overlay

## Test plan

- [ ] `swift build -c release` passes
- [ ] Open popover — sections render without jumping
- [ ] Switch metric mode (5h/7d/context) — only metric sections animate
- [ ] Toggle Tokens/Activity in settings — sections appear/disappear without layout glitch
- [ ] Click update button — no layout jump on color change
- [ ] Enable auto mode — glow pulses on button only, no oscillation in other sections
- [ ] Disable auto mode — glow stops cleanly