### PR TITLE
fix: throttled display at 100%, static star, clear label

### DIFF
--- a/AIBattery/Views/MenuBarIcon.swift
+++ b/AIBattery/Views/MenuBarIcon.swift
@@ -156,7 +156,8 @@ struct MenuBarIcon: View {
         // but can be slow; no need to serialize rendering across threads.
         let icon: NSImage
         if isBroken {
-            icon = renderBrokenIcon(color: color, pulseStep: pulseStep, highContrast: highContrast, isDarkMode: isDarkMode)
+            // Throttled: static star at peak intensity (no animation, no broken fragments)
+            icon = renderIcon(percent: 100, color: color, pulseStep: 0, highContrast: highContrast, isDarkMode: isDarkMode)
         } else if isSparkle {
             icon = renderSparkleIcon(color: color, pulseStep: pulseStep, highContrast: highContrast, isDarkMode: isDarkMode)
         } else {

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -11,7 +11,7 @@ struct FiveHourBarSection: View {
             resetsAt: limits.fiveHourReset,
             isBinding: limits.representativeClaim == RateLimitUsage.fiveHourWindow,
             isThrottled: limits.fiveHourStatus == "throttled"
-                || (limits.isThrottled && limits.fiveHourPercent >= 100),
+                || limits.fiveHourPercent >= 100,
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.fiveHourWindow)
         )
         .padding(.horizontal, 16)
@@ -30,7 +30,7 @@ struct SevenDayBarSection: View {
             resetsAt: limits.sevenDayReset,
             isBinding: limits.representativeClaim == RateLimitUsage.sevenDayWindow,
             isThrottled: limits.sevenDayStatus == "throttled"
-                || (limits.isThrottled && limits.sevenDayPercent >= 100),
+                || limits.sevenDayPercent >= 100,
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.sevenDayWindow)
         )
         .padding(.horizontal, 16)
@@ -114,7 +114,7 @@ struct UsageBar: View {
                     }
                     .transition(.opacity)
                 } else if isThrottled {
-                    Text("Rate limited")
+                    Text("Throttled")
                         .font(.caption2)
                         .foregroundStyle(ThemeColors.danger)
                         .transition(.opacity)


### PR DESCRIPTION
## Summary
- **Throttled at 100%** — 5-hour/7-day bars now show "Throttled" when percent >= 100, not just when API status header says "throttled" (which can lag behind utilization)
- **Static star when throttled** — menu bar shows normal star at peak intensity (no broken fragments, no pulsing). Just the solid star shape, static.
- **Label clarity** — "Rate limited" changed to "Throttled"

## Test plan
- [ ] At 100% utilization: bar shows "Throttled" in red
- [ ] Menu bar star: static, solid, no animation when throttled
- [ ] Below 100%: normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)