### PR TITLE
feat: collapsed state summaries for Token Usage and Projects

### DIFF
--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -113,6 +113,12 @@ struct ProjectUsageSection: View {
                 collapsed: $collapsed,
                 tooltip: "Token usage grouped by project directory (recent sessions)"
             )
+            if collapsed, let topProject = snapshot.projectTokens.first {
+                Text("\(snapshot.projectTokens.count) · \(topProject.projectName)")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(ThemeColors.tertiaryLabel)
+                    .lineLimit(1)
+            }
             Spacer()
             if let costText {
                 Text(costText)

--- a/AIBattery/Views/TokenUsageSection.swift
+++ b/AIBattery/Views/TokenUsageSection.swift
@@ -38,6 +38,14 @@ struct TokenUsageSection: View {
         return activeId.hasPrefix(model.id) || model.id.hasPrefix(activeId)
     }
 
+    /// Active model display name for collapsed summary (e.g. "Opus 4.6").
+    private var activeModelName: String? {
+        guard let activeId = activeModelId, !activeId.isEmpty else { return nil }
+        return snapshot.modelTokens
+            .first(where: { activeId.hasPrefix($0.id) || $0.id.hasPrefix(activeId) })
+            .map(\.displayName)
+    }
+
     /// Column width for cost values (e.g. "~$12.31").
     private let costColumnWidth: CGFloat = 54
     /// Column width for token values (e.g. "1.2M").
@@ -71,6 +79,12 @@ struct TokenUsageSection: View {
                 collapsed: $collapsed,
                 tooltip: "Total tokens used across all models (cost is API-equivalent estimate)"
             )
+            if collapsed, let activeModel = activeModelName {
+                Text(activeModel)
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(ThemeColors.tertiaryLabel)
+                    .lineLimit(1)
+            }
             Spacer()
             if let costText {
                 Text(costText)

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -156,7 +156,7 @@ Padding: H 16, V 8
 
 ### Collapsible Sections
 
-Context Health, Tokens, Projects, and Activity sections use `CollapsibleSectionHeader(title:collapsed:tooltip:)` — a shared view with rotating chevron (`chevron.right`, 8pt bold), bold title, and VoiceOver labels. Collapsed state persists via `@AppStorage` per section (`contextCollapsed`, `tokensCollapsed`, `projectsCollapsed`, `activityCollapsed`). When collapsed, only the header row shows (with summary value on the right). Collapse/expand animates with `.easeInOut(duration: 0.2)`.
+Context Health, Tokens, Projects, and Activity sections use `CollapsibleSectionHeader(title:collapsed:tooltip:)` — a shared view with rotating chevron (`chevron.right`, 8pt bold), bold title, and VoiceOver labels. Collapsed state persists via `@AppStorage` per section (`contextCollapsed`, `tokensCollapsed`, `projectsCollapsed`, `activityCollapsed`). When collapsed, the header row shows with summary value on the right plus a contextual hint: Token Usage shows active model name, Projects shows count + top project name, Activity shows vs-yesterday trend. Collapse/expand animates with `.easeInOut(duration: 0.2)`.
 
 ### Gate Views (`TokenUsageGate`, `ProjectUsageGate`, `ActivityChartGate`)
 


### PR DESCRIPTION
## Summary

- **Token Usage collapsed**: shows active model name (e.g. "Opus 4.6") inline after header
- **Projects collapsed**: shows project count + top project name (e.g. "3 · AIBattery") inline
- Follows the Activity section pattern where collapsed headers show a contextual hint

## Test plan

- [ ] Collapse Token Usage → verify active model name appears next to total
- [ ] Collapse Token Usage with no active model → verify no extra text shown
- [ ] Collapse Projects → verify "N · topProject" appears next to total
- [ ] Expand both → verify summaries disappear and full content shows