### PR TITLE
fix: settings panel overflow + data races in cache readers

### DIFF
--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -54,12 +54,21 @@ final class RateLimitFetcher {
                 lastWorkingModel[accountId] = model
             }
         }
-        // Also restore observed models from UserDefaults (best-effort — overwritten on first aggregation).
-        let observedPrefix = Self.observedModelsKeyPrefix
-        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(observedPrefix) {
-            if let models = defaults.stringArray(forKey: key), !models.isEmpty {
-                observedModels = models
-                break
+        // Also restore observed models from the active account's persisted list
+        // (best-effort — overwritten on first aggregation).
+        let activeAccountId = OAuthManager.shared.accountStore.activeAccountId
+        if let activeAccountId,
+           let models = defaults.stringArray(forKey: Self.observedModelsKeyPrefix + activeAccountId),
+           !models.isEmpty {
+            observedModels = models
+        } else {
+            // Fallback: try any persisted account's models so fresh fetches have a probe list
+            let observedPrefix = Self.observedModelsKeyPrefix
+            for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(observedPrefix) {
+                if let models = defaults.stringArray(forKey: key), !models.isEmpty {
+                    observedModels = models
+                    break
+                }
             }
         }
     }

--- a/AIBattery/Services/SessionLogReader.swift
+++ b/AIBattery/Services/SessionLogReader.swift
@@ -1,13 +1,39 @@
 import Foundation
 import os
 
+// MARK: - AtomicBool
+
+extension NSLock {
+    /// Lock-protected boolean for cross-thread flag signaling.
+    final class AtomicBool: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        func set(_ newValue: Bool) {
+            lock.lock()
+            value = newValue
+            lock.unlock()
+        }
+
+        /// Atomically reads the current value, sets it to `newValue`, and returns the old value.
+        func swap(_ newValue: Bool) -> Bool {
+            lock.lock()
+            let old = value
+            value = newValue
+            lock.unlock()
+            return old
+        }
+    }
+}
+
 /// Reads and caches JSONL session log files. NOT MainActor — file I/O must not block the UI.
 /// Thread-safety: mutable state accessed behind `lock`. `invalidate()` uses `tryLock` so
 /// FileWatcher on main never blocks waiting for a long-running background scan.
 final class SessionLogReader: @unchecked Sendable {
     private let lock = NSLock()
     /// Set true by invalidate() when lock is held by a scan — checked after scan completes.
-    private var pendingInvalidation = false
+    /// Atomic: written by FileWatcher (main) without the lock, read by background scan under the lock.
+    private let pendingInvalidation = NSLock.AtomicBool()
     static let shared = SessionLogReader()
 
     private let projectsURL: URL
@@ -85,14 +111,15 @@ final class SessionLogReader: @unchecked Sendable {
             lastFullEnumerationDate = nil
             lock.unlock()
         } else {
-            // Scan in progress — mark for invalidation when it finishes
-            pendingInvalidation = true
+            // Scan in progress — mark for invalidation when it finishes.
+            // Atomic so FileWatcher on main never blocks waiting for the scan lock.
+            pendingInvalidation.set(true)
         }
     }
 
     func readAllUsageEntries() -> [AssistantUsageEntry] {
         lock.lock()
-        pendingInvalidation = false
+        pendingInvalidation.set(false)
         lastCorruptLineCount = 0
 
         // Fast path: not dirty, return cached result
@@ -123,8 +150,7 @@ final class SessionLogReader: @unchecked Sendable {
         // For evicted files with unchanged fingerprint, entries already live in cachedAllEntries.
         let result = rebuild(jsonlFiles: jsonlFiles, base: cachedAllEntries)
 
-        if pendingInvalidation {
-            pendingInvalidation = false
+        if pendingInvalidation.swap(false) {
             isDirty = true
             lock.unlock()
             return result

--- a/AIBattery/Services/StatsCacheReader.swift
+++ b/AIBattery/Services/StatsCacheReader.swift
@@ -10,6 +10,7 @@ final class StatsCacheReader: @unchecked Sendable {
     static let maxFileSize: UInt64 = 10_000_000
     private let fileURL: URL
     private let checkBoundary: Bool
+    private let lock = NSLock()
 
     init(fileURL: URL? = nil, checkBoundary: Bool? = nil) {
         self.fileURL = fileURL ?? ClaudePaths.statsCache
@@ -25,13 +26,19 @@ final class StatsCacheReader: @unchecked Sendable {
 
     /// Last known modification date of stats-cache.json. Used by UsageAggregator
     /// to detect whether re-aggregation is needed.
-    var lastModificationDate: Date? { cachedModDate }
+    var lastModificationDate: Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedModDate
+    }
 
     /// Called by FileWatcher when the stats-cache file changes.
     func invalidate() {
+        lock.lock()
         cached = nil
         cachedModDate = nil
         cachedFileSize = nil
+        lock.unlock()
     }
 
     func read() -> StatsCache? {
@@ -68,18 +75,25 @@ final class StatsCacheReader: @unchecked Sendable {
             return nil
         }
 
+        lock.lock()
+
         // Cache hit — skip re-decode when file unchanged
         if let c = cached, let modDate, let fileSize,
            modDate == cachedModDate, fileSize == cachedFileSize {
+            lock.unlock()
             return c
         }
+
+        lock.unlock()
 
         do {
             let data = try Data(contentsOf: fileURL)
             let result = try Self.jsonDecoder.decode(StatsCache.self, from: data)
+            lock.lock()
             cached = result
             cachedModDate = modDate
             cachedFileSize = fileSize
+            lock.unlock()
             return result
         } catch {
             AppLogger.files.error("StatsCacheReader: error reading stats cache: \(error.localizedDescription, privacy: .public)")

--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -35,12 +35,13 @@ struct ProjectUsageSection: View {
     private var displayedProjects: [ProjectTokenSummary] {
         let sorted = cachedSorted
 
+        let limit = showAll ? Self.expandedLimit : Self.defaultLimit
+
         if showAll && !searchText.isEmpty {
             let query = searchText.lowercased()
-            return sorted.filter { $0.projectName.lowercased().contains(query) }
+            return Array(sorted.filter { $0.projectName.lowercased().contains(query) }.prefix(limit))
         }
 
-        let limit = showAll ? Self.expandedLimit : Self.defaultLimit
         return Array(sorted.prefix(limit))
     }
 

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -100,9 +100,7 @@ public struct UsagePopoverView: View {
                 )
                 .transition(.opacity.combined(with: .move(edge: .top)))
                 StyledDivider()
-            }
-
-            if let snapshot = viewModel.snapshot {
+            } else if let snapshot = viewModel.snapshot {
                 MetricToggleView(
                     metricModeRaw: $metricModeRaw,
                     autoResolvedBinding: autoResolvedBinding,
@@ -170,7 +168,7 @@ public struct UsagePopoverView: View {
                     InsightsGate(snapshot: snapshot)
                 }
 
-            } else if viewModel.isLoading {
+            } else if !showSettings && viewModel.isLoading {
                 // First load — show minimal loading state
                 HStack {
                     Spacer()
@@ -183,11 +181,11 @@ public struct UsagePopoverView: View {
                     Spacer()
                 }
                 .frame(height: 40)
-            } else if let error = viewModel.errorMessage {
+            } else if !showSettings, let error = viewModel.errorMessage {
                 PopoverErrorView(message: error) {
                     Task { await viewModel.refresh() }
                 }
-            } else {
+            } else if !showSettings {
                 PopoverEmptyView()
             }
 
@@ -225,6 +223,7 @@ public struct UsagePopoverView: View {
             }
         }
         .onChange(of: metricModeRaw) { _ in recomputeOrderedModes() }
+        .onChange(of: autoMetricMode) { _ in recomputeOrderedModes() }
         .onReceive(NotificationCenter.default.publisher(for: .panelKeyPress)) { notification in
             guard let key = notification.object as? String else { return }
             handleKeyPress(key)


### PR DESCRIPTION
## Summary

- **Settings panel overflow** — opening settings pushed metric sections below the screen edge, clipping the panel and making the gear icon unreachable. Settings now hide metric sections while open, keeping the panel within bounds.
- **StatsCacheReader data race** — `invalidate()` (main/FileWatcher) and `read()` (background aggregation) accessed cached state without synchronization. Added `NSLock`.
- **SessionLogReader data race** — `pendingInvalidation` was written by FileWatcher without the lock while the scan thread read it under the lock. Replaced with a lock-protected `AtomicBool`.
- **RateLimitFetcher wrong account** — `observedModels` was restored from an arbitrary account on launch due to `dictionaryRepresentation().keys` iteration order. Now reads the active account first.
- **Section order stale on auto-mode toggle** — `recomputeOrderedModes()` only fired on `metricModeRaw` change, not `autoMetricMode` toggle. Added missing `onChange`.
- **Unbounded project search** — filtered results ignored `expandedLimit` (10), returning all matches. Now capped.

## Test plan

- [ ] Open settings — panel stays within screen, gear icon visible and clickable
- [ ] Close settings — metric sections reappear, panel resizes correctly
- [ ] Dismiss panel with settings open (Esc/click outside) — reopens without settings
- [ ] Toggle auto metric mode — section order updates immediately
- [ ] Expand projects → search with broad query — results capped at 10
- [ ] Verify no crashes under rapid panel open/close (exercises lock changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)