### PR TITLE
Update README for Sparkle auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Requires **macOS 13+** and [Claude Code](https://docs.anthropic.com/en/docs/clau
 
 ## 🔄 Update
 
-**In-app:** Click the yellow update button → **Install Update**. Sparkle downloads, verifies, and replaces the app automatically.
+AI Battery checks for new versions once per day. When an update is available, the arrow button in the header turns **yellow** and a banner appears.
+
+**In-app (recommended):** Click **Install Update** in the banner. [Sparkle](https://sparkle-project.org/) downloads the update, verifies its EdDSA signature, replaces the app, and relaunches — all without leaving the app.
 
 **Homebrew:**
 
@@ -114,7 +116,7 @@ brew upgrade --cask aibattery
 **Or** re-run the quick install command — it overwrites the old version in place.
 
 > [!NOTE]
-> Your settings and OAuth session carry over automatically.
+> Your settings and OAuth session carry over automatically. Updates are user-initiated only — the app never downloads or installs anything in the background.
 
 ---
 
@@ -268,7 +270,7 @@ Click ⚙️ in the header to configure:
 </tr>
 </table>
 
-The header shows an **update indicator** when a new version is available (yellow arrow + "View" link).
+The header shows an **update indicator** when a new version is available — the arrow button turns yellow, and a banner appears with the version number and an **Install Update** button. Clicking Install Update downloads, verifies, and installs the update in-app via Sparkle. Click the ✕ to dismiss the banner; the yellow button re-shows it.
 
 > [!TIP]
 > Click any stat value (percentages, token counts, costs) to copy it to the clipboard.
@@ -373,7 +375,7 @@ Anthropic is actively limiting your requests. Wait for the reset timer.
 | | |
 |---|---|
 | 📂 **Local data** | Reads JSONL for token counts only — **never your message content** |
-| 🌐 **Network calls** | `api.anthropic.com` (rate limits) · `console.anthropic.com` (OAuth) · `status.claude.com` (status) · `api.github.com` (update check, once/24h) |
+| 🌐 **Network calls** | `api.anthropic.com` (rate limits) · `console.anthropic.com` (OAuth) · `status.claude.com` (status) · `api.github.com` (update check, once/24h) · `kylenesium.github.io` (Sparkle appcast, on update click) |
 | 🔄 **Backoff** | Status checks use exponential backoff on failures (60s → 5 min cap) |
 | ⏳ **Adaptive polling** | Interval doubles after 3 idle cycles, resets when data changes |
 | 🚫 **No tracking** | No analytics. No telemetry. No tracking. |
@@ -391,7 +393,7 @@ AIBattery/
   Utilities/    — TokenFormatter, ModelNameMapper, ThemeColors, AppLogger
 ```
 
-**Zero dependencies** — Apple frameworks only (SwiftUI, Charts, Security, Foundation, AppKit).
+**One dependency** — [Sparkle 2](https://sparkle-project.org/) for auto-update. Everything else is Apple frameworks (SwiftUI, Charts, Security, Foundation, AppKit).
 
 <details>
 <summary>📋 <strong>Detailed specs</strong></summary>


### PR DESCRIPTION
## Summary
- **Update section**: describe the full in-app update flow (Sparkle downloads, verifies EdDSA signature, replaces, relaunches)
- **Settings section**: replace outdated "yellow arrow + View link" with accurate Install Update banner description
- **Architecture section**: correct "Zero dependencies" to "One dependency" (Sparkle 2)
- **Privacy section**: add `kylenesium.github.io` appcast URL to network calls

Docs-only change — no code or binary changes.

## Test plan
- [ ] Verify README renders correctly on GitHub