### PR TITLE
Bump version to 1.5.4

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.3</string>
+	<string>1.5.4</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.3</string>
+	<string>1.5.4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.4] — 2026-03-02
+
+### Fixed
+- **Popover mouse pass-through** — hovering over the popover no longer interacts with windows beneath it. Configured the MenuBarExtra NSPanel (`becomesKeyOnlyIfNeeded = false`, `acceptsMouseMovedEvents = true`) and added `contentShape(Rectangle())` to close SwiftUI hit-testing gaps.
+
 ## [1.5.3] — 2026-02-26
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Bump `CFBundleShortVersionString` and `CFBundleVersion` to 1.5.4
- Add changelog entry for the popover mouse pass-through fix

Patch release for #37.