### PR TITLE
Add context explainer to README context health section

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Each session displays: **project name** · **git branch** · **duration** · **l
 
 Percentages are relative to the **usable window** — 80% of the model's raw context window. At 100%, Claude Code auto-compacts.
 
+**Think of context as Claude's short-term memory.** Every message, file read, tool call, and response accumulates in a 200K-token window. Nothing is discarded between turns. When the window fills up (100% of usable), Claude Code auto-compacts — it summarizes the session into a few paragraphs and clears the rest. That summary is lossy: file contents, specific instructions, and nuanced decisions get compressed. Claude keeps working, but from a recap instead of the real conversation. Quality degrades even before that point — a packed window means Claude is scanning thousands of stale tokens every turn, making responses slower and less accurate. Keep at least 20–40% free for best results.
+
 | Color | Range | Meaning |
 |---|---|---|
 | 🟢 Green | < 60% | Plenty of room |


### PR DESCRIPTION
## Summary
- Adds a beginner-friendly paragraph above the existing color table in the Context Health section
- Explains what context is, why filling it degrades output, what auto-compact does, and why it's lossy
- Existing table, warnings, and tips unchanged

## Test plan
- [ ] View README on GitHub — new paragraph renders correctly in markdown
- [ ] Paragraph sits between the "auto-compacts" line and the color table
- [ ] No formatting issues in the `<table>` HTML block

🤖 Generated with [Claude Code](https://claude.com/claude-code)