### PR TITLE
feat: burn rate time-to-limit from 5% usage

### DIFF
--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -89,7 +89,7 @@ struct RateLimitUsage: Equatable {
             }
         }()
 
-        guard utilization > 0.50, let reset else { return nil }
+        guard utilization > 0.05, let reset else { return nil }
 
         let remaining = reset.timeIntervalSinceNow
         guard remaining > 0 else { return nil }

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -100,8 +100,8 @@ struct UsageBar: View {
                 let resetDiff = resetsAt.map { $0.timeIntervalSince(Date()) }
                 let expired = (resetDiff ?? 1) <= 0
 
+                // Left side: time to limit / status
                 if wasExhausted && expired && percent < 1 {
-                    // Was at 100%+, timer hit 0, API confirmed reset — celebrate
                     HStack(spacing: 4) {
                         Image(systemName: "sparkles")
                             .font(.caption2)
@@ -123,13 +123,17 @@ struct UsageBar: View {
                         .foregroundStyle(ThemeColors.caution)
                         .copyable(estimateText)
                 } else {
+                    // No burn rate estimate yet — show remaining percentage
                     let remainingText = "\(max(0, Int(100 - percent)))% remaining"
                     Text(remainingText)
                         .font(.caption2)
                         .foregroundStyle(ThemeColors.secondaryLabel)
                         .copyable(remainingText)
                 }
+
                 Spacer()
+
+                // Right side: reset countdown (always shown when available)
                 if let diff = resetDiff {
                     if diff <= 0 && wasExhausted && percent >= 1 {
                         Text("Resets soon")


### PR DESCRIPTION
## Summary
- Lower `estimatedTimeToLimit` threshold from 50% to 5% so burn rate shows as soon as there's meaningful usage
- Left side shows `~Xh Ym to limit`, right side keeps `Resets in Xh Ym`
- Falls back to `X% remaining` only when no burn rate data available

## Test plan
- [ ] At low usage (5-50%): left shows time-to-limit, right shows reset countdown
- [ ] At high usage (>50%): same layout, more accurate estimate
- [ ] At 0% usage: shows "100% remaining" (no burn rate)
- [ ] Throttled: shows "Rate limited"

🤖 Generated with [Claude Code](https://claude.com/claude-code)