### PR TITLE
Fix CI test failures blocking v1.8.2 release

### DIFF
--- a/AIBattery/Views/TokenUsageSection.swift
+++ b/AIBattery/Views/TokenUsageSection.swift
@@ -54,8 +54,6 @@ struct TokenUsageSection: View {
     private var headerRow: some View {
         let totalTokensText = TokenFormatter.format(snapshot.totalTokens)
         let costText: String? = showCost ? ModelPricing.formatCost(ModelPricing.totalCost(for: snapshot.modelTokens)) : nil
-        let copyText = [costText, totalTokensText].compactMap { $0 }.joined(separator: " · ")
-
         return HStack {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) { collapsed.toggle() }
@@ -103,8 +101,6 @@ struct TokenUsageSection: View {
             )
             return ModelPricing.formatCost(cost)
         }()
-        let copyText = ([model.displayName, modelCostText, modelTokensText].compactMap { $0 }).joined(separator: " · ")
-
         return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Image(systemName: modelIcons[index % modelIcons.count])

--- a/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
@@ -305,7 +305,7 @@ struct RateLimitUsageTests {
     @Test func countdownText_lessThanOneMinute() {
         let now = Date()
         let future = now.addingTimeInterval(30) // 30 seconds
-        #expect(RateLimitUsage.countdownText(to: future, from: now) == "1m")
+        #expect(RateLimitUsage.countdownText(to: future, from: now) == "30s")
     }
 
     @Test func countdownText_exactlyOneHour() {

--- a/Tests/AIBatteryCoreTests/Models/StatsCacheTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/StatsCacheTests.swift
@@ -46,8 +46,8 @@ struct StatsCacheTests {
 
     @Test func longestSession_durationFormatted_shortDuration() {
         let session = LongestSession(sessionId: "s1", duration: 30_000, messageCount: 1, timestamp: "2025-01-01T00:00:00Z")
-        // 30 seconds → DurationFormatter.compact rounds up to 1m
-        #expect(session.durationFormatted == "1m")
+        // 30 seconds → DurationFormatter.compact now shows seconds below 60s
+        #expect(session.durationFormatted == "30s")
     }
 
     @Test func longestSession_durationFormatted_zeroDuration() {

--- a/Tests/AIBatteryCoreTests/Services/UsageAggregatorTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/UsageAggregatorTests.swift
@@ -368,8 +368,9 @@ struct UsageAggregatorTests {
         let first = aggregator.aggregate(rateLimits: nil)
         #expect(first.todayMessages == 1)
 
-        // Add a new entry — invalidate and re-read
+        // Add a new entry — invalidate both reader cache and aggregator fingerprint
         logReader.invalidate()
+        aggregator.invalidate()
         try writeJSONL(
             [
                 makeAssistantLine(input: 100, output: 50, messageId: "new-msg-1", timestamp: now),


### PR DESCRIPTION
## Summary
- Update `countdownText_lessThanOneMinute` test to expect `"30s"` instead of `"1m"` (DurationFormatter now shows seconds below 60s)
- Update `longestSession_durationFormatted_shortDuration` test for the same reason
- Add `aggregator.invalidate()` call in `aggregate_newJsonlEntries_recomputes` test — the fingerprint-based cache skip requires both the log reader and aggregator caches to be cleared
- Remove dead `copyText` variables in TokenUsageSection (unused after per-field copyable was added)

## Test plan
- [ ] CI passes (3 previously failing tests now match v1.8.2 behavior)
- [ ] No build warnings