### PR TITLE
feat: copy session details button in Context Health

### DIFF
--- a/AIBattery/Views/TokenHealthSection.swift
+++ b/AIBattery/Views/TokenHealthSection.swift
@@ -53,6 +53,9 @@ struct TokenHealthSection: View {
                     sessionToggle
                 }
 
+                if !collapsed {
+                    copyDetailsButton
+                }
                 if !collapsed, let onRefresh {
                     RefreshButton(action: onRefresh)
                 }
@@ -275,6 +278,28 @@ struct TokenHealthSection: View {
     private var sessionLabelParts: [String] { SessionInfoFormatter.labelParts(for: health) }
     private var sessionIdPrefix: String? { SessionInfoFormatter.idPrefix(for: health) }
     private var sessionBottomParts: [String] { SessionInfoFormatter.bottomParts(for: health) }
+
+    @State private var detailsCopied = false
+
+    private var copyDetailsButton: some View {
+        Button(action: {
+            let text = SessionInfoFormatter.copyableDetails(for: health)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+            detailsCopied = true
+            Task {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                detailsCopied = false
+            }
+        }) {
+            Image(systemName: detailsCopied ? "doc.on.clipboard.fill" : "doc.on.clipboard")
+                .font(.system(size: 10))
+                .foregroundStyle(detailsCopied ? .green : .secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Copy session details to clipboard")
+        .accessibilityLabel("Copy session details")
+    }
 
     private var healthBadge: some View {
         HStack(spacing: 4) {

--- a/AIBattery/Views/TokenHealthSessionInfo.swift
+++ b/AIBattery/Views/TokenHealthSessionInfo.swift
@@ -68,6 +68,47 @@ enum SessionInfoFormatter {
         return parts.joined(separator: "\n")
     }
 
+    /// Markdown-formatted session details for clipboard export.
+    /// Includes exact token counts (not abbreviated) and all visible metadata.
+    static func copyableDetails(for health: TokenHealthStatus) -> String {
+        var lines: [String] = []
+        lines.append("Context Health")
+        lines.append("─────────────")
+        if !health.id.isEmpty { lines.append("Session:  \(health.id)") }
+        if !health.model.isEmpty { lines.append("Model:    \(ModelNameMapper.displayName(for: health.model))") }
+        if let name = health.projectName { lines.append("Project:  \(name)") }
+        if let branch = health.gitBranch, branch != "HEAD", !branch.isEmpty {
+            lines.append("Branch:   \(branch)")
+        }
+        lines.append("Context:  \(health.totalUsed)/\(health.usableWindow) (\(Int(health.usagePercentage))%)")
+        lines.append("Input:    \(health.inputTokens)")
+        lines.append("Output:   \(health.outputTokens)")
+        if health.cacheReadTokens > 0 { lines.append("Cache R:  \(health.cacheReadTokens)") }
+        if health.cacheWriteTokens > 0 { lines.append("Cache W:  \(health.cacheWriteTokens)") }
+        lines.append("Turns:    \(health.turnCount)")
+        if let duration = health.sessionDuration {
+            lines.append("Duration: \(DurationFormatter.compact(duration))")
+        }
+        if let velocity = health.tokensPerMinute, velocity > 0 {
+            lines.append("Velocity: \(Int(velocity)) tok/min")
+        }
+        if let start = health.sessionStart {
+            lines.append("Started:  \(formatSessionTime(start))")
+        }
+        if let lastActivity = health.lastActivity {
+            lines.append("Last:     \(formatSessionTime(lastActivity))")
+        }
+        if !health.warnings.isEmpty {
+            for w in health.warnings {
+                lines.append("⚠ \(w.message)")
+            }
+        }
+        if let action = health.suggestedAction {
+            lines.append("→ \(action)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
     // MARK: - Time formatting
 
     private static let timeFormatter: DateFormatter = {

--- a/Tests/AIBatteryCoreTests/Views/SessionInfoFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/SessionInfoFormatterTests.swift
@@ -139,6 +139,49 @@ struct SessionInfoFormatterTests {
         #expect(result.hasPrefix("Today"))
     }
 
+    // MARK: - Copyable details
+
+    @Test func copyableDetails_includesHeader() {
+        let health = makeHealth()
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(text.contains("Context Health"))
+        #expect(text.contains("─────────────"))
+    }
+
+    @Test func copyableDetails_includesSessionId() {
+        let health = makeHealth(id: "abc-12345")
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(text.contains("Session:  abc-12345"))
+    }
+
+    @Test func copyableDetails_includesModel() {
+        let health = makeHealth(model: "claude-sonnet-4-5-20250929")
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(text.contains("Model:"))
+    }
+
+    @Test func copyableDetails_includesProjectAndBranch() {
+        let health = makeHealth(projectName: "MyApp", gitBranch: "feat/login")
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(text.contains("Project:  MyApp"))
+        #expect(text.contains("Branch:   feat/login"))
+    }
+
+    @Test func copyableDetails_includesExactTokenCounts() {
+        let health = makeHealth(totalUsed: 50000, usableWindow: 160000)
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(text.contains("Context:  50000/160000"))
+    }
+
+    @Test func copyableDetails_omitsEmptyFields() {
+        let health = makeHealth(id: "", model: "", projectName: nil, gitBranch: nil)
+        let text = SessionInfoFormatter.copyableDetails(for: health)
+        #expect(!text.contains("Session:"))
+        #expect(!text.contains("Model:"))
+        #expect(!text.contains("Project:"))
+        #expect(!text.contains("Branch:"))
+    }
+
     // MARK: - Helpers
 
     private func makeHealth(

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -111,7 +111,7 @@ AIBattery/
     TutorialOverlay.swift         — First-launch 3-step walkthrough overlay
     UsageBarsSection.swift        — FiveHourBarSection + SevenDayBarSection rate limit bars
     TokenHealthSection.swift      — Context health gauge + warnings + multi-session chevron toggle
-    TokenHealthSessionInfo.swift  — Session detail computation: label parts, tooltip, idle detection, time formatting
+    TokenHealthSessionInfo.swift  — Session detail computation: label parts, tooltip, idle detection, time formatting, clipboard export
     TokenUsageSection.swift       — Per-model token breakdown with token type tags + optional cost
     ProjectUsageSection.swift     — Per-project token breakdown with optional cost
     ActivityChartView.swift        — 24H/7D/12M activity chart (Swift Charts, rolling windows) + insight rows (All Time, Longest, Period)

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -226,6 +226,7 @@ Takes `sessions: [TokenHealthStatus]` array (top 5 by highest context usage). Ba
 - **VoiceOver**: `.accessibilityAdjustableAction` on section — increment/decrement maps to next/previous session
 - **Stale session badge** (if lastActivity > 30 min and band != .green): amber dot (6pt) + `"Idle Xm"` (.caption2, .orange)
 - **Expanded tooltip**: `.help()` on session info label with full details — session ID, model, context window, all timestamps, all token counts, warnings
+- **Copy details button**: `doc.on.clipboard` 10pt, .secondary → green `doc.on.clipboard.fill` for 1.5s after click. Copies full session details (exact token counts, model, project, branch, warnings) to clipboard via `SessionInfoFormatter.copyableDetails(for:)`.
 - **Refresh button**: `arrow.clockwise` 10pt, .secondary
 - **Health badge**: 8pt colored circle + percentage in monospaced subheadline semibold
 - **Gauge bar**: same style as usage bars (8pt, 3pt radius), width proportional to usagePercentage


### PR DESCRIPTION
## Summary

- **Copy session details button** in Context Health header — clipboard icon next to refresh button copies full session details as aligned plain text
- Output includes exact token counts (not abbreviated), model, project, branch, duration, velocity, warnings, and suggested actions
- Green checkmark feedback for 1.5s after copy
- 6 new tests for `SessionInfoFormatter.copyableDetails()`

Example clipboard output:
```
Context Health
─────────────
Session:  abc-12345-def
Model:    Opus 4.6
Project:  AIBattery
Branch:   feat/login
Context:  50000/160000 (31%)
Input:    30000
Output:   20000
Turns:    42
Duration: 2h 15m
Velocity: 350 tok/min
```

## Test plan

- [ ] Build and verify copy button appears next to refresh in Context Health
- [ ] Click copy → verify clipboard contains formatted session details
- [ ] Verify green icon feedback appears for ~1.5s
- [ ] Collapsed state: button hidden (only shows when expanded)
- [ ] Run `swift test` — 6 new SessionInfoFormatter tests pass