### PR TITLE
Fix settings scroll height and sync spec files

### DIFF
--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -94,7 +94,8 @@ public final class StatusBarManager: NSObject {
         panel.contentView = hosting
         panel.setContentSize(NSSize(width: 275, height: 700))
 
-        // Resize panel when SwiftUI content changes height
+        // Resize panel when SwiftUI content changes height.
+        // Max height is screen-relative so all sections fit on most displays.
         hosting.setContentHuggingPriority(.defaultHigh, for: .vertical)
         hosting.postsFrameChangedNotifications = true
         frameObserver = NotificationCenter.default.addObserver(
@@ -103,7 +104,9 @@ public final class StatusBarManager: NSObject {
             queue: .main
         ) { [weak panel, weak hosting, weak self] _ in
             guard let panel, let hosting, let self else { return }
-            let fittingHeight = min(hosting.fittingSize.height, 700)
+            let screenMaxHeight = panel.screen?.visibleFrame.height ?? 900
+            let maxPanelHeight = screenMaxHeight - 40
+            let fittingHeight = min(hosting.fittingSize.height, maxPanelHeight)
             let newHeight = max(fittingHeight, 100)
             // Grow downward from fixed top anchor (set by positionPanel)
             let newOrigin = NSPoint(

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -63,28 +63,19 @@ public struct UsagePopoverView: View {
             Divider()
 
             if showSettings {
-                // Settings in its own ScrollView with capped height so it doesn't
-                // push main content off-screen when all sections are visible.
-                ScrollView {
-                    SettingsRow(
-                        viewModel: viewModel,
-                        accountStore: accountStore,
-                        onAddAccount: { isAddingAccount = true }
-                    )
-                }
-                .scrollIndicators(.automatic)
-                .frame(maxHeight: 350)
+                SettingsRow(
+                    viewModel: viewModel,
+                    accountStore: accountStore,
+                    onAddAccount: { isAddingAccount = true }
+                )
                 .transition(.opacity.combined(with: .move(edge: .top)))
                 Divider()
             }
 
             if let snapshot = viewModel.snapshot {
-                // Metric mode toggle
                 metricToggle
                 Divider()
 
-                // Sections reordered: selected metric first, then the others.
-                // Animation scoped here — only metric sections animate on mode change.
                 ForEach(orderedModes, id: \.rawValue) { mode in
                     switch mode {
                     case .fiveHour:

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -8,9 +8,8 @@
        └─ StatusBarManager.setup(viewModel:oauthManager:)
             ├─ NSStatusItem: native button.image + button.title (no NSHostingView)
             └─ PopoverPanel (floating NSPanel, borderless)
-                 └─ NSVisualEffectView (.popover material)
-                      └─ NSHostingView → PopoverContentView
-                           └─ Group { UsagePopoverView | AuthView }
+                 └─ NSHostingView → PopoverContentView (controlBackgroundColor background)
+                      └─ Group { UsagePopoverView | AuthView }
 ```
 
 `StatusBarManager` owns the `NSStatusItem` and a floating `NSPanel` directly, bypassing SwiftUI's `MenuBarExtra`. The panel uses `hidesOnDeactivate = false` and `.floating` level so it stays open regardless of focus changes — only closes on status item click or Escape.
@@ -97,7 +96,7 @@ AIBattery/
   ViewModels/
     UsageViewModel.swift          — @MainActor ObservableObject, single source of truth
   Views/
-    StatusBarManager.swift        — NSStatusItem + floating NSPanel, native AppKit button, NSVisualEffectView, Combine-driven updates
+    StatusBarManager.swift        — NSStatusItem + floating NSPanel, native AppKit button, controlBackgroundColor, Combine-driven updates
     MenuBarIcon.swift             — 4-pointed star NSImage: breathing glow, broken star (throttled), recovery sparkle; quantized cache
     UsagePopoverView.swift        — Main popover: header, metric toggle, ordered sections, footer
     Settings/

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -362,7 +362,7 @@ Most bar and accent colors use system palette in both modes (the opaque light-mo
 | Tertiary label | black 55% | white 35% |
 | Track fill | black 14% opacity | white 10% opacity |
 | Badge fill | black 9% opacity | white 6% opacity |
-| Popover background | solid `windowBackgroundColor` | translucent `.popover` vibrancy |
+| Popover background | `controlBackgroundColor` (opaque white) | `controlBackgroundColor` (opaque dark) |
 
 ### Context health bands
 

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -378,7 +378,7 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
 
 **Panel behavior** (floating `NSPanel`, not `NSPopover`):
 - Standalone `PopoverPanel` subclass (borderless, `canBecomeKey = true`, handles Cmd+Q) with `NSHostingView` content (10pt corner radius via layer)
-- **Dynamic height**: panel resizes to fit SwiftUI content (via `NSView.frameDidChangeNotification` on hosting view), max 700pt, grows downward from fixed top anchor (`panelTopY` set by `positionPanel`)
+- **Dynamic height**: panel resizes to fit SwiftUI content (via `NSView.frameDidChangeNotification` on hosting view), max height is screen-relative (`screen.visibleFrame.height - 40pt`) so all sections fit on most displays, grows downward from fixed top anchor (`panelTopY` set by `positionPanel`)
 - `hidesOnDeactivate = false`, `level = .floating`
 - Closes on: (1) clicking the status item again, (2) pressing Escape, or (3) clicking outside the panel / switching apps
 - Positioned below the status item, left-aligned to the status item's left edge, clamped to screen edges (multi-monitor safe)
@@ -472,7 +472,7 @@ Self-managing 3-step walkthrough. Owns its own `@AppStorage(hasSeenTutorial)` �
 
 See `spec/CONSTANTS.md` for all color threshold tables.
 
-**Popover background**: `controlBackgroundColor` — adapts to light/dark mode automatically. Very dark in dark mode (matches native macOS menus like Battery and Clipy), white in light mode. Panel tracks system appearance changes via KVO on `NSApp.effectiveAppearance`.
+**Popover background**: `controlBackgroundColor` — opaque background that adapts to light/dark mode automatically. Very dark in dark mode (matches native macOS menus like Battery and Clipy), white in light mode. Panel tracks system appearance changes via KVO on `NSApp.effectiveAppearance`.
 
 **Light/dark mode**: Bar and accent colors use system palette in both modes — the opaque light-mode background provides sufficient contrast for `.systemYellow`, `.systemOrange`, etc. Only text labels and fills use `ThemeColors.adaptive(light:dark:)` for distinct per-appearance values:
 - **Orange** (caution, 80–94% bars, orange band): `.systemOrange` both modes


### PR DESCRIPTION
## Summary
- Remove nested ScrollView wrapping SettingsRow — settings content sits flat in the main VStack
- Panel max height now derives from `screen.visibleFrame.height - 40pt` instead of hardcoded 700pt, so all sections fit on most displays
- Sync spec files to match v1.8.5 reality: NSVisualEffectView → controlBackgroundColor, panel height is screen-relative, popover background is opaque in both modes

## Test plan
- [ ] Open panel, expand all sections — verify content is visible and panel resizes correctly
- [ ] Toggle settings gear — verify settings expand/collapse smoothly without layout jumps
- [ ] Test on different screen sizes (laptop vs external monitor) — verify panel height adapts
- [ ] Verify dark mode appearance matches light mode behavior (opaque background)