### PR TITLE
feat: instant rate limits on launch, fix throttle + slider bugs

### DIFF
--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -7,7 +7,7 @@ import Foundation
 ///   - 7-day window (long-term usage)
 /// Each reports a utilization fraction (0.0–1.0) and a reset timestamp.
 /// The `representative-claim` tells which window is the binding constraint.
-struct RateLimitUsage: Equatable {
+struct RateLimitUsage: Equatable, Codable {
     /// Window identifiers used in API headers.
     static let fiveHourWindow = "five_hour"
     static let sevenDayWindow = "seven_day"

--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -22,6 +22,9 @@ final class RateLimitFetcher {
     /// Maximum age of cached result before it's considered stale and discarded.
     static let cacheMaxAge: TimeInterval = 3600 // 1 hour
 
+    /// UserDefaults key prefix for persisted rate limits.
+    private static let persistKeyPrefix = "aibattery_rateLimits_"
+
     /// Models to try in order. Free accounts may not have access to larger models,
     /// but rate limit headers come back the same regardless of model.
     private let models = [
@@ -32,6 +35,10 @@ final class RateLimitFetcher {
 
     /// Per-account model index (remembers last working model to avoid repeated fallbacks).
     private var currentModelIndex: [String: Int] = [:]
+
+    private init() {
+        restorePersistedRateLimits()
+    }
 
     /// User-Agent string built from bundle version at startup.
     private let userAgent: String = {
@@ -52,6 +59,7 @@ final class RateLimitFetcher {
             case .success(let fetchResult):
                 currentModelIndex[accountId] = i
                 cachedResults[accountId] = fetchResult
+                persistRateLimits(fetchResult.rateLimits, fetchedAt: fetchResult.fetchedAt, accountId: accountId)
                 return fetchResult
             case .modelUnavailable:
                 // This model isn't available for this account — try the next one
@@ -210,6 +218,50 @@ final class RateLimitFetcher {
             return .success(result)
         } catch {
             return .networkError
+        }
+    }
+
+    // MARK: - Rate limit persistence (survive app restart)
+
+    /// Wrapper for persisting rate limits + fetch timestamp.
+    private struct PersistedRateLimits: Codable {
+        let rateLimits: RateLimitUsage
+        let fetchedAt: Date
+    }
+
+    /// Save rate limits to UserDefaults for instant display on next launch.
+    private func persistRateLimits(_ rateLimits: RateLimitUsage?, fetchedAt: Date, accountId: String) {
+        guard let rateLimits else { return }
+        let key = Self.persistKeyPrefix + accountId
+        let persisted = PersistedRateLimits(rateLimits: rateLimits, fetchedAt: fetchedAt)
+        if let data = try? JSONEncoder().encode(persisted) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
+    /// Restore persisted rate limits into the in-memory cache on launch.
+    /// Only restores if within cacheMaxAge — stale persisted data is discarded.
+    private func restorePersistedRateLimits() {
+        let defaults = UserDefaults.standard
+        let prefix = Self.persistKeyPrefix
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(prefix) {
+            let accountId = String(key.dropFirst(prefix.count))
+            guard let data = defaults.data(forKey: key),
+                  let persisted = try? JSONDecoder().decode(PersistedRateLimits.self, from: data) else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
+            let age = Date().timeIntervalSince(persisted.fetchedAt)
+            if age < Self.cacheMaxAge {
+                cachedResults[accountId] = APIFetchResult(
+                    rateLimits: persisted.rateLimits,
+                    profile: nil,
+                    fetchedAt: persisted.fetchedAt,
+                    isCached: true
+                )
+            } else {
+                defaults.removeObject(forKey: key)
+            }
         }
     }
 

--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -58,11 +58,22 @@ public final class UsageViewModel: ObservableObject {
         }
 
         let wasEmpty = snapshot == nil
-        if wasEmpty { isLoading = true }
-        // Yield to let SwiftUI render the loading state before blocking on network + aggregation.
+        let accountId = oauthManager.accountStore.activeAccountId
+
+        // Show cached rate limits immediately while API call is in-flight.
+        // This eliminates the empty-bars delay on launch.
+        if wasEmpty, let accountId {
+            let cached = RateLimitFetcher.shared.cachedOrEmpty(accountId: accountId)
+            if cached.rateLimits != nil {
+                let earlyResult = aggregator.aggregate(rateLimits: cached.rateLimits, accountId: accountId)
+                snapshot = earlyResult
+                isShowingCachedData = true
+            } else {
+                isLoading = true
+            }
+        }
         await Task.yield()
 
-        let accountId = oauthManager.accountStore.activeAccountId
         let (api, status) = await fetchAPIData(oauthManager: oauthManager, accountId: accountId)
 
         apiResult = api

--- a/AIBattery/Views/Settings/DisplaySettingsSection.swift
+++ b/AIBattery/Views/Settings/DisplaySettingsSection.swift
@@ -29,6 +29,11 @@ struct DisplaySettingsSection: View {
                             idleSliderPosition = 6
                         }
                     }
+                    .onChange(of: idleSessionMinutes) { newValue in
+                        if let idx = Self.idleSteps.firstIndex(of: newValue) {
+                            idleSliderPosition = Double(idx + 1)
+                        }
+                    }
                     .accessibilityLabel("Hide idle sessions")
                     .accessibilityValue(idleLabelForPosition)
                 Text(idleLabelForPosition)

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -11,7 +11,7 @@ struct FiveHourBarSection: View {
             resetsAt: limits.fiveHourReset,
             isBinding: limits.representativeClaim == RateLimitUsage.fiveHourWindow,
             isThrottled: limits.fiveHourStatus == "throttled"
-                || limits.fiveHourPercent >= 100,
+                || (limits.isThrottled && limits.fiveHourPercent >= 100),
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.fiveHourWindow)
         )
         .padding(.horizontal, 16)
@@ -30,7 +30,7 @@ struct SevenDayBarSection: View {
             resetsAt: limits.sevenDayReset,
             isBinding: limits.representativeClaim == RateLimitUsage.sevenDayWindow,
             isThrottled: limits.sevenDayStatus == "throttled"
-                || limits.sevenDayPercent >= 100,
+                || (limits.isThrottled && limits.sevenDayPercent >= 100),
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.sevenDayWindow)
         )
         .padding(.horizontal, 16)


### PR DESCRIPTION
## Summary

- **Instant rate limits on launch** — persists last `RateLimitUsage` per account to UserDefaults. On restart, rate limit bars appear immediately from cache while the API call runs in the background. No more 5-15s empty bars.
- **Fix throttle display** — restore original condition: only shows "Throttled" when API status header confirms throttling (was incorrectly triggering at 100% usage regardless, blocking reset celebration)
- **Fix idle slider sync** — adds `onChange(of: idleSessionMinutes)` to keep slider position in sync when AppStorage changes externally

## Test plan
- [ ] Launch app — rate limit bars appear instantly (after first successful fetch persists data)
- [ ] Kill and restart — bars show cached values immediately, update when fresh data arrives
- [ ] At 100% but not throttled: shows reset countdown, not "Throttled"
- [ ] When actually throttled: shows "Throttled" correctly
- [ ] Reset celebration still works after throttle clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)