### PR TITLE
perf: single-pass aggregation, batched pricing, slider debounce

### DIFF
--- a/AIBattery/Models/ModelPricing.swift
+++ b/AIBattery/Models/ModelPricing.swift
@@ -82,17 +82,9 @@ struct ModelPricing {
         return result
     }
 
-    /// Total cost across all model summaries.
+    /// Total cost across all model summaries (uses pre-computed estimatedCost).
     static func totalCost(for models: [ModelTokenSummary]) -> Double {
-        models.reduce(0) { total, model in
-            guard let pricing = pricing(for: model.id) else { return total }
-            return total + pricing.cost(
-                input: model.inputTokens,
-                output: model.outputTokens,
-                cacheRead: model.cacheReadTokens,
-                cacheWrite: model.cacheWriteTokens
-            )
-        }
+        models.reduce(0) { $0 + $1.estimatedCost }
     }
 
     // MARK: - Pricing Table

--- a/AIBattery/Models/UsageSnapshot.swift
+++ b/AIBattery/Models/UsageSnapshot.swift
@@ -265,6 +265,8 @@ struct ModelTokenSummary: Identifiable, Equatable {
     let outputTokens: Int
     let cacheReadTokens: Int
     let cacheWriteTokens: Int
+    /// Pre-computed API-equivalent cost (avoids per-render pricing lock acquisition).
+    let estimatedCost: Double
 
     var totalTokens: Int {
         inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens

--- a/AIBattery/Services/TokenLedger.swift
+++ b/AIBattery/Services/TokenLedger.swift
@@ -49,25 +49,35 @@ final class TokenLedger {
                 changed = true
             }
 
+            let cost = ModelPricing.pricing(for: model.id)?.cost(
+                input: merged.input, output: merged.output,
+                cacheRead: merged.cacheRead, cacheWrite: merged.cacheWrite
+            ) ?? 0
             result.append(ModelTokenSummary(
                 id: model.id,
                 displayName: model.displayName,
                 inputTokens: merged.input,
                 outputTokens: merged.output,
                 cacheReadTokens: merged.cacheRead,
-                cacheWriteTokens: merged.cacheWrite
+                cacheWriteTokens: merged.cacheWrite,
+                estimatedCost: cost
             ))
         }
 
         // Restore historical models no longer in current stats-cache/JSONL
         for (modelId, record) in accountData where !seenModels.contains(modelId) {
+            let cost = ModelPricing.pricing(for: modelId)?.cost(
+                input: record.input, output: record.output,
+                cacheRead: record.cacheRead, cacheWrite: record.cacheWrite
+            ) ?? 0
             result.append(ModelTokenSummary(
                 id: modelId,
                 displayName: ModelNameMapper.displayName(for: modelId),
                 inputTokens: record.input,
                 outputTokens: record.output,
                 cacheReadTokens: record.cacheRead,
-                cacheWriteTokens: record.cacheWrite
+                cacheWriteTokens: record.cacheWrite,
+                estimatedCost: cost
             ))
         }
 

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -90,7 +90,8 @@ final class UsageAggregator {
         }
 
         let todayMessages = todayEntries.count
-        let todaySessions = Set(todayEntries.map(\.sessionId)).count
+        // Reuse session set from entriesByDate instead of re-allocating
+        let todaySessions = entriesByDate[todayDate]?.sessions.count ?? 0
         let todayToolCalls = statsCache?.dailyActivity
             .first(where: { $0.date == todayDate })?.toolCallCount ?? 0
 
@@ -127,12 +128,16 @@ final class UsageAggregator {
         let rawModelTokens = Self.buildModelTokens(from: modelTokensMap)
         let projectTokens = Self.buildProjectTokens(from: allEntries)
 
-        // Windowed model tokens for Insights cost breakdown (JSONL-only)
+        // Windowed model tokens for Insights cost breakdown — single pass over allEntries
+        // instead of 3 separate filter+accumulate passes (eliminates 5 redundant iterations).
         let sevenDaysAgo = calendar.date(byAdding: .day, value: -7, to: today) ?? today
         let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) ?? today
-        let todayModelTokens = Self.buildModelTokensFromEntries(allEntries.filter { $0.timestamp >= today })
-        let weekModelTokens = Self.buildModelTokensFromEntries(allEntries.filter { $0.timestamp >= sevenDaysAgo })
-        let monthModelTokens = Self.buildModelTokensFromEntries(allEntries.filter { $0.timestamp >= monthStart })
+        let windowed = Self.buildWindowedModelTokens(
+            from: allEntries, today: today, weekStart: sevenDaysAgo, monthStart: monthStart
+        )
+        let todayModelTokens = windowed.today
+        let weekModelTokens = windowed.week
+        let monthModelTokens = windowed.month
 
         // Merge with persistent ledger — preserves high-water marks across stats-cache rebuilds.
         let modelTokens: [ModelTokenSummary]
@@ -259,19 +264,22 @@ final class UsageAggregator {
         return snapshot
     }
 
-    /// Group JSONL entries by project (full cwd path as key), compute per-entry cost.
+    /// Group JSONL entries by project (full cwd path as key), compute cost per (project, model) pair.
+    /// Batches pricing lookups to O(projects × models) instead of O(entries) lock acquisitions.
     /// Entries without cwd are grouped under "Other". JSONL-only — stats-cache lacks per-entry cwd.
     private static func buildProjectTokens(from entries: [AssistantUsageEntry]) -> [ProjectTokenSummary] {
-        struct Accumulator {
-            var displayName: String
+        struct ModelAccum {
             var input: Int = 0
             var output: Int = 0
             var cacheRead: Int = 0
             var cacheWrite: Int = 0
-            var cost: Double = 0
+        }
+        struct ProjectAccum {
+            var displayName: String
+            var byModel: [String: ModelAccum] = [:]
         }
 
-        var byProject: [String: Accumulator] = [:]
+        var byProject: [String: ProjectAccum] = [:]
         for entry in entries {
             guard entry.model.hasPrefix("claude-") else { continue }
 
@@ -285,49 +293,88 @@ final class UsageAggregator {
                 displayName = "Other"
             }
 
-            var acc = byProject[key] ?? Accumulator(displayName: displayName)
-            acc.input += entry.inputTokens
-            acc.output += entry.outputTokens
-            acc.cacheRead += entry.cacheReadTokens
-            acc.cacheWrite += entry.cacheWriteTokens
-            if let pricing = ModelPricing.pricing(for: entry.model) {
-                acc.cost += pricing.cost(
-                    input: entry.inputTokens,
-                    output: entry.outputTokens,
-                    cacheRead: entry.cacheReadTokens,
-                    cacheWrite: entry.cacheWriteTokens
-                )
-            }
-            byProject[key] = acc
+            var proj = byProject[key] ?? ProjectAccum(displayName: displayName)
+            var model = proj.byModel[entry.model] ?? ModelAccum()
+            model.input += entry.inputTokens
+            model.output += entry.outputTokens
+            model.cacheRead += entry.cacheReadTokens
+            model.cacheWrite += entry.cacheWriteTokens
+            proj.byModel[entry.model] = model
+            byProject[key] = proj
         }
 
-        return byProject.map { key, acc in
-            ProjectTokenSummary(
+        // Compute cost once per (project, model) pair — O(projects × models) pricing lookups
+        return byProject.map { key, proj in
+            var totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheWrite = 0
+            var totalCost: Double = 0
+            for (modelId, tokens) in proj.byModel {
+                totalInput += tokens.input
+                totalOutput += tokens.output
+                totalCacheRead += tokens.cacheRead
+                totalCacheWrite += tokens.cacheWrite
+                if let pricing = ModelPricing.pricing(for: modelId) {
+                    totalCost += pricing.cost(
+                        input: tokens.input, output: tokens.output,
+                        cacheRead: tokens.cacheRead, cacheWrite: tokens.cacheWrite
+                    )
+                }
+            }
+            return ProjectTokenSummary(
                 id: key,
-                projectName: acc.displayName,
-                inputTokens: acc.input,
-                outputTokens: acc.output,
-                cacheReadTokens: acc.cacheRead,
-                cacheWriteTokens: acc.cacheWrite,
-                estimatedCost: acc.cost
+                projectName: proj.displayName,
+                inputTokens: totalInput,
+                outputTokens: totalOutput,
+                cacheReadTokens: totalCacheRead,
+                cacheWriteTokens: totalCacheWrite,
+                estimatedCost: totalCost
             )
         }.sorted { $0.totalTokens > $1.totalTokens }
     }
 
-    /// Filter to Claude models, map to summaries, sort by total tokens descending.
-    /// Build per-model token summaries directly from JSONL entries (for windowed views).
-    private static func buildModelTokensFromEntries(_ entries: [AssistantUsageEntry]) -> [ModelTokenSummary] {
-        var map: [String: (input: Int, output: Int, cacheRead: Int, cacheWrite: Int)] = [:]
+    /// Single-pass windowed token computation. Iterates allEntries once, bucketing each entry
+    /// into today/week/month accumulators based on timestamp. Replaces 3 separate filter+accumulate passes.
+    private static func buildWindowedModelTokens(
+        from entries: [AssistantUsageEntry],
+        today: Date,
+        weekStart: Date,
+        monthStart: Date
+    ) -> (today: [ModelTokenSummary], week: [ModelTokenSummary], month: [ModelTokenSummary]) {
+        typealias TokenMap = [String: (input: Int, output: Int, cacheRead: Int, cacheWrite: Int)]
+        var todayMap: TokenMap = [:]
+        var weekMap: TokenMap = [:]
+        var monthMap: TokenMap = [:]
+
         for entry in entries {
-            let existing = map[entry.model] ?? (0, 0, 0, 0)
-            map[entry.model] = (
-                input: existing.input + entry.inputTokens,
-                output: existing.output + entry.outputTokens,
-                cacheRead: existing.cacheRead + entry.cacheReadTokens,
-                cacheWrite: existing.cacheWrite + entry.cacheWriteTokens
-            )
+            let ts = entry.timestamp
+            // Entries are roughly sorted by timestamp; check narrowest window first
+            if ts >= today {
+                let e = todayMap[entry.model] ?? (0, 0, 0, 0)
+                todayMap[entry.model] = (e.input + entry.inputTokens, e.output + entry.outputTokens,
+                                         e.cacheRead + entry.cacheReadTokens, e.cacheWrite + entry.cacheWriteTokens)
+                // Today entries are also in week and month
+                let w = weekMap[entry.model] ?? (0, 0, 0, 0)
+                weekMap[entry.model] = (w.input + entry.inputTokens, w.output + entry.outputTokens,
+                                        w.cacheRead + entry.cacheReadTokens, w.cacheWrite + entry.cacheWriteTokens)
+                let m = monthMap[entry.model] ?? (0, 0, 0, 0)
+                monthMap[entry.model] = (m.input + entry.inputTokens, m.output + entry.outputTokens,
+                                         m.cacheRead + entry.cacheReadTokens, m.cacheWrite + entry.cacheWriteTokens)
+            } else if ts >= weekStart {
+                let w = weekMap[entry.model] ?? (0, 0, 0, 0)
+                weekMap[entry.model] = (w.input + entry.inputTokens, w.output + entry.outputTokens,
+                                        w.cacheRead + entry.cacheReadTokens, w.cacheWrite + entry.cacheWriteTokens)
+                if ts >= monthStart {
+                    let m = monthMap[entry.model] ?? (0, 0, 0, 0)
+                    monthMap[entry.model] = (m.input + entry.inputTokens, m.output + entry.outputTokens,
+                                             m.cacheRead + entry.cacheReadTokens, m.cacheWrite + entry.cacheWriteTokens)
+                }
+            } else if ts >= monthStart {
+                let m = monthMap[entry.model] ?? (0, 0, 0, 0)
+                monthMap[entry.model] = (m.input + entry.inputTokens, m.output + entry.outputTokens,
+                                         m.cacheRead + entry.cacheReadTokens, m.cacheWrite + entry.cacheWriteTokens)
+            }
         }
-        return buildModelTokens(from: map)
+
+        return (buildModelTokens(from: todayMap), buildModelTokens(from: weekMap), buildModelTokens(from: monthMap))
     }
 
     private static func buildModelTokens(
@@ -335,13 +382,18 @@ final class UsageAggregator {
     ) -> [ModelTokenSummary] {
         map.compactMap { modelId, tokens in
             guard modelId.hasPrefix("claude-") else { return nil }
+            let cost = ModelPricing.pricing(for: modelId)?.cost(
+                input: tokens.input, output: tokens.output,
+                cacheRead: tokens.cacheRead, cacheWrite: tokens.cacheWrite
+            ) ?? 0
             return ModelTokenSummary(
                 id: modelId,
                 displayName: ModelNameMapper.displayName(for: modelId),
                 inputTokens: tokens.input,
                 outputTokens: tokens.output,
                 cacheReadTokens: tokens.cacheRead,
-                cacheWriteTokens: tokens.cacheWrite
+                cacheWriteTokens: tokens.cacheWrite,
+                estimatedCost: cost
             )
         }.sorted { $0.totalTokens > $1.totalTokens }
     }

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -510,16 +510,7 @@ struct InsightsView: View {
 
                 ForEach(models) { model in
                     let modelTokensText = TokenFormatter.format(model.totalTokens)
-                    let modelCost: String = {
-                        guard let pricing = ModelPricing.pricing(for: model.id) else { return "" }
-                        let cost = pricing.cost(
-                            input: model.inputTokens,
-                            output: model.outputTokens,
-                            cacheRead: model.cacheReadTokens,
-                            cacheWrite: model.cacheWriteTokens
-                        )
-                        return "~\(ModelPricing.formatCompactCost(cost))"
-                    }()
+                    let modelCost = "~\(ModelPricing.formatCompactCost(model.estimatedCost))"
                     let copyText = "\(model.displayName) \u{00B7} \(modelCost) \u{00B7} \(modelTokensText)"
                     HStack(spacing: 6) {
                         Text(model.displayName)
@@ -535,12 +526,10 @@ struct InsightsView: View {
 
                         Spacer()
 
-                        if !modelCost.isEmpty {
-                            Text(modelCost)
-                                .font(.system(.caption2, design: .monospaced))
-                                .foregroundStyle(ThemeColors.tertiaryLabel)
-                                .frame(width: costColumnWidth, alignment: .trailing)
-                        }
+                        Text(modelCost)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(ThemeColors.tertiaryLabel)
+                            .frame(width: costColumnWidth, alignment: .trailing)
 
                         Text(modelTokensText)
                             .font(.system(.caption2, design: .monospaced))

--- a/AIBattery/Views/Settings/DisplaySettingsSection.swift
+++ b/AIBattery/Views/Settings/DisplaySettingsSection.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct DisplaySettingsSection: View {
     @AppStorage(UserDefaultsKeys.idleSessionMinutes) private var idleSessionMinutes: Double = 0
     @AppStorage(UserDefaultsKeys.colorblindMode) private var colorblindMode: Bool = false
+    @State private var idleSliderPosition: Double = 6
     /// Slider positions (1-6) mapped to minutes: 30, 60, 120, 240, 480, 0 (never).
     private static let idleSteps: [Double] = [30, 60, 120, 240, 480, 0]
 
@@ -15,13 +16,25 @@ struct DisplaySettingsSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .frame(width: 50, alignment: .trailing)
-                Slider(value: idleSliderBinding, in: 1...6, step: 1)
+                Slider(value: $idleSliderPosition, in: 1...6, step: 1) { editing in
+                    if !editing {
+                        // Only write to AppStorage on drag end — avoids cascading redraws per tick
+                        idleSessionMinutes = Self.idleSteps[max(0, min(Int(idleSliderPosition) - 1, Self.idleSteps.count - 1))]
+                    }
+                }
+                    .onAppear {
+                        if let idx = Self.idleSteps.firstIndex(of: idleSessionMinutes) {
+                            idleSliderPosition = Double(idx + 1)
+                        } else {
+                            idleSliderPosition = 6
+                        }
+                    }
                     .accessibilityLabel("Hide idle sessions")
-                    .accessibilityValue(idleLabel)
-                Text(idleLabel)
+                    .accessibilityValue(idleLabelForPosition)
+                Text(idleLabelForPosition)
                     .font(.system(.caption, design: .monospaced))
                     .frame(width: 28, alignment: .trailing)
-                    .help(idleSessionMinutes == 0 ? "Show all sessions" : "Hide sessions idle > \(idleLabel)")
+                    .help(idleSliderPosition >= 6 ? "Show all sessions" : "Hide sessions idle > \(idleLabelForPosition)")
             }
             sliderMarks(labels: ["30m", "1h", "2h", "4h", "8h", "\u{221E}"], leadingPad: 50)
         }
@@ -39,22 +52,11 @@ struct DisplaySettingsSection: View {
         }
     }
 
-    /// Maps slider position (1-6) <-> stored minutes (30/60/120/240/480/0).
-    private var idleSliderBinding: Binding<Double> {
-        Binding(
-            get: {
-                if let idx = Self.idleSteps.firstIndex(of: idleSessionMinutes) {
-                    return Double(idx + 1)
-                }
-                return 6 // default to "Never"
-            },
-            set: { idleSessionMinutes = Self.idleSteps[max(0, min(Int($0) - 1, Self.idleSteps.count - 1))] }
-        )
-    }
-
-    /// Display label for the current idle cutoff.
-    private var idleLabel: String {
-        switch Int(idleSessionMinutes) {
+    /// Display label for the current slider position (live during drag).
+    private var idleLabelForPosition: String {
+        let idx = max(0, min(Int(idleSliderPosition) - 1, Self.idleSteps.count - 1))
+        let minutes = Self.idleSteps[idx]
+        switch Int(minutes) {
         case 30: return "30m"
         case 60: return "1h"
         case 120: return "2h"

--- a/AIBattery/Views/Settings/RefreshSettingsSection.swift
+++ b/AIBattery/Views/Settings/RefreshSettingsSection.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct RefreshSettingsSection: View {
     let viewModel: UsageViewModel
     @AppStorage(UserDefaultsKeys.refreshInterval) private var refreshInterval: Double = 60
+    @State private var sliderValue: Double = 60
+    @State private var isDragging = false
 
     var body: some View {
         VStack(spacing: 2) {
@@ -12,13 +14,18 @@ struct RefreshSettingsSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .frame(width: 50, alignment: .trailing)
-                Slider(value: $refreshInterval, in: 10...60, step: 5)
-                    .onChange(of: refreshInterval) { _ in
-                        viewModel.updatePollingInterval(refreshInterval)
+                Slider(value: $sliderValue, in: 10...60, step: 5) { editing in
+                    isDragging = editing
+                    if !editing {
+                        // Only update polling when drag ends — avoids timer restarts per tick
+                        refreshInterval = sliderValue
+                        viewModel.updatePollingInterval(sliderValue)
                     }
+                }
+                    .onAppear { sliderValue = refreshInterval }
                     .accessibilityLabel("Refresh interval")
-                    .accessibilityValue("\(Int(refreshInterval)) seconds")
-                Text("\(Int(refreshInterval))s")
+                    .accessibilityValue("\(Int(sliderValue)) seconds")
+                Text("\(Int(sliderValue))s")
                     .font(.system(.caption, design: .monospaced))
                     .frame(width: 28, alignment: .trailing)
             }


### PR DESCRIPTION
## Summary

- **Single-pass windowed tokens** — replaces 3×filter + 3×accumulate (6 passes over all JSONL entries) with one iteration that buckets into today/week/month maps simultaneously
- **Batched project pricing** — accumulates per (project, model) pair, computes cost once per pair instead of per entry. Reduces ModelPricing lock acquisitions from O(entries) to O(projects × models)
- **Pre-computed `estimatedCost` on ModelTokenSummary** — cost computed once at aggregation time, eliminates per-render pricing lock acquisitions in InsightsView and ModelPricing.totalCost
- **Slider debounce** — refresh and idle sliders only write to AppStorage / restart timers on drag end, preventing cascading redraws and timer restarts during drag
- **Reuse `entriesByDate` for todaySessions** — eliminates redundant Set allocation

## Test plan
- [ ] `swift build` compiles cleanly
- [ ] Open popover — Insights cost breakdown shows correct values
- [ ] Toggle 24H/7D/12M — windowed costs update correctly
- [ ] Drag refresh slider — timer only restarts on release, label updates live
- [ ] Drag idle slider — value only saves on release, label updates live
- [ ] Projects section costs unchanged
- [ ] Settings feel responsive during slider interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)