### PR TITLE
fix: v2.1.3 throttle and menu bar polish

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -69,6 +69,17 @@ struct RateLimitUsage: Equatable, Codable {
             || sevenDayStatus == "throttled"
     }
 
+    /// Whether a specific window is currently throttled.
+    /// A global throttled status alone is not enough to mark every window as throttled.
+    func isWindowThrottled(_ window: String) -> Bool {
+        switch window {
+        case Self.sevenDayWindow:
+            return sevenDayStatus == "throttled"
+        default:
+            return fiveHourStatus == "throttled"
+        }
+    }
+
     /// Force a throttled state when the HTTP response proves the account is rate limited
     /// but the unified headers lag behind and still report an allowed status/utilization.
     func markedThrottled(bindingWindow: String? = nil) -> RateLimitUsage {

--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -12,6 +12,17 @@ struct RateLimitUsage: Equatable, Codable {
     static let fiveHourWindow = "five_hour"
     static let sevenDayWindow = "seven_day"
 
+    private static func inferredWindowStatus(
+        explicitStatus: String?,
+        overallStatus: String,
+        representativeClaim: String,
+        window: String
+    ) -> String {
+        if let explicitStatus { return explicitStatus }
+        guard overallStatus == "throttled" else { return overallStatus }
+        return representativeClaim == window ? "throttled" : "allowed"
+    }
+
     /// The binding constraint: "five_hour" or "seven_day"
     let representativeClaim: String
 
@@ -174,14 +185,26 @@ struct RateLimitUsage: Equatable, Codable {
             return nil
         }
 
+        let representativeClaim = stringHeader("anthropic-ratelimit-unified-representative-claim") ?? fiveHourWindow
+
         return RateLimitUsage(
-            representativeClaim: stringHeader("anthropic-ratelimit-unified-representative-claim") ?? fiveHourWindow,
+            representativeClaim: representativeClaim,
             fiveHourUtilization: min(max(doubleHeader("anthropic-ratelimit-unified-5h-utilization"), 0), 1),
             fiveHourReset: dateFromUnix("anthropic-ratelimit-unified-5h-reset"),
-            fiveHourStatus: stringHeader("anthropic-ratelimit-unified-5h-status") ?? status,
+            fiveHourStatus: inferredWindowStatus(
+                explicitStatus: stringHeader("anthropic-ratelimit-unified-5h-status"),
+                overallStatus: status,
+                representativeClaim: representativeClaim,
+                window: fiveHourWindow
+            ),
             sevenDayUtilization: min(max(doubleHeader("anthropic-ratelimit-unified-7d-utilization"), 0), 1),
             sevenDayReset: dateFromUnix("anthropic-ratelimit-unified-7d-reset"),
-            sevenDayStatus: stringHeader("anthropic-ratelimit-unified-7d-status") ?? status,
+            sevenDayStatus: inferredWindowStatus(
+                explicitStatus: stringHeader("anthropic-ratelimit-unified-7d-status"),
+                overallStatus: status,
+                representativeClaim: representativeClaim,
+                window: sevenDayWindow
+            ),
             overallStatus: status
         )
     }
@@ -373,14 +396,26 @@ struct RateLimitUsage: Equatable, Codable {
             return overallStatus ?? "allowed"
         }()
 
+        let normalizedRepresentativeClaim = representativeClaim == sevenDayWindow ? sevenDayWindow : fiveHourWindow
+
         return RateLimitUsage(
-            representativeClaim: representativeClaim == sevenDayWindow ? sevenDayWindow : fiveHourWindow,
+            representativeClaim: normalizedRepresentativeClaim,
             fiveHourUtilization: fiveHourUtilization ?? 0,
             fiveHourReset: fiveHourReset,
-            fiveHourStatus: fiveHourStatus ?? inferredOverallStatus,
+            fiveHourStatus: inferredWindowStatus(
+                explicitStatus: fiveHourStatus,
+                overallStatus: inferredOverallStatus,
+                representativeClaim: normalizedRepresentativeClaim,
+                window: fiveHourWindow
+            ),
             sevenDayUtilization: sevenDayUtilization ?? 0,
             sevenDayReset: sevenDayReset,
-            sevenDayStatus: sevenDayStatus ?? inferredOverallStatus,
+            sevenDayStatus: inferredWindowStatus(
+                explicitStatus: sevenDayStatus,
+                overallStatus: inferredOverallStatus,
+                representativeClaim: normalizedRepresentativeClaim,
+                window: sevenDayWindow
+            ),
             overallStatus: inferredOverallStatus
         )
     }

--- a/AIBattery/Views/MenuBarIcon.swift
+++ b/AIBattery/Views/MenuBarIcon.swift
@@ -120,7 +120,7 @@ struct MenuBarIcon: View {
     /// `isSparkle` triggers the recovery sparkle effect (30s after throttle clears).
     /// Inset to trim left-side canvas padding so the icon sits tight against the title text.
     /// macOS battery has ~1pt between text and icon; our 22pt canvas has ~4pt whitespace on each side.
-    private static let iconAlignmentInsets = NSEdgeInsets(top: 0, left: 3, bottom: 0, right: 3)
+    private static let iconAlignmentInsets = NSEdgeInsets(top: 0, left: 1, bottom: 0, right: 5)
 
     static func statusBarImage(for percent: Double, color: NSColor, isBroken: Bool = false, isSparkle: Bool = false, pulseStep: Int = 0) -> NSImage {
         cachedIcon(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: pulseStep)

--- a/AIBattery/Views/MenuBarIcon.swift
+++ b/AIBattery/Views/MenuBarIcon.swift
@@ -120,7 +120,7 @@ struct MenuBarIcon: View {
     /// `isSparkle` triggers the recovery sparkle effect (30s after throttle clears).
     /// Inset to trim left-side canvas padding so the icon sits tight against the title text.
     /// macOS battery has ~1pt between text and icon; our 22pt canvas has ~4pt whitespace on each side.
-    private static let iconAlignmentInsets = NSEdgeInsets(top: 0, left: 3, bottom: 0, right: 0)
+    private static let iconAlignmentInsets = NSEdgeInsets(top: 0, left: 3, bottom: 0, right: 3)
 
     static func statusBarImage(for percent: Double, color: NSColor, isBroken: Bool = false, isSparkle: Bool = false, pulseStep: Int = 0) -> NSImage {
         cachedIcon(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: pulseStep)

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -110,9 +110,7 @@ struct PopoverFooterView: View {
                         if let lastFetch = lastFreshFetch {
                             RelativeTimeText(
                                 date: lastFetch,
-                                isStale: isShowingCachedData,
-                                alternateText: rateLimitSource?.shortLabel,
-                                alternateTooltip: rateLimitSource?.explanation
+                                isStale: isShowingCachedData
                             )
                         } else if isLoading {
                             Text("Updating…")

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -306,6 +306,7 @@ public final class StatusBarManager: NSObject {
         let displayText = resolveDisplayText(rateLimits: rateLimits, percent: percent)
         button.title = displayText
         button.setAccessibilityValue(displayText)
+        updateStatusItemWidth(button: button, displayText: displayText)
         // Never grey out — the icon always shows the last known state.
         // Other menu bar apps (Battery, WiFi) don't dim on stale data.
 
@@ -324,6 +325,15 @@ public final class StatusBarManager: NSObject {
         }
         let raw = UserDefaults.standard.string(forKey: UserDefaultsKeys.metricMode) ?? "5h"
         return MetricMode(rawValue: raw) ?? .fiveHour
+    }
+
+    private func updateStatusItemWidth(button: NSStatusBarButton, displayText: String) {
+        guard let statusItem else { return }
+        let font = button.font ?? .monospacedDigitSystemFont(ofSize: 11, weight: .medium)
+        let titleWidth = ceil((displayText as NSString).size(withAttributes: [.font: font]).width)
+        let iconWidth = max(12, button.image?.alignmentRect.size.width ?? 12)
+        // Tight width: title + icon + small gap + minimal capsule padding.
+        statusItem.length = titleWidth + iconWidth + 6
     }
 
     private func resolveStarColor(metricMode: MetricMode, percent: Double, isThrottled: Bool) -> NSColor {

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -12,8 +12,7 @@ struct FiveHourBarSection: View {
             resetsAt: limits.fiveHourReset,
             source: source,
             isBinding: limits.representativeClaim == RateLimitUsage.fiveHourWindow,
-            isThrottled: limits.fiveHourStatus == "throttled"
-                || (limits.isThrottled && limits.representativeClaim == RateLimitUsage.fiveHourWindow),
+            isThrottled: limits.isWindowThrottled(RateLimitUsage.fiveHourWindow),
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.fiveHourWindow)
         )
         .padding(.horizontal, Spacing.sectionHorizontal)
@@ -33,8 +32,7 @@ struct SevenDayBarSection: View {
             resetsAt: limits.sevenDayReset,
             source: source,
             isBinding: limits.representativeClaim == RateLimitUsage.sevenDayWindow,
-            isThrottled: limits.sevenDayStatus == "throttled"
-                || (limits.isThrottled && limits.representativeClaim == RateLimitUsage.sevenDayWindow),
+            isThrottled: limits.isWindowThrottled(RateLimitUsage.sevenDayWindow),
             estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.sevenDayWindow)
         )
         .padding(.horizontal, Spacing.sectionHorizontal)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## [2.1.2] — 2026-04-08
+## [2.1.3] — 2026-04-08
+
+### Fixed
+- **7-day false throttle state** — when Anthropic reports an overall throttled state without explicit per-window statuses, the app now marks only the binding window as throttled instead of showing both 5-hour and 7-day as blocked
+- **Footer source rotation** — the footer now stays on `Updated …` / `Cached …` instead of alternating to `Via Anthropic API`
 
 ### Changed
-- **Release candidate refresh** — bumped the app version metadata and release notes for the `v2.1.2` draft build so the packaged app and PR tracking stay aligned for local verification
+- **Menu bar pill spacing** — tightened the trailing icon inset so the menu bar capsule hugs the content more closely
 
 ## [2.1.1] — 2026-04-04
 

--- a/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
@@ -250,6 +250,19 @@ struct RateLimitUsageTests {
         #expect(noneThrottled.isThrottled == false)
     }
 
+    @Test func isWindowThrottled_onlyFlagsMatchingWindow() {
+        let usage = makeUsage(
+            claim: "five_hour",
+            fiveHourStatus: "throttled",
+            sevenDayStatus: "allowed",
+            status: "throttled"
+        )
+
+        #expect(usage.isThrottled == true)
+        #expect(usage.isWindowThrottled(RateLimitUsage.fiveHourWindow) == true)
+        #expect(usage.isWindowThrottled(RateLimitUsage.sevenDayWindow) == false)
+    }
+
     @Test func markedThrottled_bindingWindowMarksRepresentativeWindow() {
         let usage = makeUsage(
             claim: "seven_day",

--- a/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
@@ -102,6 +102,21 @@ struct RateLimitUsageTests {
         #expect(usage?.fiveHourStatus == "throttled")
     }
 
+    @Test func parse_throttledHeaders_withoutWindowStatuses_onlyMarksBindingWindow() {
+        let headers: [AnyHashable: Any] = [
+            "anthropic-ratelimit-unified-status": "throttled",
+            "anthropic-ratelimit-unified-representative-claim": "five_hour",
+            "anthropic-ratelimit-unified-5h-utilization": "1.0",
+            "anthropic-ratelimit-unified-7d-utilization": "1.0",
+        ]
+
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
+        #expect(usage.fiveHourStatus == "throttled")
+        #expect(usage.sevenDayStatus == "allowed")
+        #expect(usage.isWindowThrottled(RateLimitUsage.fiveHourWindow) == true)
+        #expect(usage.isWindowThrottled(RateLimitUsage.sevenDayWindow) == false)
+    }
+
     @Test func parse_clampsUtilizationAboveOne() {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
@@ -178,6 +193,29 @@ struct RateLimitUsageTests {
         #expect(usage?.fiveHourReset?.timeIntervalSince1970 == 1700000000)
         #expect(usage?.sevenDayReset?.timeIntervalSince1970 == 1700500000)
         #expect(usage?.overallStatus == "allowed")
+    }
+
+    @Test func parse_clientDataJSON_overallThrottledWithoutWindowStatuses_onlyMarksBindingWindow() throws {
+        let data = try #require("""
+        {
+          "rate_limits": {
+            "status": "throttled",
+            "representative_claim": "five_hour",
+            "five_hour": {
+              "utilization": 1.0
+            },
+            "seven_day": {
+              "utilization": 1.0
+            }
+          }
+        }
+        """.data(using: .utf8))
+
+        let usage = try #require(RateLimitUsage.parse(clientData: data))
+        #expect(usage.fiveHourStatus == "throttled")
+        #expect(usage.sevenDayStatus == "allowed")
+        #expect(usage.isWindowThrottled(RateLimitUsage.fiveHourWindow) == true)
+        #expect(usage.isWindowThrottled(RateLimitUsage.sevenDayWindow) == false)
     }
 
     // MARK: - Computed properties

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "2.1.2"
-        CURRENT_PROJECT_VERSION: "14"
+        MARKETING_VERSION: "2.1.3"
+        CURRENT_PROJECT_VERSION: "15"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- fix per-window throttled rendering so 7-day does not show throttled when only 5-hour is throttled
- remove the rotating footer source text so the footer stays on Updated/Cached timestamps
- tighten the menu bar pill by trimming trailing icon padding

## Verification
- swift build
- added regression coverage for per-window throttled state
