### PR TITLE
perf: selective FileWatcher invalidation, expand ProjectTokenSummary tests

### DIFF
--- a/AIBattery/Services/FileWatcher.swift
+++ b/AIBattery/Services/FileWatcher.swift
@@ -77,7 +77,7 @@ final class FileWatcher {
 
         source.setEventHandler { [weak self] in
             MainActor.assumeIsolated {
-                self?.debounceNotify()
+                self?.debounceNotify(invalidateStatsCache: true, invalidateSessionLog: false)
             }
         }
 
@@ -114,7 +114,7 @@ final class FileWatcher {
             let box = Unmanaged<WeakBox<FileWatcher>>.fromOpaque(info).takeUnretainedValue()
             guard let watcher = box.value else { return }
             MainActor.assumeIsolated {
-                watcher.debounceNotify()
+                watcher.debounceNotify(invalidateStatsCache: false, invalidateSessionLog: true)
             }
         }
 
@@ -163,15 +163,17 @@ final class FileWatcher {
         }
     }
 
-    private func debounceNotify() {
+    /// Selective invalidation — only clear the cache for the reader whose data actually changed.
+    /// Stats-cache changes don't require re-scanning JSONL files, and vice versa.
+    /// Fallback timer invalidates both (safe catch-all when FS events are unavailable).
+    private func debounceNotify(invalidateStatsCache: Bool = true, invalidateSessionLog: Bool = true) {
         guard !isStopped else { return }
         debounceWorkItem?.cancel()
         let work = DispatchWorkItem { [weak self] in
             MainActor.assumeIsolated {
                 guard let self, !self.isStopped else { return }
-                // Invalidate reader caches so the next refresh re-scans changed files
-                SessionLogReader.shared.invalidate()
-                StatsCacheReader.shared.invalidate()
+                if invalidateSessionLog { SessionLogReader.shared.invalidate() }
+                if invalidateStatsCache { StatsCacheReader.shared.invalidate() }
                 self.onChange()
             }
         }

--- a/Tests/AIBatteryCoreTests/Models/ProjectTokenSummaryTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ProjectTokenSummaryTests.swift
@@ -16,4 +16,88 @@ struct ProjectTokenSummaryTests {
         )
         #expect(summary.totalTokens == 1000)
     }
+
+    @Test func totalTokens_zeroWhenAllZero() {
+        let summary = ProjectTokenSummary(
+            id: "/workspace/empty",
+            projectName: "empty",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            estimatedCost: 0
+        )
+        #expect(summary.totalTokens == 0)
+    }
+
+    @Test func id_isUsedAsIdentifiable() {
+        let summary = ProjectTokenSummary(
+            id: "/Users/kyle/projects/myapp",
+            projectName: "myapp",
+            inputTokens: 500,
+            outputTokens: 250,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            estimatedCost: 1.50
+        )
+        #expect(summary.id == "/Users/kyle/projects/myapp")
+    }
+
+    @Test func projectName_displaysLastPathComponent() {
+        // Simulates what UsageAggregator.buildProjectTokens does
+        let cwd = "/Users/kyle/projects/my-app"
+        let displayName = URL(fileURLWithPath: cwd).lastPathComponent
+        let summary = ProjectTokenSummary(
+            id: cwd,
+            projectName: displayName,
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            estimatedCost: 0.30
+        )
+        #expect(summary.projectName == "my-app")
+    }
+
+    @Test func otherProject_usedForMissingCwd() {
+        let summary = ProjectTokenSummary(
+            id: "Other",
+            projectName: "Other",
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            estimatedCost: 0.10
+        )
+        #expect(summary.id == "Other")
+        #expect(summary.projectName == "Other")
+        #expect(summary.totalTokens == 150)
+    }
+
+    @Test func estimatedCost_storedDirectly() {
+        let summary = ProjectTokenSummary(
+            id: "test",
+            projectName: "test",
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+            cacheReadTokens: 2_000_000,
+            cacheWriteTokens: 100_000,
+            estimatedCost: 18.75
+        )
+        #expect(summary.estimatedCost == 18.75)
+        #expect(summary.totalTokens == 3_600_000)
+    }
+
+    @Test func largeTokenCounts_noOverflow() {
+        let summary = ProjectTokenSummary(
+            id: "large",
+            projectName: "large",
+            inputTokens: 500_000_000,
+            outputTokens: 200_000_000,
+            cacheReadTokens: 800_000_000,
+            cacheWriteTokens: 100_000_000,
+            estimatedCost: 5000.0
+        )
+        #expect(summary.totalTokens == 1_600_000_000)
+    }
 }

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -392,7 +392,7 @@ Pricing table (per million tokens):
 - FSEventStream flags: `kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagUseCFTypes`
 - WeakBox wrapper for C callback to prevent retain cycles
 - Debounce: 2 seconds via `DispatchWorkItem`
-- **Cache invalidation**: debounced handler calls `SessionLogReader.shared.invalidate()` and `StatsCacheReader.shared.invalidate()` before triggering refresh
+- **Selective cache invalidation**: stats-cache watcher only invalidates `StatsCacheReader`, JSONL watcher only invalidates `SessionLogReader` — avoids unnecessary cache rebuilds when only one data source changed. Fallback timer invalidates both (safe catch-all)
 - Fallback timer: 60 seconds — starts if either DispatchSource or FSEventStream fails (ensures changes are picked up even if one watcher is unavailable)
 - Calls `onChange` closure → triggers `viewModel.refresh()`
 - **Stats-cache retry**: if `stats-cache.json` doesn't exist on launch (normal before first `/stats` run), retries with exponential backoff (60s base, doubles each retry, capped at 300s, max 10 retries ~30 min). Counter resets on success or `stopWatching()`


### PR DESCRIPTION
## Summary

- **Selective FileWatcher cache invalidation**: stats-cache watcher only invalidates `StatsCacheReader`, JSONL watcher only invalidates `SessionLogReader`. Avoids unnecessary JSONL re-scans when only stats-cache changed (and vice versa). Fallback timer still invalidates both as a safe catch-all.
- **ProjectTokenSummary tests**: expanded from 1 → 7 tests covering zero tokens, Identifiable id, lastPathComponent display name, Other project for missing cwd, stored cost value, and large token overflow guard.

## Test plan

- [ ] Build and run locally — verify no regressions in data refresh
- [ ] Modify stats-cache manually → confirm token data updates without JSONL re-scan
- [ ] New JSONL entry → confirm session data updates without stats-cache re-read
- [ ] Run `swift test` — all 7 ProjectTokenSummary tests pass