### PR TITLE
Add aibattery.dev reference to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to AI Battery
 
-Thanks for your interest in contributing! Here's how to get started.
+Thanks for your interest in contributing! Visit [aibattery.dev](https://aibattery.dev) to learn more about the project. Here's how to get started.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

- Add aibattery.dev link to CONTRIBUTING.md intro paragraph
- Repo homepage already set to https://aibattery.dev via `gh repo edit`

## Test plan

- [ ] Link renders correctly in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)