### PR TITLE
Add ENABLE_VERSION_CHECKER flag, fix App Store entitlements, add SandboxAccessManager

### DIFF
--- a/AIBattery/AIBattery-AppStore.entitlements
+++ b/AIBattery/AIBattery-AppStore.entitlements
@@ -6,9 +6,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.files.home-relative-path.read-only</key>
-	<array>
-		<string>.claude/</string>
-	</array>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 </dict>
 </plist>

--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -30,5 +30,7 @@
 	<string>https://kylenesium.github.io/AIBattery/appcast.xml</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2025 KyleNesium. All rights reserved.</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 </dict>
 </plist>

--- a/AIBattery/Services/SandboxAccessManager.swift
+++ b/AIBattery/Services/SandboxAccessManager.swift
@@ -1,0 +1,71 @@
+#if APP_SANDBOX
+import Foundation
+import AppKit
+
+/// Manages security-scoped bookmark persistence for `~/.claude/` access under App Sandbox.
+/// Only active when `APP_SANDBOX` compile flag is set (dormant in direct-download builds).
+@MainActor
+public final class SandboxAccessManager {
+    static let shared = SandboxAccessManager()
+
+    private let bookmarkKey = "aibattery_claudeDirBookmark"
+
+    /// Whether we have a valid bookmark for ~/.claude/.
+    var hasAccess: Bool { resolveBookmark() != nil }
+
+    /// Prompt user to select ~/.claude/ directory via NSOpenPanel.
+    /// Returns the security-scoped URL on success.
+    func requestAccess() -> URL? {
+        let panel = NSOpenPanel()
+        panel.message = "AI Battery needs access to your ~/.claude folder to read usage data."
+        panel.prompt = "Grant Access"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude")
+
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+
+        // Store security-scoped bookmark
+        if let data = try? url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        ) {
+            UserDefaults.standard.set(data, forKey: bookmarkKey)
+        }
+        return url
+    }
+
+    /// Resolve stored bookmark to a security-scoped URL.
+    func resolveBookmark() -> URL? {
+        guard let data = UserDefaults.standard.data(forKey: bookmarkKey) else { return nil }
+        var isStale = false
+        guard let url = try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        ) else { return nil }
+
+        if isStale {
+            // Re-store refreshed bookmark
+            if let fresh = try? url.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) {
+                UserDefaults.standard.set(fresh, forKey: bookmarkKey)
+            }
+        }
+        return url
+    }
+
+    /// Start accessing the security-scoped resource. Call on app launch.
+    func startAccessing() -> Bool {
+        guard let url = resolveBookmark() else { return false }
+        return url.startAccessingSecurityScopedResource()
+    }
+}
+#endif

--- a/AIBattery/Services/VersionChecker.swift
+++ b/AIBattery/Services/VersionChecker.swift
@@ -1,3 +1,4 @@
+#if ENABLE_VERSION_CHECKER
 import Foundation
 
 /// Checks GitHub Releases for new versions. Fetches once per 24 hours.
@@ -153,3 +154,4 @@ public final class VersionChecker {
         }
     }
 }
+#endif

--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -11,8 +11,10 @@ public final class UsageViewModel: ObservableObject {
     @Published var lastFreshFetch: Date?
     /// Whether the most recent API result was served from cache.
     @Published var isShowingCachedData = false
+    #if ENABLE_VERSION_CHECKER
     /// Available update from GitHub Releases (nil if up-to-date or not checked).
     @Published var availableUpdate: VersionChecker.UpdateInfo?
+    #endif
 
     private let aggregator = UsageAggregator()
     private var fileWatcher: FileWatcher?
@@ -162,9 +164,11 @@ public final class UsageViewModel: ObservableObject {
             NotificationManager.shared.checkRateLimitAlerts(rateLimits: limits)
         }
 
+        #if ENABLE_VERSION_CHECKER
         if availableUpdate == nil {
             availableUpdate = await VersionChecker.shared.checkForUpdate()
         }
+        #endif
     }
 
     /// Switch to a different account and refresh data.

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -7,9 +7,11 @@ public struct UsagePopoverView: View {
     @State private var isAddingAccount = false
     @AppStorage(UserDefaultsKeys.metricMode) private var metricModeRaw: String = "5h"
     @AppStorage(UserDefaultsKeys.autoMetricMode) private var autoMetricMode: Bool = false
+    #if ENABLE_VERSION_CHECKER
     @State private var updateCheckMessage: String?
     @State private var updateCheckDismissTask: Task<Void, Never>?
     @State private var updateBannerDismissed = false
+    #endif
     @State private var accountCountAtAddStart = 0
 
     public init(viewModel: UsageViewModel) {
@@ -117,9 +119,11 @@ public struct UsagePopoverView: View {
         .overlay {
             TutorialOverlay(hasData: viewModel.snapshot != nil)
         }
+        #if ENABLE_VERSION_CHECKER
         .onDisappear {
             updateCheckDismissTask?.cancel()
         }
+        #endif
     }
 
     private var accounts: [AccountRecord] {
@@ -138,6 +142,7 @@ public struct UsagePopoverView: View {
                         .scaleEffect(0.6)
                         .frame(width: 16, height: 16)
                 }
+                #if ENABLE_VERSION_CHECKER
                 Text("v\(VersionChecker.currentAppVersion)")
                     .font(.system(size: 9, design: .monospaced))
                     .foregroundStyle(ThemeColors.tertiaryLabel)
@@ -173,6 +178,11 @@ public struct UsagePopoverView: View {
                 )
                 .help(viewModel.availableUpdate.map { "v\($0.version) available" } ?? "Check for updates")
                 .accessibilityLabel(viewModel.availableUpdate.map { "Version \($0.version) available" } ?? "Check for updates")
+                #else
+                Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0")")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(ThemeColors.tertiaryLabel)
+                #endif
                 Button(action: { withAnimation(.easeInOut(duration: 0.2)) { showSettings.toggle() } }) {
                     Image(systemName: "gearshape")
                         .font(.system(size: 11, weight: .medium))
@@ -184,6 +194,7 @@ public struct UsagePopoverView: View {
                 .accessibilityHint(showSettings ? "Close settings" : "Open settings")
             }
 
+            #if ENABLE_VERSION_CHECKER
             // Update status message (appears/disappears below header row)
             if let update = viewModel.availableUpdate, !updateBannerDismissed {
                 HStack(spacing: 6) {
@@ -261,6 +272,7 @@ public struct UsagePopoverView: View {
                 }
                 .transition(.opacity)
             }
+            #endif
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/Package.swift
+++ b/Package.swift
@@ -19,19 +19,19 @@ let package = Package(
             path: "AIBattery",
             exclude: ["Info.plist", "AIBattery.entitlements", "AIBattery-AppStore.entitlements"],
             resources: [.copy("PrivacyInfo.xcprivacy")],
-            swiftSettings: [.define("ENABLE_SPARKLE")]
+            swiftSettings: [.define("ENABLE_SPARKLE"), .define("ENABLE_VERSION_CHECKER")]
         ),
         .executableTarget(
             name: "AIBattery",
             dependencies: ["AIBatteryCore"],
             path: "AIBatteryApp",
-            swiftSettings: [.define("ENABLE_SPARKLE")]
+            swiftSettings: [.define("ENABLE_SPARKLE"), .define("ENABLE_VERSION_CHECKER")]
         ),
         .testTarget(
             name: "AIBatteryCoreTests",
             dependencies: ["AIBatteryCore"],
             path: "Tests/AIBatteryCoreTests",
-            swiftSettings: [.define("ENABLE_SPARKLE")]
+            swiftSettings: [.define("ENABLE_SPARKLE"), .define("ENABLE_VERSION_CHECKER")]
         )
     ]
 )

--- a/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
@@ -1,3 +1,4 @@
+#if ENABLE_VERSION_CHECKER
 import Foundation
 import Testing
 @testable import AIBatteryCore
@@ -218,3 +219,4 @@ struct VersionCheckerTests {
         #expect(UserDefaultsKeys.lastUpdateURL.hasPrefix("aibattery_"))
     }
 }
+#endif

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -45,6 +45,12 @@ if [ -n "$GIT_TAG" ]; then
   echo "Injected version ${VERSION} from tag ${GIT_TAG}"
 fi
 
+# Strip Sparkle feed URL for App Store builds
+if [ -n "${APP_STORE_BUILD:-}" ]; then
+  /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
+  echo "Stripped SUFeedURL for App Store build"
+fi
+
 # Inject Sparkle EdDSA public key (required for signature verification)
 if [ -n "${SPARKLE_EDDSA_PUBLIC_KEY:-}" ]; then
   /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string ${SPARKLE_EDDSA_PUBLIC_KEY}" "$APP_DIR/Contents/Info.plist"

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -90,6 +90,7 @@ AIBattery/
     LaunchAtLoginManager.swift    — SMAppService launch-at-login toggle
     VersionChecker.swift          — GitHub Releases update checker (24h cadence)
     SparkleUpdateService.swift     — Sparkle 2 wrapper for user-initiated auto-update
+    SandboxAccessManager.swift    — Security-scoped bookmark for ~/.claude/ (dormant, APP_SANDBOX flag)
   ViewModels/
     UsageViewModel.swift          — @MainActor ObservableObject, single source of truth
   Views/
@@ -177,6 +178,8 @@ CHANGELOG.md                      — Release notes per version
 - **Dock icon**: None (LSUIElement = true)
 - **Dependencies**: Sparkle 2 (SPM, auto-update framework) — all other dependencies are Apple frameworks only (SwiftUI, Charts, Security, Foundation, AppKit, ServiceManagement)
 - **Compiler flag**: `ENABLE_SPARKLE` — defined in all 3 SPM targets via `swiftSettings`. Guards all Sparkle imports/usage. Remove the define to build without Sparkle (App Store variant)
+- **Compiler flag**: `ENABLE_VERSION_CHECKER` — defined in all 3 SPM targets. Guards VersionChecker + update UI. Remove to build App Store variant (guideline 3.1.1)
+- **Compiler flag**: `APP_SANDBOX` — NOT defined by default. Enables SandboxAccessManager for security-scoped bookmark flow. Only set for App Store builds
 - **Privacy manifest**: `PrivacyInfo.xcprivacy` bundled as SPM resource, also copied to `Contents/Resources/` by build script
 
 ## Release Pipeline
@@ -212,10 +215,13 @@ Not currently planned, but documented here for reference. These are the architec
 
 | Blocker | Impact | Status |
 |---------|--------|--------|
-| App Sandbox | Can't read `~/.claude/` — App Store requires sandbox | `AIBattery-AppStore.entitlements` prepared with `files.home-relative-path.read-only` for `.claude/` |
+| App Sandbox | Can't read `~/.claude/` — App Store requires sandbox | `AIBattery-AppStore.entitlements` has `user-selected.read-only` + `bookmarks.app-scope`; `SandboxAccessManager` handles NSOpenPanel + bookmark persistence (dormant behind `APP_SANDBOX` flag) |
 | Sparkle framework | App Store rejects third-party update mechanisms | `ENABLE_SPARKLE` flag gates all Sparkle code; remove define for App Store build |
+| Version checker | App Store rejects apps that check for updates outside the store (guideline 3.1.1) | `ENABLE_VERSION_CHECKER` flag gates VersionChecker + update UI; remove define for App Store build |
 | `disable-library-validation` entitlement | Rejected by App Store review (only needed for Sparkle's dynamic loading) | Not in `AIBattery-AppStore.entitlements` — resolved when Sparkle is disabled |
+| SUFeedURL in Info.plist | App Store may flag Sparkle feed URL | `build-app.sh` strips SUFeedURL when `APP_STORE_BUILD` env is set |
 | Privacy manifest | Required for App Store submission | `PrivacyInfo.xcprivacy` added (UserDefaults + FileTimestamp) |
+| LSApplicationCategoryType | Required App Store metadata | Set to `public.app-category.developer-tools` in Info.plist |
 | Apple Developer certificate | App Store requires signed builds ($99/yr) | Enroll in Apple Developer Program |
 
 Remaining blockers are non-trivial and should be addressed as a dedicated effort, not mixed into routine code changes.

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -337,6 +337,16 @@ Most bar and accent colors use system palette in both modes (the opaque light-mo
 | Flag | Default | Effect |
 |------|---------|--------|
 | `ENABLE_SPARKLE` | Defined (all 3 SPM targets) | Guards Sparkle imports, `SparkleUpdateService`, and Sparkle-dependent UI. Remove to build App Store variant without Sparkle. |
+| `ENABLE_VERSION_CHECKER` | Defined (all 3 SPM targets) | Guards `VersionChecker`, update banner UI, and version check button. Remove for App Store (guideline 3.1.1). |
+| `APP_SANDBOX` | NOT defined | Enables `SandboxAccessManager` (security-scoped bookmark for `~/.claude/` access). Only set for App Store builds. |
+
+## Sandbox Access (App Store only)
+
+| Constant | Value |
+|----------|-------|
+| Bookmark key | `aibattery_claudeDirBookmark` (Data, security-scoped bookmark for `~/.claude/`) |
+| Active when | `APP_SANDBOX` compiler flag is defined |
+| User flow | NSOpenPanel prompts for `~/.claude/` directory; bookmark persisted to UserDefaults |
 
 ## Predictive Rate Limit
 


### PR DESCRIPTION
## Summary
- **ENABLE_VERSION_CHECKER compile flag** — gates VersionChecker + update UI (App Store guideline 3.1.1 rejects external update checks)
- **Fix App Store entitlements** — replaced invalid `files.home-relative-path.read-only` with `user-selected.read-only` + `bookmarks.app-scope` for security-scoped bookmark approach
- **SandboxAccessManager** — new service (dormant behind `APP_SANDBOX` flag) handles NSOpenPanel + bookmark persistence for `~/.claude/` access under sandbox
- **LSApplicationCategoryType** — `public.app-category.developer-tools` added to Info.plist (required App Store metadata)
- **Build script** — strips SUFeedURL from Info.plist when `APP_STORE_BUILD` env is set
- **Specs updated** — ARCHITECTURE.md + CONSTANTS.md reflect new flags, services, and entitlements

All changes are safe for current direct-download users (flags default ON for version checker, APP_SANDBOX not defined).

## Test plan
- [x] `swift build` — clean compile with ENABLE_VERSION_CHECKER ON, APP_SANDBOX OFF
- [x] `swift build -c release` — clean release build
- [ ] CI: `swift test` passes (all VersionChecker tests still run with flag enabled)
- [ ] Verify `scripts/build-app.sh` still produces valid bundle (SUFeedURL kept for direct-download)
- [ ] Verify `APP_STORE_BUILD=1 scripts/build-app.sh` strips SUFeedURL

🤖 Generated with [Claude Code](https://claude.com/claude-code)