### PR TITLE
Add privacy manifest, ENABLE_SPARKLE flag, and App Store prep

### DIFF
--- a/AIBattery/AIBattery-AppStore.entitlements
+++ b/AIBattery/AIBattery-AppStore.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.home-relative-path.read-only</key>
+	<array>
+		<string>.claude/</string>
+	</array>
+</dict>
+</plist>

--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -28,5 +28,7 @@
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://kylenesium.github.io/AIBattery/appcast.xml</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025 KyleNesium. All rights reserved.</string>
 </dict>
 </plist>

--- a/AIBattery/PrivacyInfo.xcprivacy
+++ b/AIBattery/PrivacyInfo.xcprivacy
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>DDA9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/AIBattery/Services/SparkleUpdateService.swift
+++ b/AIBattery/Services/SparkleUpdateService.swift
@@ -1,3 +1,4 @@
+#if ENABLE_SPARKLE
 import AppKit
 import Sparkle
 
@@ -53,3 +54,4 @@ public final class SparkleUpdateService {
         updaterController.updater
     }
 }
+#endif

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -207,11 +207,17 @@ public struct UsagePopoverView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel("Version \(update.version) release notes")
                     Button(action: {
+                        #if ENABLE_SPARKLE
                         if SparkleUpdateService.shared.canCheckForUpdates {
                             SparkleUpdateService.shared.checkForUpdates()
                         } else if let url = URL(string: update.url) {
                             NSWorkspace.shared.open(url)
                         }
+                        #else
+                        if let url = URL(string: update.url) {
+                            NSWorkspace.shared.open(url)
+                        }
+                        #endif
                     }) {
                         HStack(spacing: 3) {
                             Image(systemName: "arrow.down.circle")

--- a/AIBatteryApp/AIBatteryApp.swift
+++ b/AIBatteryApp/AIBatteryApp.swift
@@ -12,7 +12,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             SingleInstanceGuard.ensureSingleInstance()
             SingleInstanceGuard.installSignalHandlers()
             _ = NotificationManager.shared
+            #if ENABLE_SPARKLE
             _ = SparkleUpdateService.shared
+            #endif
             statusBarManager.setup(viewModel: viewModel, oauthManager: oauthManager)
         }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -17,17 +17,21 @@ let package = Package(
             name: "AIBatteryCore",
             dependencies: ["Sparkle"],
             path: "AIBattery",
-            exclude: ["Info.plist", "AIBattery.entitlements"]
+            exclude: ["Info.plist", "AIBattery.entitlements", "AIBattery-AppStore.entitlements"],
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.define("ENABLE_SPARKLE")]
         ),
         .executableTarget(
             name: "AIBattery",
             dependencies: ["AIBatteryCore"],
-            path: "AIBatteryApp"
+            path: "AIBatteryApp",
+            swiftSettings: [.define("ENABLE_SPARKLE")]
         ),
         .testTarget(
             name: "AIBatteryCoreTests",
             dependencies: ["AIBatteryCore"],
-            path: "Tests/AIBatteryCoreTests"
+            path: "Tests/AIBatteryCoreTests",
+            swiftSettings: [.define("ENABLE_SPARKLE")]
         )
     ]
 )

--- a/Tests/AIBatteryCoreTests/Services/SparkleUpdateServiceTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SparkleUpdateServiceTests.swift
@@ -1,3 +1,4 @@
+#if ENABLE_SPARKLE
 import Foundation
 import Testing
 import Sparkle
@@ -60,3 +61,4 @@ struct SparkleUpdateServiceTests {
         #expect(service.updater.automaticallyDownloadsUpdates == false)
     }
 }
+#endif

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -32,6 +32,7 @@ install_name_tool -add_rpath @executable_path/../Frameworks "$APP_DIR/Contents/M
 cp .build/AppIcon.icns "$APP_DIR/Contents/Resources/AppIcon.icns"
 
 cp AIBattery/Info.plist "$APP_DIR/Contents/Info.plist"
+cp AIBattery/PrivacyInfo.xcprivacy "$APP_DIR/Contents/Resources/PrivacyInfo.xcprivacy"
 
 # Inject version from git tag if available (e.g. v1.2.4 → 1.2.4)
 GIT_TAG=$(git describe --tags --exact-match 2>/dev/null || true)

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -60,7 +60,9 @@ AIBatteryApp/
   AIBatteryApp.swift              — @main, imports AIBatteryCore, AppDelegate + Settings { EmptyView() }, initializes StatusBarManager
 AIBattery/
   Info.plist                      — LSUIElement = YES (no Dock icon)
-  AIBattery.entitlements          — App sandbox disabled
+  AIBattery.entitlements          — Direct-download entitlements (sandbox disabled)
+  AIBattery-AppStore.entitlements — App Store entitlements (sandbox + network.client + .claude/ read)
+  PrivacyInfo.xcprivacy           — Privacy manifest (UserDefaults + FileTimestamp API declarations)
   Models/
     AccountRecord.swift           — Per-account identity record (Codable, Identifiable)
     APIFetchResult.swift          — Combined result from a single Messages API call
@@ -174,6 +176,8 @@ CHANGELOG.md                      — Release notes per version
 - **App icon**: Generated at build time via `scripts/generate-icon.swift` (sparkle star, all macOS sizes). Embedded in `Contents/Resources/AppIcon.icns` and used as DMG volume icon.
 - **Dock icon**: None (LSUIElement = true)
 - **Dependencies**: Sparkle 2 (SPM, auto-update framework) — all other dependencies are Apple frameworks only (SwiftUI, Charts, Security, Foundation, AppKit, ServiceManagement)
+- **Compiler flag**: `ENABLE_SPARKLE` — defined in all 3 SPM targets via `swiftSettings`. Guards all Sparkle imports/usage. Remove the define to build without Sparkle (App Store variant)
+- **Privacy manifest**: `PrivacyInfo.xcprivacy` bundled as SPM resource, also copied to `Contents/Resources/` by build script
 
 ## Release Pipeline
 
@@ -206,12 +210,12 @@ CHANGELOG.md                      — Release notes per version
 
 Not currently planned, but documented here for reference. These are the architectural changes required before an App Store submission would be possible.
 
-| Blocker | Impact | Resolution Path |
-|---------|--------|-----------------|
-| App Sandbox | Can't read `~/.claude/` — App Store requires sandbox | XPC helper process or File Provider extension with bookmark access |
-| Sparkle framework | App Store rejects third-party update mechanisms | Remove Sparkle; use App Store's built-in update system |
-| `disable-library-validation` entitlement | Rejected by App Store review (only needed for Sparkle's dynamic loading) | Remove once Sparkle is gone |
+| Blocker | Impact | Status |
+|---------|--------|--------|
+| App Sandbox | Can't read `~/.claude/` — App Store requires sandbox | `AIBattery-AppStore.entitlements` prepared with `files.home-relative-path.read-only` for `.claude/` |
+| Sparkle framework | App Store rejects third-party update mechanisms | `ENABLE_SPARKLE` flag gates all Sparkle code; remove define for App Store build |
+| `disable-library-validation` entitlement | Rejected by App Store review (only needed for Sparkle's dynamic loading) | Not in `AIBattery-AppStore.entitlements` — resolved when Sparkle is disabled |
+| Privacy manifest | Required for App Store submission | `PrivacyInfo.xcprivacy` added (UserDefaults + FileTimestamp) |
 | Apple Developer certificate | App Store requires signed builds ($99/yr) | Enroll in Apple Developer Program |
-| Info.plist privacy descriptions | Missing usage descriptions required by App Store review | Add `NSDesktopFolderUsageDescription` etc. |
 
-Each blocker is non-trivial and should be addressed as a dedicated effort, not mixed into routine code changes.
+Remaining blockers are non-trivial and should be addressed as a dedicated effort, not mixed into routine code changes.

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -332,6 +332,12 @@ Most bar and accent colors use system palette in both modes (the opaque light-mo
 
 **Incident escalation**: When components report `operational` but active incidents exist, the incident `impact` field (`none`, `minor`, `major`, `critical`) is factored in. If impact is `none` but incidents are active, the status escalates to at least Degraded Performance (yellow).
 
+## Compiler Flags
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `ENABLE_SPARKLE` | Defined (all 3 SPM targets) | Guards Sparkle imports, `SparkleUpdateService`, and Sparkle-dependent UI. Remove to build App Store variant without Sparkle. |
+
 ## Predictive Rate Limit
 
 | Constant | Value |


### PR DESCRIPTION
## Summary
- Add `NSHumanReadableCopyright` to Info.plist
- Create `PrivacyInfo.xcprivacy` declaring UserDefaults (`CA92.1`) and FileTimestamp (`DDA9.1`) API usage, bundled as SPM resource and copied by build script
- Gate all Sparkle code behind `ENABLE_SPARKLE` compiler flag (defined by default in all 3 SPM targets) — remove the define for App Store builds
- Create `AIBattery-AppStore.entitlements` with sandbox + network.client + `.claude/` read-only access (excluded from SPM, not active yet)
- Update `spec/ARCHITECTURE.md` and `spec/CONSTANTS.md` with new files, compiler flag docs, and updated App Store blocker status

## Test plan
- [ ] `swift build` compiles cleanly (debug + release)
- [ ] `swift test` passes (requires Xcode toolchain)
- [ ] Build script produces bundle with `PrivacyInfo.xcprivacy` in `Contents/Resources/`
- [ ] Sparkle update flow still works (ENABLE_SPARKLE is ON by default)
- [ ] Verify `#else` fallback in UsagePopoverView opens GitHub release URL