### PR TITLE
Release v1.6.8

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.7</string>
+	<string>1.6.8</string>
 	<key>CFBundleVersion</key>
-	<string>1.6.7</string>
+	<string>1.6.8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.6.8] — 2026-03-05
+
+### Improved
+- **Duration formatting** — `LongestSession.durationFormatted` now uses shared `DurationFormatter.compact` (0ms shows "soon", sub-minute shows "1m", durations ≥24h get "Xd Yh")
+- **Defensive coding** — replaced force-unwraps in monthly chart data with guard-let early return; guarded request body serialization in `RateLimitFetcher` with log + error return
+- **Error logging** — `AccountStore` and `SingleInstanceGuard` now log warnings on previously silent failures (JSON encode, directory creation)
+- **View performance** — eliminated duplicate `TokenFormatter.format` / `ModelPricing.formatCost` calls in `TokenUsageSection` and `TokenHealthSection` (stored in `let` bindings)
+
+### Removed
+- **Dead code** — removed `StatusComponent.fireKey` alias (was identical to `alertKey`), removed trivial `formatDuration` passthrough wrapper in `UsageBar`
+
 ## [1.6.7] — 2026-03-05
 
 ### Changed


### PR DESCRIPTION
## Summary
- Bump version to 1.6.8
- Update CHANGELOG.md with code quality improvements from #72

## Changelog
### Improved
- Duration formatting — shared `DurationFormatter.compact` in `LongestSession`
- Defensive coding — guard force-unwraps, guard request serialization
- Error logging — warnings on previously silent failures
- View performance — deduplicate computed strings in token views

### Removed
- Dead code — `StatusComponent.fireKey` alias, trivial `formatDuration` wrapper

## Test plan
- [ ] CI passes
- [ ] Tag `v1.6.8` after merge triggers release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)