### PR TITLE
Fix 7D activity chart, persistent popover, and context health UX

### DIFF
--- a/AIBattery/Services/TokenHealthMonitor.swift
+++ b/AIBattery/Services/TokenHealthMonitor.swift
@@ -40,7 +40,8 @@ final class TokenHealthMonitor {
             }
         }
 
-        recentResults.sort { ($0.lastActivity ?? .distantPast) > ($1.lastActivity ?? .distantPast) }
+        // Highest context usage first so the most-consumed session is always position 1
+        recentResults.sort { $0.usagePercentage > $1.usagePercentage }
         let top = Array(recentResults.prefix(topLimit))
 
         return (current, top)

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -162,7 +162,29 @@ final class UsageAggregator {
         let tokenHealth = healthResult.current
         let topSessionHealths = healthResult.top
 
-        let activity = statsCache?.dailyActivity ?? []
+        // Merge today's live JSONL data into dailyActivity so the 7D chart
+        // reflects current-day usage even when stats-cache hasn't been rebuilt.
+        var activity = statsCache?.dailyActivity ?? []
+        if todayMessages > 0 {
+            if let idx = activity.firstIndex(where: { $0.date == todayDate }) {
+                // Replace if JSONL has more messages than stale cache entry
+                if todayMessages > activity[idx].messageCount {
+                    activity[idx] = DailyActivity(
+                        date: todayDate,
+                        messageCount: todayMessages,
+                        sessionCount: todaySessions,
+                        toolCallCount: max(todayToolCalls, activity[idx].toolCallCount)
+                    )
+                }
+            } else {
+                activity.append(DailyActivity(
+                    date: todayDate,
+                    messageCount: todayMessages,
+                    sessionCount: todaySessions,
+                    toolCallCount: todayToolCalls
+                ))
+            }
+        }
 
         let snapshot = UsageSnapshot(
             lastUpdated: now,

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -12,6 +12,9 @@ public final class StatusBarManager: NSObject {
     private var hostingView: NSHostingView<PopoverContentView>?
     private var cancellables = Set<AnyCancellable>()
     private var escapeMonitor: Any?
+    /// Tracks intended panel visibility — used to re-show panel after app deactivation.
+    private var isPanelShowing = false
+    private var deactivationObserver: Any?
 
     public override init() {
         super.init()
@@ -102,11 +105,23 @@ public final class StatusBarManager: NSObject {
 
         // Close panel on Escape key
         escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53, let self, let panel = self.panel, panel.isVisible {
-                panel.orderOut(nil)
+            if event.keyCode == 53, let self, self.isPanelShowing {
+                self.panel?.orderOut(nil)
+                self.isPanelShowing = false
                 return nil
             }
             return event
+        }
+
+        // Fallback: re-show panel if app deactivation hides it despite hidesOnDeactivate override
+        deactivationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, let panel = self.panel, self.isPanelShowing, !panel.isVisible else { return }
+                panel.orderFront(nil)
+            }
         }
 
         self.statusItem = item
@@ -117,6 +132,9 @@ public final class StatusBarManager: NSObject {
     deinit {
         if let monitor = escapeMonitor {
             NSEvent.removeMonitor(monitor)
+        }
+        if let observer = deactivationObserver {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 
@@ -161,12 +179,14 @@ public final class StatusBarManager: NSObject {
 
     @objc private func statusItemClicked() {
         guard let panel, let button = statusItem?.button else { return }
-        if panel.isVisible {
+        if isPanelShowing {
             panel.orderOut(nil)
+            isPanelShowing = false
         } else {
             positionPanel(relativeTo: button)
             panel.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            isPanelShowing = true
         }
     }
 
@@ -193,8 +213,22 @@ public final class StatusBarManager: NSObject {
 // MARK: - Panel subclass
 
 /// Borderless panel that can become key (accepts keyboard events).
+/// Overrides `hidesOnDeactivate` to always return false — prevents SwiftUI's
+/// app lifecycle from hiding the panel when the app loses focus.
 private class PopoverPanel: NSPanel {
     override var canBecomeKey: Bool { true }
+    override var hidesOnDeactivate: Bool {
+        get { false }
+        set { /* ignore — panel must stay visible regardless of app activation */ }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 { // Escape
+            orderOut(nil)
+        } else {
+            super.keyDown(with: event)
+        }
+    }
 }
 
 // MARK: - SwiftUI content

--- a/AIBattery/Views/TokenHealthSection.swift
+++ b/AIBattery/Views/TokenHealthSection.swift
@@ -158,34 +158,28 @@ struct TokenHealthSection: View {
     /// Chevron buttons to cycle through sessions
     private var sessionToggle: some View {
         HStack(spacing: 2) {
-            Button(action: {
+            ChevronButton(
+                direction: .left,
+                enabled: selectedIndex > 0
+            ) {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     selectedIndex = max(selectedIndex - 1, 0)
                 }
-            }) {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 8, weight: .semibold))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(selectedIndex > 0 ? .secondary : .quaternary)
-            .disabled(selectedIndex == 0)
             .accessibilityLabel("Previous session")
 
             Text("\(selectedIndex + 1)/\(sessions.count)")
                 .font(.system(.caption2, design: .monospaced))
                 .foregroundStyle(.tertiary)
 
-            Button(action: {
+            ChevronButton(
+                direction: .right,
+                enabled: selectedIndex < sessions.count - 1
+            ) {
                 withAnimation(.easeInOut(duration: 0.15)) {
                     selectedIndex = min(selectedIndex + 1, sessions.count - 1)
                 }
-            }) {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .semibold))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(selectedIndex < sessions.count - 1 ? .secondary : .quaternary)
-            .disabled(selectedIndex >= sessions.count - 1)
             .accessibilityLabel("Next session")
         }
         .help("Browse recent sessions")
@@ -366,5 +360,36 @@ struct TokenHealthSection: View {
 
     private var bandColor: Color {
         ThemeColors.bandColor(health.band)
+    }
+}
+
+// MARK: - Chevron button with larger hit target and press highlight
+
+private struct ChevronButton: View {
+    enum Direction { case left, right }
+
+    let direction: Direction
+    let enabled: Bool
+    let action: () -> Void
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: direction == .left ? "chevron.left" : "chevron.right")
+                .font(.system(size: 9, weight: .bold))
+                .frame(width: 22, height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isPressed ? Color.primary.opacity(0.1) : Color.clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(enabled ? Color.primary.opacity(0.6) : Color.primary.opacity(0.15))
+        .disabled(!enabled)
+        .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
+            isPressed = pressing
+        }, perform: {})
     }
 }

--- a/Tests/AIBatteryCoreTests/Services/TokenHealthMonitorTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/TokenHealthMonitorTests.swift
@@ -153,8 +153,9 @@ struct TokenHealthMonitorTests {
         #expect(top.first?.id == "recent")
     }
 
-    @Test func topSessions_sortedByRecency() {
+    @Test func topSessions_sortedByHighestUsage() {
         let now = Date()
+        // s3 has highest input (most context consumed), then s2, then s1
         let entries = [
             makeEntry(sessionId: "s1", input: 1000, output: 100, timestamp: now.addingTimeInterval(-3600)),
             makeEntry(sessionId: "s2", input: 2000, output: 200, timestamp: now),
@@ -162,9 +163,10 @@ struct TokenHealthMonitorTests {
         ]
         let top = monitor.topSessions(entries: entries, limit: 5)
         #expect(top.count == 3)
-        #expect(top[0].id == "s2")
-        #expect(top[1].id == "s1")
-        #expect(top[2].id == "s3")
+        // Sorted by usagePercentage descending (highest context usage first)
+        #expect(top[0].id == "s3")
+        #expect(top[1].id == "s2")
+        #expect(top[2].id == "s1")
     }
 
     @Test func topSessions_respectsLimit() {


### PR DESCRIPTION
## Summary
- **7D/12M activity chart fix** — merge today's live JSONL messages into `dailyActivity` so charts reflect current-day usage even when `stats-cache.json` is stale
- **Persistent popover** — override `hidesOnDeactivate` in PopoverPanel subclass + deactivation observer fallback to prevent SwiftUI lifecycle from hiding the panel
- **Context health sorting** — sessions sorted by highest context usage (position 1 = most consumed) instead of recency
- **Chevron buttons** — 22pt hit targets with press highlight, replacing tiny 8pt icons

## Test plan
- [ ] Open 7D activity chart — today's bar should appear
- [ ] Switch to 12M — should show monthly aggregates including current month
- [ ] 24H chart should display hourly distribution
- [ ] Click menu bar icon → popover opens, click another app → popover stays open
- [ ] Press Escape → popover closes
- [ ] Context health arrows are easy to click and highlight on press
- [ ] Highest-usage session appears first in context health

🤖 Generated with [Claude Code](https://claude.com/claude-code)