### PR TITLE
perf: Equatable UsageSnapshot, binary search in health monitor

### DIFF
--- a/AIBattery/Models/UsageSnapshot.swift
+++ b/AIBattery/Models/UsageSnapshot.swift
@@ -1,6 +1,26 @@
 import Foundation
 
-struct UsageSnapshot {
+struct UsageSnapshot: Equatable {
+    /// Custom equality skips `lastUpdated` (always changes) and compares meaningful data.
+    /// Prevents unnecessary SwiftUI diffs when polling returns identical data.
+    static func == (lhs: UsageSnapshot, rhs: UsageSnapshot) -> Bool {
+        lhs.rateLimits == rhs.rateLimits
+            && lhs.totalSessions == rhs.totalSessions
+            && lhs.totalMessages == rhs.totalMessages
+            && lhs.todayMessages == rhs.todayMessages
+            && lhs.todaySessions == rhs.todaySessions
+            && lhs.totalTokens == rhs.totalTokens
+            && lhs.totalProjectTokens == rhs.totalProjectTokens
+            && lhs.modelTokens == rhs.modelTokens
+            && lhs.projectTokens == rhs.projectTokens
+            && lhs.dailyActivity == rhs.dailyActivity
+            && lhs.topSessionHealths == rhs.topSessionHealths
+            && lhs.tokenHealth == rhs.tokenHealth
+            && lhs.todayHourCounts == rhs.todayHourCounts
+            && lhs.todayModelTokens == rhs.todayModelTokens
+            && lhs.weekModelTokens == rhs.weekModelTokens
+            && lhs.monthModelTokens == rhs.monthModelTokens
+    }
     /// Weekday symbols from the user's current calendar (Sunday = index 0).
     private static let weekdaySymbols = Calendar.current.weekdaySymbols
 

--- a/AIBattery/Services/TokenHealthMonitor.swift
+++ b/AIBattery/Services/TokenHealthMonitor.swift
@@ -22,11 +22,30 @@ final class TokenHealthMonitor {
         let cutoff = now.addingTimeInterval(-cutoffSeconds)
         let currentSessionId = latestEntry.sessionId
 
-        // Pre-filter to sessions with recent activity (or the current session) before
-        // grouping — avoids allocating dictionary buckets for months of stale sessions.
-        let relevantEntries = entries.filter {
-            $0.sessionId == currentSessionId || $0.timestamp > cutoff
+        // Binary search for cutoff index — entries are sorted by timestamp.
+        // Only scan from cutoff forward instead of filtering all entries (O(log N + recent) vs O(N)).
+        let cutoffIndex = binarySearchCutoff(entries: entries, cutoff: cutoff)
+
+        // Collect recent entries + current session entries from before the cutoff
+        var relevantEntries: [AssistantUsageEntry] = []
+        relevantEntries.reserveCapacity(entries.count - cutoffIndex + 50)
+
+        // Entries after cutoff — all potentially relevant
+        for i in cutoffIndex..<entries.count {
+            relevantEntries.append(entries[i])
         }
+
+        // Current session entries before cutoff (scan backward from cutoff)
+        for i in stride(from: cutoffIndex - 1, through: 0, by: -1) {
+            if entries[i].sessionId == currentSessionId {
+                relevantEntries.append(entries[i])
+            } else {
+                // Stop scanning once we hit a different session far enough back
+                // (current session entries tend to be clustered near the end)
+                if entries[i].timestamp < cutoff.addingTimeInterval(-3600) { break }
+            }
+        }
+
         let grouped = Dictionary(grouping: relevantEntries, by: \.sessionId)
         var current: TokenHealthStatus?
         var recentResults: [TokenHealthStatus] = []
@@ -54,6 +73,21 @@ final class TokenHealthMonitor {
         let top = Array(recentResults.prefix(topLimit))
 
         return (current, top)
+    }
+
+    /// Binary search for the first entry index with timestamp > cutoff.
+    /// Entries must be sorted by timestamp ascending.
+    private func binarySearchCutoff(entries: [AssistantUsageEntry], cutoff: Date) -> Int {
+        var lo = 0, hi = entries.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if entries[mid].timestamp > cutoff {
+                hi = mid
+            } else {
+                lo = mid + 1
+            }
+        }
+        return lo
     }
 
     /// Convenience: assess health for the most recent session only.

--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -43,7 +43,7 @@ public final class UsageViewModel: ObservableObject {
         // Skip network work when not authenticated — still aggregate local data.
         guard oauthManager.isAuthenticated else {
             let result = aggregator.aggregate(rateLimits: nil)
-            if result.totalMessages > 0 { snapshot = result }
+            if result.totalMessages > 0, result != snapshot { snapshot = result }
             isLoading = false
             return
         }
@@ -51,7 +51,7 @@ public final class UsageViewModel: ObservableObject {
         // Skip network when offline — show local data with cached rate limits.
         guard NetworkMonitor.shared.isConnected else {
             let result = aggregator.aggregate(rateLimits: apiResult?.rateLimits)
-            snapshot = result
+            if result != snapshot { snapshot = result }
             isLoading = false
             errorMessage = "No internet connection"
             return
@@ -133,7 +133,7 @@ public final class UsageViewModel: ObservableObject {
             hasProfile: api.profile != nil,
             totalMessages: result.totalMessages
         )
-        snapshot = result
+        if result != snapshot { snapshot = result }
         isLoading = false
     }
 


### PR DESCRIPTION
## Summary

- **Equatable on UsageSnapshot** — custom `==` skips `lastUpdated` (always changes), compares meaningful data fields. All 3 snapshot assignment sites guarded with `!=` check. Prevents unnecessary SwiftUI `objectWillChange` when polling returns identical data — eliminates full popover re-render on no-change cycles.

- **Binary search in TokenHealthMonitor** — `assessSessions` now binary-searches for the cutoff timestamp index instead of filtering all entries. Scans only entries after cutoff + targeted backward scan for current session entries. O(log N + recent) vs O(N).

## Test plan
- [ ] `swift build` compiles cleanly
- [ ] Popover data updates correctly when usage changes
- [ ] Context health sessions display correctly (chevron navigation works)
- [ ] No visual changes — purely internal optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)