### PR TITLE
Release v1.6.0

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.6</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.6</string>
+	<string>1.6.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Changelog
 
-## [1.5.6] — 2026-03-03
+## [1.6.0] — 2026-03-03
 
 ### Added
 - **Menu bar throttle countdown** — when rate-limited, menu bar shows countdown to reset (e.g., "2h 15m", "45m") instead of "100%". Updates on each polling cycle, overrides metric mode while throttled.
+- **Live activity chart** — 7D and 12M charts now merge today's live JSONL messages into `dailyActivity`, showing current-day usage even when `stats-cache.json` is stale.
 - 7 new tests: countdown formatter (6), throttled header parsing (1) — 421 → 428 total
 
 ### Changed
 - **StatusBarManager rewrite** — replaced SwiftUI `MenuBarExtra` with native AppKit `NSStatusItem` + floating `NSPanel`. Menu bar button uses native `button.image` + `button.title` with system monospaced-digit font (matches macOS battery indicator). Removed `PanelAccessor.swift` and `MenuBarLabel.swift`.
+- **Context health sorted by usage** — sessions ordered by highest context consumption (position 1 = most-consumed) instead of recency.
+- **Improved context health navigation** — chevron buttons enlarged to 22pt hit targets with press highlight for easier clicking.
 
 ### Fixed
-- **Popover stays open** — panel no longer dismisses when mouse moves away or focus shifts. Uses a floating `NSPanel` (`hidesOnDeactivate = false`) instead of `NSPopover` — only closes on status item click or Escape key.
+- **Popover stays open** — panel no longer dismisses when mouse moves away or focus shifts. `PopoverPanel` overrides `hidesOnDeactivate` getter to always return `false`, with a deactivation observer fallback. Only closes on status item click or Escape key.
 - **Blank menu bar icon** — `NSHostingView` inside `NSStatusBarButton` doesn't render; replaced with native AppKit properties (`button.image`, `button.title`).
 - **Rate limit bars vanishing when throttled** — 429 responses now parse rate limit headers directly instead of discarding them. Usage bars and reset times remain visible while rate-limited.
+- **7D activity chart empty** — chart showed "No activity data" because today's JSONL messages weren't included in `dailyActivity`. Now merged before snapshot construction.
 
 ## [1.5.5] — 2026-03-03
 

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -202,6 +202,9 @@ Pricing per million tokens:
 | Status dot size | 6pt |
 | Model dot size | 8pt |
 | Token type dot size | 6pt |
+| Chevron button frame | 22×22pt |
+| Chevron icon size | 9pt (bold weight) |
+| Chevron corner radius | 4pt |
 | Chart height | 50pt |
 | Chart modes | 24H (hourly), 7D (daily rolling), 12M (monthly rolling) |
 

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -24,9 +24,9 @@ Main aggregated data struct consumed by all views.
 | `todayToolCalls` | `Int` | stats-cache dailyActivity for today |
 | `hourCounts` | `[String: Int]` | stats-cache hourCounts (hour "0"-"23" → message count) |
 | `modelTokens` | `[ModelTokenSummary]` | Merged stats-cache + JSONL |
-| `dailyActivity` | `[DailyActivity]` | stats-cache |
+| `dailyActivity` | `[DailyActivity]` | stats-cache + today's JSONL merge |
 | `tokenHealth` | `TokenHealthStatus?` | Most recent session assessment |
-| `topSessionHealths` | `[TokenHealthStatus]` | Top 5 sessions by most recent activity (descending) |
+| `topSessionHealths` | `[TokenHealthStatus]` | Top 5 sessions by highest usagePercentage (descending) |
 
 Stored (pre-computed at construction): `totalTokens: Int` (sum of all `modelTokens.totalTokens`), `dailyAverage: Int` (average messages/day from last 7 days of `dailyActivity`), `trendDirection: TrendDirection` (compare this week vs last week averages, ±10% threshold → `.up`/`.down`/`.flat`), `busiestDayOfWeek: (name: String, averageCount: Int)?` (highest average from `dailyActivity` by weekday).
 
@@ -326,14 +326,15 @@ Pricing table (per million tokens):
   - **All-time mode (0)**: stats-cache `modelUsage` + uncached JSONL, anti-double-counting for dates already in stats cache, 72-hour recent model filter
   - **Windowed mode (1–7)**: computes token totals from all JSONL entries within the window, bypasses stats-cache `modelUsage`
 - **Non-Claude model filter**: excludes model IDs that don't start with `"claude-"` (e.g. `"synthetic"`)
+- **Daily activity merge**: merges today's JSONL message/session counts into `dailyActivity` before snapshot construction, so the 7D chart reflects current-day usage even when stats-cache hasn't been rebuilt. If today's JSONL has more messages than the stale cache entry, replaces it; if no entry exists for today, appends one. Preserves the higher of JSONL or cache tool-call counts.
 - Tool calls from stats cache only (not parsed from JSONL)
 - Token health via `TokenHealthMonitor.assessSessions` (single-pass: returns both current + top 5)
 
 ### TokenHealthMonitor (`Services/TokenHealthMonitor.swift`)
 - Singleton: `.shared`
-- `assessSessions(entries:topLimit:) -> (current: TokenHealthStatus?, top: [TokenHealthStatus])` — **single-pass**: groups entries once via `Dictionary(grouping:)`, assesses all sessions, returns current session health + top N most recent (excludes sessions with no activity in last 24 hours). Default topLimit is 5.
+- `assessSessions(entries:topLimit:) -> (current: TokenHealthStatus?, top: [TokenHealthStatus])` — **single-pass**: groups entries once via `Dictionary(grouping:)`, assesses all sessions, returns current session health + top N sorted by `usagePercentage` descending (highest context usage first). Excludes sessions with no activity in last 24 hours. Default topLimit is 5.
 - `assessCurrentSession(entries:) -> TokenHealthStatus?` — convenience wrapper, returns `assessSessions().current`
-- `topSessions(entries:limit:) -> [TokenHealthStatus]` — convenience wrapper, returns `assessSessions().top`
+- `topSessions(entries:limit:) -> [TokenHealthStatus]` — convenience wrapper, returns `assessSessions().top` (sorted by highest usagePercentage)
 - Groups by sessionId, each session assessed independently
 - **Core calculation**: `totalUsed = latestEntry.inputTokens + latestEntry.cacheReadTokens + latestEntry.cacheWriteTokens + sum(all outputTokens)` — input + cache tokens are cumulative (latest entry has total), output tokens are per-message. Each component capped at contextWindow to guard against overflow from corrupted data.
 - **Usable window**: `usableWindow = contextWindow × 0.80` — percentages calculated against usable portion

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -203,18 +203,18 @@ Padding: H 16, V 12
 
 ### ❸ Context Health (`Views/TokenHealthSection.swift`)
 
-Takes `sessions: [TokenHealthStatus]` array (top 5 most recent). Backward-compat `init(health:onRefresh:)` for single session.
+Takes `sessions: [TokenHealthStatus]` array (top 5 by highest context usage). Backward-compat `init(health:onRefresh:)` for single session.
 
 - **Header row**: `"Context Health"` (.subheadline.bold) + session toggle + refresh + health badge
 - **Session info** (two lines below header, .caption2, .tertiary):
   - Line 1: `projectName · gitBranch · sessionId[:8]` — project, branch, and 8-char session ID prefix (`.copyable()`) for cross-referencing
   - Line 2: `duration · lastActivity · velocity` — e.g. "2h 15m · Today 14:32 · 1.2K/min"
   - Falls back to `"Latest session"` if no metadata on line 1
-- **Session toggle** (if multiple sessions): `< 1/3 >` chevron buttons
-  - `@State selectedIndex` tracks current session
+- **Session toggle** (if multiple sessions): `< 1/3 >` `ChevronButton` components
+  - `@State selectedIndex` tracks current session (position 1 = highest context usage)
+  - `ChevronButton`: 22pt square hit target, `chevron.left`/`chevron.right` icons at 9pt bold, 4pt corner radius background with press highlight (`Color.primary.opacity(0.1)`), `.plain` button style. Disabled state uses 0.15 opacity; enabled uses 0.6 opacity.
   - Left/right chevrons with `.easeInOut(0.15)` animation
   - Counter: monospaced caption2, e.g. `"1/3"`
-  - Disabled states at bounds, `.quaternary` color when disabled
 - **Swipe gesture**: `DragGesture(minimumDistance: 20)` on main VStack — horizontal drag >50pt or fast flick (velocity >300pt/s) navigates prev/next session (same animation as chevron buttons)
 - **VoiceOver**: `.accessibilityAdjustableAction` on section — increment/decrement maps to next/previous session
 - **Stale session badge** (if lastActivity > 30 min and band != .green): amber dot (6pt) + `"Idle Xm"` (.caption2, .orange)


### PR DESCRIPTION
## Summary
Version bump to 1.6.0 consolidating all changes since 1.5.5:

- **Menu bar throttle countdown** — countdown to reset when rate-limited
- **StatusBarManager rewrite** — native AppKit NSStatusItem + floating NSPanel
- **Persistent popover** — hidesOnDeactivate override + deactivation observer
- **Live activity charts** — 7D/12M merge today's JSONL messages
- **Context health by usage** — highest-consumed session first
- **Better navigation arrows** — 22pt targets with press highlight
- **429 header parsing** — rate limit bars stay visible when throttled

## Test plan
- [ ] `swift build` clean
- [ ] CI passes
- [ ] Local test: all 3 chart modes (24H, 7D, 12M) show data
- [ ] Popover stays open on focus loss
- [ ] Context health arrows clickable and highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)