### PR TITLE
Bump version to 1.5.1 and update changelog

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1] — 2026-02-26
+
+### Fixed
+- **Stale update banner after upgrade** — `VersionChecker` now validates the cached update version against the current app version on startup, discarding stale entries (e.g. "v1.4.1 available" no longer shows after upgrading to v1.5.0)
+- **Release workflow Homebrew step** — appcast deploy checked out `gh-pages`, losing the source tree for the subsequent Homebrew cask update step; added checkout restore
+
 ## [1.5.0] — 2026-02-25
 
 ### Added

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -374,7 +374,7 @@ Pricing table (per million tokens):
 - `stripTag(_:) -> String` — strips leading "v" or "V"
 - `currentAppVersion` — reads `CFBundleShortVersionString` from bundle
 - `UpdateInfo`: `version: String`, `url: String`
-- Cache: `lastCheck: Date?`, `cachedUpdate: UpdateInfo?` — restored from UserDefaults on init (`aibattery_lastUpdateCheck` as Unix timestamp, `aibattery_lastUpdateVersion` + `aibattery_lastUpdateURL`), persisted after each check
+- Cache: `lastCheck: Date?`, `cachedUpdate: UpdateInfo?` — restored from UserDefaults on init (`aibattery_lastUpdateCheck` as Unix timestamp, `aibattery_lastUpdateVersion` + `aibattery_lastUpdateURL`), persisted after each check. On restore, validates cached version against `currentAppVersion` — discards stale entries when the app has been upgraded past the cached version.
 - Timeout: 10 sec
 
 ### SparkleUpdateService (`Services/SparkleUpdateService.swift`)


### PR DESCRIPTION
## Summary
- Bump version to 1.5.1
- Add changelog entry for stale update banner fix and release workflow fix
- Document VersionChecker stale cache discard behavior in DATA_LAYER spec