### PR TITLE
Fix cache bug, path traversal, cursor stack; add website links

### DIFF
--- a/AIBattery/Models/ModelPricing.swift
+++ b/AIBattery/Models/ModelPricing.swift
@@ -31,16 +31,22 @@ struct ModelPricing {
 
     /// Lookup cache — avoids repeated displayName + linear scan per model ID.
     /// Lock-protected for thread safety (Swift Testing runs tests concurrently).
+    /// Uses `Optional<ModelPricing>` values; key presence means "already looked up",
+    /// nil value means "looked up but no match found".
     private static var pricingCache: [String: ModelPricing?] = [:]
     private static let cacheLock = NSLock()
 
     /// Look up pricing by model ID. Uses `ModelNameMapper.displayName` for matching.
     /// Results are cached per model ID since the pricing table is static.
     static func pricing(for modelId: String) -> ModelPricing? {
-        // Check cache first (fast path)
-        if let cached = cacheLock.withLock({ pricingCache[modelId] }) {
-            return cached
+        // Check cache first (fast path) — key presence means we've already looked up
+        let hit: (found: Bool, value: ModelPricing?) = cacheLock.withLock {
+            if let entry = pricingCache.index(forKey: modelId) {
+                return (true, pricingCache[entry].value)
+            }
+            return (false, nil)
         }
+        if hit.found { return hit.value }
 
         // Compute outside the lock — avoids nested lock with ModelNameMapper
         let display = ModelNameMapper.displayName(for: modelId).lowercased()
@@ -52,7 +58,7 @@ struct ModelPricing {
             }
         }
 
-        // Store in cache
+        // Store in cache (including nil for unknown models)
         cacheLock.withLock { pricingCache[modelId] = result }
         return result
     }

--- a/AIBattery/Services/SessionLogReader.swift
+++ b/AIBattery/Services/SessionLogReader.swift
@@ -170,7 +170,11 @@ final class SessionLogReader {
         // within the projects directory. Prevents a symlink inside ~/.claude/projects/
         // pointing to an arbitrary file outside that directory.
         let resolvedBase = projectsURL.resolvingSymlinksInPath().path
-        jsonlFiles = jsonlFiles.filter { $0.resolvingSymlinksInPath().path.hasPrefix(resolvedBase) }
+        let resolvedBaseSlash = resolvedBase + "/"
+        jsonlFiles = jsonlFiles.filter {
+            let resolved = $0.resolvingSymlinksInPath().path
+            return resolved == resolvedBase || resolved.hasPrefix(resolvedBaseSlash)
+        }
 
         // Regular file filter — skip pipes, devices, sockets
         jsonlFiles = jsonlFiles.filter {

--- a/AIBattery/Services/StatsCacheReader.swift
+++ b/AIBattery/Services/StatsCacheReader.swift
@@ -57,7 +57,7 @@ final class StatsCacheReader {
             let resolvedPath = fileURL.resolvingSymlinksInPath().path
             let claudeDir = FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".claude").resolvingSymlinksInPath().path
-            guard resolvedPath.hasPrefix(claudeDir) else {
+            guard resolvedPath == claudeDir || resolvedPath.hasPrefix(claudeDir + "/") else {
                 AppLogger.files.warning("StatsCacheReader: file resolves outside ~/.claude/, skipping")
                 return nil
             }

--- a/AIBattery/Views/CopyableText.swift
+++ b/AIBattery/Views/CopyableText.swift
@@ -6,6 +6,8 @@ struct CopyableModifier: ViewModifier {
     let value: String
     @State private var copied = false
     @State private var isHovered = false
+    /// Whether we have an active cursor push on the stack.
+    @State private var cursorPushed = false
     /// Tracks the active feedback task so rapid taps restart the timer.
     @State private var feedbackTask: Task<Void, Never>?
 
@@ -29,14 +31,21 @@ struct CopyableModifier: ViewModifier {
             .onHover { hovering in
                 isHovered = hovering
                 if hovering {
-                    NSCursor.pointingHand.push()
+                    if !cursorPushed {
+                        NSCursor.pointingHand.push()
+                        cursorPushed = true
+                    }
                 } else {
-                    NSCursor.pop()
+                    if cursorPushed {
+                        NSCursor.pop()
+                        cursorPushed = false
+                    }
                 }
             }
             .onDisappear {
-                if isHovered {
+                if cursorPushed {
                     NSCursor.pop()
+                    cursorPushed = false
                 }
             }
             .help("Click to copy: \(value)")

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Get the most out of your Claude subscription.**
 
+[aibattery.dev](https://aibattery.dev)
+
 Monitor rate limits, context health, and token usage — always visible in your macOS menu bar. Know exactly when to pace yourself, when to start a fresh session, and how much runway you have left.
 
 [![Swift](https://img.shields.io/badge/Swift-5.9-orange?logo=swift&logoColor=white)](https://swift.org)
@@ -98,7 +100,7 @@ open .build/AIBattery.app
 
 </details>
 
-Requires **macOS 13+** and [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+Requires **macOS 13+** and [Claude Code](https://docs.anthropic.com/en/docs/claude-code). See [aibattery.dev](https://aibattery.dev) for more info.
 
 ---
 
@@ -458,7 +460,7 @@ Contributions welcome! Please read the [contributing guide](CONTRIBUTING.md) fir
 
 ## 💛 Support
 
-AI Battery is **free and open source** — always will be.
+AI Battery is **free and open source** — always will be. Visit [aibattery.dev](https://aibattery.dev) to learn more.
 
 If it saves you time or helps you get more out of your Claude subscription, consider [sponsoring the project](https://github.com/sponsors/KyleNesium). It helps cover development time and keeps the project going.
 
@@ -468,12 +470,12 @@ If it saves you time or helps you get more out of your Claude subscription, cons
 
 ## 🧪 Test Coverage
 
-**488 tests** across 35 test files.
+**490 tests** across 35 test files.
 
 | Area | Tests | What's covered |
 |------|-------|----------------|
-| Models | 151 | Token summaries, rate limit parsing (predictive estimates, fresh window guard, unknown claim defaults, countdown formatter, throttled header parsing), health status, metric modes, API profiles (org ID validation: empty, too long, special chars, hyphens/underscores), session entries (service_tier decode), account records, stats cache, usage snapshots (trends, busiest day, auto-resolved mode with priority tiers, context health fallback chain), model pricing, health config |
-| Services | 221 | Version checker (semver comparison, tag stripping, cache behavior, force check, stale cache discard, persistence keys), Sparkle update service (automatic checks disabled, automatic downloads disabled, check interval zero, feed URL, singleton identity, canCheckForUpdates), notification manager (alert thresholds, alert key migration), token health monitor (band classification, warnings, anomalies, velocity, rapid consumption, custom config, idle session inclusion), status checker (severity ordering, incident escalation, known components catalog, status string parsing), status indicator (dot colors, label text), session log reader (entry decoding, makeUsageEntry, symlink boundary check), account store (multi-account CRUD, persistence, merge metadata preservation), stats cache reader (decode, caching, invalidation, full payload, file size guard, symlink boundary check), usage aggregator (empty state, stats-only, JSONL-only, rate limit pass-through, model filtering, deduplication, stats+JSONL merge, all-time mode, redundant aggregation skip, hourly merge, peak hour update, totalMessages dedup, old model visibility, all-dates daily merge, todayHourCounts separation), rate limit fetcher (cache expiry, stale marking, multi-account isolation, Retry-After parsing), OAuth manager (AuthError messages, transient error classification) |
+| Models | 152 | Token summaries, rate limit parsing (predictive estimates, fresh window guard, unknown claim defaults, countdown formatter, throttled header parsing), health status, metric modes, API profiles (org ID validation: empty, too long, special chars, hyphens/underscores), session entries (service_tier decode), account records, stats cache, usage snapshots (trends, busiest day, auto-resolved mode with priority tiers, context health fallback chain), model pricing (cache correctness for unknown models), health config |
+| Services | 222 | Version checker (semver comparison, tag stripping, cache behavior, force check, stale cache discard, persistence keys), Sparkle update service (automatic checks disabled, automatic downloads disabled, check interval zero, feed URL, singleton identity, canCheckForUpdates), notification manager (alert thresholds, alert key migration), token health monitor (band classification, warnings, anomalies, velocity, rapid consumption, custom config, idle session inclusion), status checker (severity ordering, incident escalation, known components catalog, status string parsing), status indicator (dot colors, label text), session log reader (entry decoding, makeUsageEntry, symlink boundary check), account store (multi-account CRUD, persistence, merge metadata preservation), stats cache reader (decode, caching, invalidation, full payload, file size guard, symlink boundary check, prefix traversal attack), usage aggregator (empty state, stats-only, JSONL-only, rate limit pass-through, model filtering, deduplication, stats+JSONL merge, all-time mode, redundant aggregation skip, hourly merge, peak hour update, totalMessages dedup, old model visibility, all-dates daily merge, todayHourCounts separation), rate limit fetcher (cache expiry, stale marking, multi-account isolation, Retry-After parsing), OAuth manager (AuthError messages, transient error classification) |
 | ViewModels | 23 | UsageViewModel static helpers (refresh interval clamping, error message logic, adaptive polling data-change detection, throttle event recording with dedup, throttle count filtering) |
 | Utilities | 93 | Token formatter (K/M suffixes, boundaries), model name mapper (display names, versions, date stripping, result cache), Claude paths (suffixes, URLs), theme colors (standard + colorblind palettes, NSColor, semantic colors, danger), UserDefaults keys (prefix, uniqueness), date formatters (format strings, round-trips, locale pinning), adaptive polling state (threshold behavior, progressive doubling, caps, reset), secure networking (ephemeral session config, singleton, size limit, cookie policy, resource timeout), duration formatter (compact format, boundaries, 24h edge case, days/hours/minutes) |
 

--- a/Tests/AIBatteryCoreTests/Models/ModelPricingTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ModelPricingTests.swift
@@ -143,4 +143,16 @@ struct ModelPricingTests {
     @Test func formatCost_exactDollar() {
         #expect(ModelPricing.formatCost(1.0) == "$1.00")
     }
+
+    // MARK: - Cache correctness
+
+    @Test func pricing_unknownModel_cachedOnSecondCall() {
+        // First call computes and caches nil
+        let first = ModelPricing.pricing(for: "totally-fake-model-xyz-12345")
+        #expect(first == nil)
+
+        // Second call should hit the cache (not recompute) — still nil
+        let second = ModelPricing.pricing(for: "totally-fake-model-xyz-12345")
+        #expect(second == nil)
+    }
 }

--- a/Tests/AIBatteryCoreTests/Services/StatsCacheReaderTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/StatsCacheReaderTests.swift
@@ -244,6 +244,22 @@ struct StatsCacheReaderTests {
         #expect(reader.read() == nil)
     }
 
+    @Test func read_symlinkPrefixAttack_returnsNil() throws {
+        // Simulate a path like ~/.claude-evil/ that shares a prefix with ~/.claude/
+        // but is a different directory. The boundary check should reject it.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let evilDir = home.appendingPathComponent(".claude-evil-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: evilDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: evilDir) }
+
+        let target = evilDir.appendingPathComponent("stats-cache.json")
+        try Data(Self.minimalJSON.utf8).write(to: target)
+
+        // checkBoundary: true enforces the ~/.claude/ boundary
+        let reader = StatsCacheReader(fileURL: target, checkBoundary: true)
+        #expect(reader.read() == nil)
+    }
+
     // MARK: - Test JSON
 
     private static let minimalJSON = """


### PR DESCRIPTION
## Summary

- **ModelPricing cache bug**: `[String: ModelPricing?]` dictionary couldn't distinguish "not cached" from "cached nil" — unknown models triggered a full table scan on every call. Fixed by checking key existence via `index(forKey:)`.
- **Path traversal in boundary checks**: `hasPrefix("/Users/x/.claude")` matched `/Users/x/.claude-evil/`. Fixed in both `StatsCacheReader` and `SessionLogReader` by appending `/` to the prefix.
- **NSCursor push/pop imbalance**: `CopyableText` could double-pop or pop-from-empty if SwiftUI fired `onHover`/`onDisappear` out of order. Added `cursorPushed` state to track actual stack state.
- **Website links**: Added [aibattery.dev](https://aibattery.dev) links to README header, install section, and support section.
- **Tests**: Added ModelPricing cache correctness test and StatsCacheReader prefix traversal attack test (488 → 490 tests).

## Test plan

- [ ] `swift build` passes
- [ ] CI tests pass (490 tests)
- [ ] Verify unknown model pricing lookup doesn't cause repeated table scans
- [ ] Verify `.claude-evil/` style paths are rejected by boundary checks
- [ ] Verify cursor behavior when rapidly hovering copyable text elements
- [ ] Verify aibattery.dev links render correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)