### PR TITLE
Bump version to 1.5.5 and update changelog

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.4</string>
+	<string>1.5.5</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.4</string>
+	<string>1.5.5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.5.5] — 2026-03-03
+
+### Added
+- **Defense-in-depth security hardening** — ephemeral URLSession (no disk cache/cookies), 2 MB response size guard, 10 MB stats-cache file size guard, symlink boundary check for JSONL discovery, Keychain accessibility migration (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`)
+- **Performance caching** — ModelNameMapper result cache, UsageAggregator redundant aggregation skip (fingerprint-based), StatsCacheReader exposes `lastModificationDate` for change detection
+- **NotificationManager concurrency** — `@MainActor` annotation, structured concurrency batching (replaces DispatchSource timer), `shouldAlert` marked `nonisolated`
+- 13 new tests (408 → 421 total): SecureNetworking, SessionLogReader symlink boundary, StatsCacheReader file size guard, UsageAggregator redundant skip, ModelNameMapper result cache
+
 ## [1.5.4] — 2026-03-02
 
 ### Fixed

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -221,6 +221,13 @@ Pricing per million tokens:
 | MarqueeText hold | 3s before cycling to next text (non-scrolling) |
 | MarqueeText cross-fade | 0.3s ease-out fade out, 0.3s ease-in fade in |
 
+## Security Guards
+
+| Constant | Value | File |
+|----------|-------|------|
+| Max API response size | 2,000,000 bytes (2 MB) — drops oversized responses | SecureNetworking |
+| Max stats-cache file size | 10,000,000 bytes (10 MB) — rejects before read | StatsCacheReader |
+
 ## JSONL Processing
 
 | Constant | Value |


### PR DESCRIPTION
## Summary
- Bump version to 1.5.5 in Info.plist
- Add changelog entry covering security hardening (PR #40) and performance caching (PR #41)
- Add missing "Security Guards" section to CONSTANTS.md (maxResponseSize, maxFileSize)

## Test plan
- [x] `swift build -c release` passes
- [ ] CI build + test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)