### PR TITLE
perf: breathing timer optimization, chart caching, account switch UX

### DIFF
--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -172,6 +172,7 @@ public final class UsageViewModel: ObservableObject {
         isShowingCachedData = false
         lastFreshFetch = nil
         errorMessage = nil
+        isLoading = true
         OAuthManager.shared.objectWillChange.send()
         Task { await refresh() }
     }

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -38,21 +38,35 @@ struct ActivityChartView: View {
     @State private var cachedMonthly: [ActivityChartData.MonthlyPoint] = []
     @State private var cachedMonthTotals: [String: Int] = [:]
 
+    /// Per-mode fingerprint to skip recomputation when toggling back to a mode
+    /// whose underlying data hasn't changed (e.g. 24H → 7D → 24H).
+    @State private var lastHourlyFingerprint: Int = 0
+    @State private var lastDailyFingerprint: Int = 0
+    @State private var lastMonthlyFingerprint: Int = 0
+
     /// Recompute cached data for the active mode only. Called from body via .onChange.
     private func refreshCachedData() {
-        ensureCachedData(for: mode)
+        ensureCachedData(for: mode, force: true)
     }
 
     /// Lazily compute cached data only for the requested mode.
-    private func ensureCachedData(for chartMode: ActivityChartMode) {
+    /// Skips recomputation if the underlying data fingerprint hasn't changed.
+    private func ensureCachedData(for chartMode: ActivityChartMode, force: Bool = false) {
+        let fp = dataFingerprint
         switch chartMode {
         case .hourly:
+            guard force || fp != lastHourlyFingerprint else { return }
             cachedHourly = ActivityChartData.hourlyData(from: todayHourCounts)
+            lastHourlyFingerprint = fp
         case .daily:
+            guard force || fp != lastDailyFingerprint else { return }
             cachedDaily = ActivityChartData.dailyData(from: dailyActivity)
+            lastDailyFingerprint = fp
         case .monthly:
+            guard force || fp != lastMonthlyFingerprint else { return }
             cachedMonthly = ActivityChartData.monthlyData(from: dailyActivity)
             cachedMonthTotals = ActivityChartData.monthTotals(from: dailyActivity)
+            lastMonthlyFingerprint = fp
         }
     }
 

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -309,10 +309,21 @@ public final class StatusBarManager: NSObject {
 
     // MARK: - Breath timer
 
-    /// Breathing cycle: 4s per full cycle, 8 discrete steps (500ms per tick).
-    /// Always runs. Pauses on screen sleep.
+    /// Breathing cycle: 4s per full cycle, discrete steps.
+    /// Sparkle mode: 8 steps (500ms per tick) for smooth twinkling.
+    /// Red band (≥95%): 4 steps (1s per tick) — halves CPU wakeups with imperceptible visual change.
+    /// Pauses on screen sleep.
+    private var breathTimerStepSize: Int = 1
+
     private func startBreathTimerIfNeeded() {
+        // Red band uses every-other step (4 wakeups/cycle); sparkle uses every step (8 wakeups/cycle).
+        let newStepSize = isSparkleActive ? 1 : 2
+        // Restart timer if step size changed (e.g. sparkle → red transition)
+        if breathTimer != nil && breathTimerStepSize != newStepSize {
+            stopBreathTimer()
+        }
         guard breathTimer == nil else { return }
+        breathTimerStepSize = newStepSize
 
         // Observe screen sleep/wake to pause animation when display is off
         if screenSleepObserver == nil {
@@ -330,11 +341,11 @@ public final class StatusBarManager: NSObject {
             }
         }
 
-        let interval: TimeInterval = 4.0 / Double(MenuBarIcon.pulseSteps)
+        let interval: TimeInterval = 4.0 / Double(MenuBarIcon.pulseSteps) * Double(newStepSize)
         breathTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self, let button = self.statusItem?.button else { return }
-                self.currentPulseStep = (self.currentPulseStep + 1) % MenuBarIcon.pulseSteps
+                self.currentPulseStep = (self.currentPulseStep + self.breathTimerStepSize) % MenuBarIcon.pulseSteps
                 button.image = MenuBarIcon.statusBarImage(
                     for: self.currentPercent,
                     color: self.currentColor,

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -233,8 +233,8 @@ Pricing per million tokens:
 | Recovery sparkle duration | 30 sec |
 | Pulse steps per cycle | 8 |
 | Pulse cycle duration | 4.0 sec |
-| Pulse tick interval | 500ms (4s ÷ 8) |
-| Breath timer threshold | ≥95% usage, throttled, or sparkle active (orange 80–95% uses static glow, no timer) |
+| Pulse tick interval | 500ms sparkle (4s ÷ 8), 1s red band (4s ÷ 8 × 2-step) |
+| Breath timer threshold | ≥95% usage or sparkle active (orange 80–95% uses static glow, no timer; throttled stops timer) |
 | Burst ray count | 12 |
 | Burst ray half-angle | 0.08 radians |
 | Health dot size | 8pt |

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -307,7 +307,7 @@ X-axis per mode:
   - **7D**: Rolling 7-day window. Day abbreviation (`.system(size: 9)`) for all days including today
   - **12M**: Rolling 12-month window. 3-letter month (`"MMM"` → Jan, Feb, etc.), `.system(size: 9)`
 
-Data per mode:
+Data per mode (cached per-mode with fingerprint — toggling back to a mode skips recomputation if underlying data unchanged):
   - **24H**: `todayHourCounts` trailing 24 hours (`(currentHour - 23)` through `currentHour`, wrapping via `% 24`)
   - **7D**: `dailyActivity` last 7 days (rolling window) → daily message counts
   - **12M**: `dailyActivity` grouped by year-month, summed, rolling 12-month window. Current month projected to full-month pace (`total * daysInMonth / dayOfMonth`) for fair comparison.
@@ -436,7 +436,7 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
    - Triggered by `StatusBarManager` detecting `isThrottled` going from true → false
    - Automatically stops after 30 seconds, returning to normal breathing mode
 
-**Animation**: `StatusBarManager` runs a repeating timer (4s full cycle, 8 discrete steps, 500ms per tick).
+**Animation**: `StatusBarManager` runs a repeating timer (4s full cycle, 8 discrete steps). Sparkle mode ticks every 500ms (all 8 steps). Red band (≥95%) ticks every 1s (steps by 2) — halves CPU wakeups with imperceptible visual change. Timer restarts automatically when transitioning between sparkle and red band modes.
 - Active only when visually impactful: sparkle active or critical usage (≥95%). Throttled uses static broken star — no timer. Orange band (80–95%) uses static glow — no timer. Below 80%, breathing is imperceptible — timer stopped to save wake-ups.
 - Recovery sparkle overlaid for 30s after throttle clears
 - Pauses on screen sleep, resumes on wake


### PR DESCRIPTION
## Summary

- **Breathing animation CPU reduction**: Red band (≥95%) now ticks every 1s instead of 500ms — halves timer wakeups with imperceptible visual change. Sparkle mode keeps 500ms for smooth twinkling. Timer auto-restarts on sparkle↔red transitions.
- **Chart mode data caching**: Per-mode fingerprint avoids recomputing chart data when toggling back to a previously-viewed mode (e.g. 24H→7D→24H) if underlying data hasn't changed.
- **Account switch loading state**: Sets `isLoading = true` immediately on account switch so the spinner appears during refresh instead of briefly showing stale data.

## Test plan

- [ ] Build and run locally
- [ ] Switch accounts — verify spinner appears immediately, no stale data flash
- [ ] Toggle chart modes rapidly (24H→7D→12M→24H) — verify smooth transitions
- [ ] With usage ≥95%: verify breathing animation still looks smooth at 1s ticks
- [ ] Trigger sparkle recovery: verify twinkling at 500ms still works
- [ ] Verify sparkle→red transition restarts timer at correct interval