### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.1] — 2026-02-25
+
+### Fixed
+- **Layout jump bug** — sections no longer jump to top-left on state changes. Root causes: `.animation()` was scoped to the entire VStack instead of just the ForEach; `withAnimation(.repeatForever)` for auto-mode glow leaked a global repeating animation transaction; `withAnimation` on update check caused global layout animation.
+
+### Improved
+- **Gate views** — `TokenUsageGate` and `ActivityChartGate` now own their `@AppStorage` toggles, preventing parent view redraws when display settings change
+- **TutorialOverlay** — self-managing visibility via own `@AppStorage(hasSeenTutorial)`, parent passes only `hasData: Bool`
+- **Auto-mode glow** — uses scoped `.animation()` modifiers on stroke/shadow views instead of global `withAnimation(.repeatForever)`
+
 ## [1.4.0] — 2026-02-25
 
 ### Improved

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "1.4.0"
-        CURRENT_PROJECT_VERSION: "12"
+        MARKETING_VERSION: "1.4.1"
+        CURRENT_PROJECT_VERSION: "13"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- Bumps `CFBundleShortVersionString` → 1.4.1, `CFBundleVersion` → 13
- Syncs `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in project.yml
- Adds 1.4.1 changelog entry (layout jump fix)

## Test plan
- [ ] `swift build -c release` passes