### PR TITLE
fix: consistent token counting across all display areas

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/AIBattery/Models/UsageSnapshot.swift
+++ b/AIBattery/Models/UsageSnapshot.swift
@@ -89,7 +89,7 @@ struct UsageSnapshot: Equatable {
     let sevenDayTokens: Int
     /// 5-hour 15-minute token buckets for the chart (bucket 0 = oldest, 19 = now).
     let fiveHourTokenBuckets: [Int: Int]
-    /// Per-date token totals for 7D and 12M chart modes (date-key → input+output tokens).
+    /// Per-date token totals for 7D and 12M chart modes (date-key → all token types).
     let dailyTokenTotals: [String: Int]
 
     // Windowed model tokens for Insights cost breakdown (JSONL-only, not ledger-merged)

--- a/AIBattery/Models/UsageSnapshot.swift
+++ b/AIBattery/Models/UsageSnapshot.swift
@@ -118,6 +118,36 @@ struct UsageSnapshot: Equatable {
         }
     }
 
+    /// Token total for the 5-hour rate limit window, aligned to the actual window boundary.
+    /// Uses the reset time to determine when the current window started, then sums only
+    /// the 15-minute buckets within that window. Falls back to the full trailing sum.
+    func fiveHourWindowTokens(resetsAt: Date?) -> Int {
+        guard let resetsAt else { return fiveHourTokens }
+        let remaining = resetsAt.timeIntervalSinceNow
+        guard remaining > 0 else { return fiveHourTokens }
+        let elapsed = 5 * 3600.0 - remaining
+        guard elapsed > 0 else { return 0 }
+        // Each bucket = 15 min. Bucket 19 = now, bucket 0 = 5h ago.
+        let bucketsElapsed = min(20, Int(elapsed / 900) + 1)
+        let startBucket = 20 - bucketsElapsed
+        return (startBucket..<20).reduce(0) { $0 + (fiveHourTokenBuckets[$1] ?? 0) }
+    }
+
+    /// Token total for the 7-day rate limit window, aligned to the actual window boundary.
+    /// Sums daily token totals from the window start date onward.
+    func sevenDayWindowTokens(resetsAt: Date?) -> Int {
+        guard let resetsAt else { return sevenDayTokens }
+        let remaining = resetsAt.timeIntervalSinceNow
+        guard remaining > 0 else { return sevenDayTokens }
+        let elapsed = 7 * 24 * 3600.0 - remaining
+        guard elapsed > 0 else { return 0 }
+        let windowStart = Date().addingTimeInterval(-elapsed)
+        let windowStartKey = DateFormatters.dateKey.string(from: windowStart)
+        return dailyTokenTotals.reduce(0) { total, entry in
+            entry.key >= windowStartKey ? total + entry.value : total
+        }
+    }
+
     /// Whether the 5h/7d data comes from local token estimation (no API data).
     var isUsingLocalEstimate: Bool {
         rateLimits == nil && (fiveHourTokens > 0 || sevenDayTokens > 0)

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -109,6 +109,9 @@ final class UsageAggregator: @unchecked Sendable {
         // All-time model tokens from JSONL entries not covered by stats-cache
         let cachedDates = Set(statsCache?.dailyModelTokens.map(\.date) ?? [])
         var uncachedModelTokensMap: TokenMap = [:]
+        // All JSONL model tokens (all dates) — used as a floor for all-time totals
+        // so that Projects (JSONL-only) never exceeds All Time.
+        var allJsonlModelTokensMap: TokenMap = [:]
         var jsonlTodayToolCalls = 0
 
         // Project accumulators (keyed by cwd → model → tokens)
@@ -192,6 +195,17 @@ final class UsageAggregator: @unchecked Sendable {
                     e.output + entry.outputTokens,
                     e.cacheRead + entry.cacheReadTokens,
                     e.cacheWrite + entry.cacheWriteTokens
+                )
+            }
+
+            // Accumulate all JSONL model tokens (all dates) as a floor for all-time totals.
+            if entry.model.hasPrefix("claude-") {
+                let j = allJsonlModelTokensMap[entry.model] ?? (0, 0, 0, 0)
+                allJsonlModelTokensMap[entry.model] = (
+                    j.input + entry.inputTokens,
+                    j.output + entry.outputTokens,
+                    j.cacheRead + entry.cacheReadTokens,
+                    j.cacheWrite + entry.cacheWriteTokens
                 )
             }
 
@@ -281,6 +295,18 @@ final class UsageAggregator: @unchecked Sendable {
                 output: existing.output + tokens.output,
                 cacheRead: existing.cacheRead + tokens.cacheRead,
                 cacheWrite: existing.cacheWrite + tokens.cacheWrite
+            )
+        }
+        // Ensure all-time per-model totals are never less than JSONL-only totals.
+        // Stats-cache can be stale (not rebuilt since new JSONL entries were added for
+        // a cached date), which would make Projects (all JSONL) exceed All Time.
+        for (model, jsonl) in allJsonlModelTokensMap {
+            let existing = modelTokensMap[model] ?? (0, 0, 0, 0)
+            modelTokensMap[model] = (
+                input: max(existing.input, jsonl.input),
+                output: max(existing.output, jsonl.output),
+                cacheRead: max(existing.cacheRead, jsonl.cacheRead),
+                cacheWrite: max(existing.cacheWrite, jsonl.cacheWrite)
             )
         }
         let rawModelTokens = Self.buildModelTokens(from: modelTokensMap)

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -181,7 +181,8 @@ final class UsageAggregator: @unchecked Sendable {
                 sevenDayTokens += entryAllTokens
             }
             // Daily token totals (all dates, for 7D and 12M charts)
-            dailyTokenTotals[dateKey, default: 0] += entryTokens
+            // Uses all token types to match 5h/7d summary totals and model breakdowns.
+            dailyTokenTotals[dateKey, default: 0] += entryAllTokens
 
             // All-time model tokens from dates not in stats-cache
             if !cachedDates.contains(dateKey) {

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -169,8 +169,7 @@ final class UsageAggregator: @unchecked Sendable {
             // --- 5-hour and 7-day token totals for local usage estimation ---
             // Include all token types: Anthropic's unified rate limit counts input, output,
             // cache read, and cache write tokens toward the 5h/7d budget.
-            let entryTokens = entry.inputTokens + entry.outputTokens
-            let entryAllTokens = entryTokens + entry.cacheReadTokens + entry.cacheWriteTokens
+            let entryAllTokens = entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens
             if ts >= fiveHoursAgo {
                 fiveHourTokens += entryAllTokens
                 // 15-minute bucket: offset 0 = 5h ago, offset 19 = now

--- a/AIBattery/Utilities/TokenFormatter.swift
+++ b/AIBattery/Utilities/TokenFormatter.swift
@@ -11,9 +11,14 @@ enum TokenFormatter {
             // Avoid "1000K" — show "1.0M" instead when rounding pushes past 999
             if k >= 999.5 { return "1.0M" }
             return k < 10 ? String(format: "%.1fK", k) : String(format: "%.0fK", k)
-        default:
+        case 1_000_000..<1_000_000_000:
             let m = Double(count) / 1_000_000.0
+            // Avoid "1000M" — show "1.0B" instead when rounding pushes past 999
+            if m >= 999.5 { return "1.0B" }
             return m < 10 ? String(format: "%.1fM", m) : String(format: "%.0fM", m)
+        default:
+            let b = Double(count) / 1_000_000_000.0
+            return b < 10 ? String(format: "%.1fB", b) : String(format: "%.0fB", b)
         }
     }
 

--- a/AIBattery/Views/ActivityChartData.swift
+++ b/AIBattery/Views/ActivityChartData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Pure data transformations for activity charts — extracted from InsightsView for testability.
-/// All chart modes show token counts (input+output) rather than message counts.
+/// All chart modes show token counts (all types) rather than message counts.
 enum ActivityChartData {
 
     struct DailyPoint: Identifiable {

--- a/AIBattery/Views/ActivityChartTrend.swift
+++ b/AIBattery/Views/ActivityChartTrend.swift
@@ -84,16 +84,15 @@ enum ActivityTrendComputation {
     // MARK: - Comparison helpers
 
     static func changeVsYesterday(_ snapshot: UsageSnapshot, cal: Calendar = .current, now: Date = .init()) -> ActivityChangeInfo? {
+        let todayStr = DateFormatters.dateKey.string(from: now)
         let yesterdayStr = DateFormatters.dateKey.string(
             from: cal.date(byAdding: .day, value: -1, to: now) ?? now
         )
 
-        guard let yesterday = snapshot.dailyActivity.first(where: { $0.date == yesterdayStr }) else {
-            return nil
-        }
-
-        let diff = snapshot.todayMessages - yesterday.messageCount
-        return changeInfo(diff: diff, suffix: "vs yesterday")
+        let todayTokens = snapshot.dailyTokenTotals[todayStr] ?? 0
+        let yesterdayTokens = snapshot.dailyTokenTotals[yesterdayStr]
+        guard let yesterdayTokens, yesterdayTokens > 0 else { return nil }
+        return percentChangeInfo(current: todayTokens, previous: yesterdayTokens, suffix: "vs yesterday")
     }
 
     static func changeVsLastWeek(_ snapshot: UsageSnapshot, cal: Calendar = .current, now: Date = .init()) -> ActivityChangeInfo? {
@@ -109,14 +108,14 @@ enum ActivityTrendComputation {
         let thisWeekRange = DateFormatters.dateKey.string(from: thisWeekStart)...DateFormatters.dateKey.string(from: today)
         let lastWeekRange = DateFormatters.dateKey.string(from: lastWeekStart)...DateFormatters.dateKey.string(from: lastWeekSameDay)
 
-        // Single pass: accumulate both week totals simultaneously
+        // Single pass: accumulate both week token totals simultaneously
         var thisWeekTotal = 0
         var lastWeekTotal = 0
-        for day in snapshot.dailyActivity {
-            if thisWeekRange.contains(day.date) {
-                thisWeekTotal += day.messageCount
-            } else if lastWeekRange.contains(day.date) {
-                lastWeekTotal += day.messageCount
+        for (date, tokens) in snapshot.dailyTokenTotals {
+            if thisWeekRange.contains(date) {
+                thisWeekTotal += tokens
+            } else if lastWeekRange.contains(date) {
+                lastWeekTotal += tokens
             }
         }
 

--- a/AIBattery/Views/ActivityChartTrend.swift
+++ b/AIBattery/Views/ActivityChartTrend.swift
@@ -57,6 +57,7 @@ enum ActivityTrendComputation {
             }
             let thisMonth = thisMonthKey.flatMap { monthTotals[$0] } ?? 0
             let lastMonth = lastMonthKey.flatMap { monthTotals[$0] } ?? 0
+            let twelveMonthTotal = monthTotals.values.reduce(0, +)
             let busiestLabel: String? = {
                 guard let peak = monthTotals.max(by: { $0.value < $1.value }),
                       let date = DateFormatters.dateKey.date(from: peak.key + "-01") else { return nil }
@@ -64,7 +65,7 @@ enum ActivityTrendComputation {
             }()
             return ActivityTrendData(
                 change: monthChangeInfo(thisMonth: thisMonth, lastMonth: lastMonth, cal: cal, now: now),
-                stat: thisMonth > 0 ? "\(InsightsView.compactCount(thisMonth)) this month" : nil,
+                stat: twelveMonthTotal > 0 ? "\(InsightsView.compactCount(twelveMonthTotal)) in 12m" : nil,
                 throttleCount: UsageViewModel.throttleCount(days: 30),
                 peak: busiestLabel.map { "Peak: \($0)" },
                 throttleDays: 30

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -91,26 +91,6 @@ struct InsightsView: View {
         }
     }
 
-    /// Formatted token total for the current time window, shown next to the mode picker.
-    private var windowTokenTotal: String? {
-        guard let snap = snapshot else { return nil }
-        let total: Int
-        switch mode {
-        case .fiveHour:
-            total = snap.fiveHourTokens
-        case .sevenDay:
-            total = snap.sevenDayTokens
-        case .monthly:
-            let cal = Calendar.current
-            let comps = cal.dateComponents([.year, .month], from: Date())
-            guard let y = comps.year, let m = comps.month else { return nil }
-            let key = String(format: "%04d-%02d", y, m)
-            total = cachedMonthTotals[key] ?? 0
-        }
-        guard total > 0 else { return nil }
-        return TokenFormatter.format(total)
-    }
-
     /// Brief summary shown in the collapsed header when no trend data is available.
     private func collapsedSummary(_ snap: UsageSnapshot) -> String {
         let todayTokens = snap.todayModelTokens.reduce(0) { $0 + $1.totalTokens }
@@ -150,11 +130,6 @@ struct InsightsView: View {
                     }
                 }
                 if !collapsed {
-                    if let windowTotal = windowTokenTotal {
-                        Text(windowTotal)
-                            .font(Typography.monoCaption)
-                            .foregroundStyle(ThemeColors.secondaryLabel)
-                    }
                     Picker("", selection: $modeRaw) {
                         ForEach(ActivityChartMode.allCases, id: \.rawValue) { m in
                             Text(m.rawValue).tag(m.rawValue)

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -93,7 +93,7 @@ struct InsightsView: View {
 
     /// Brief summary shown in the collapsed header when no trend data is available.
     private func collapsedSummary(_ snap: UsageSnapshot) -> String {
-        let todayTokens = snap.todayModelTokens.reduce(0) { $0 + $1.inputTokens + $1.outputTokens }
+        let todayTokens = snap.todayModelTokens.reduce(0) { $0 + $1.totalTokens }
         if todayTokens > 0 {
             return "\(TokenFormatter.format(todayTokens)) today"
         }

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -91,6 +91,26 @@ struct InsightsView: View {
         }
     }
 
+    /// Formatted token total for the current time window, shown next to the mode picker.
+    private var windowTokenTotal: String? {
+        guard let snap = snapshot else { return nil }
+        let total: Int
+        switch mode {
+        case .fiveHour:
+            total = snap.fiveHourTokens
+        case .sevenDay:
+            total = snap.sevenDayTokens
+        case .monthly:
+            let cal = Calendar.current
+            let comps = cal.dateComponents([.year, .month], from: Date())
+            guard let y = comps.year, let m = comps.month else { return nil }
+            let key = String(format: "%04d-%02d", y, m)
+            total = cachedMonthTotals[key] ?? 0
+        }
+        guard total > 0 else { return nil }
+        return TokenFormatter.format(total)
+    }
+
     /// Brief summary shown in the collapsed header when no trend data is available.
     private func collapsedSummary(_ snap: UsageSnapshot) -> String {
         let todayTokens = snap.todayModelTokens.reduce(0) { $0 + $1.totalTokens }
@@ -130,6 +150,11 @@ struct InsightsView: View {
                     }
                 }
                 if !collapsed {
+                    if let windowTotal = windowTokenTotal {
+                        Text(windowTotal)
+                            .font(Typography.monoCaption)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
+                    }
                     Picker("", selection: $modeRaw) {
                         ForEach(ActivityChartMode.allCases, id: \.rawValue) { m in
                             Text(m.rawValue).tag(m.rawValue)

--- a/AIBattery/Views/InsightsRowsAndHover.swift
+++ b/AIBattery/Views/InsightsRowsAndHover.swift
@@ -157,8 +157,13 @@ extension InsightsView {
     /// Compact integer counts for chart axes (e.g. 1500 → "2K").
     /// Differs from TokenFormatter which formats fractional token values (e.g. 1500 → "1.5K").
     static func compactCount(_ value: Int) -> String {
+        if value >= 1_000_000_000 {
+            let b = Double(value) / 1_000_000_000
+            return b == b.rounded() ? "\(Int(b))B" : String(format: "%.1fB", b)
+        }
         if value >= 1_000_000 {
             let m = Double(value) / 1_000_000
+            if m >= 999.5 { return "1.0B" }
             return m == m.rounded() ? "\(Int(m))M" : String(format: "%.1fM", m)
         }
         if value >= 1_000 {

--- a/AIBattery/Views/InsightsRowsAndHover.swift
+++ b/AIBattery/Views/InsightsRowsAndHover.swift
@@ -31,13 +31,13 @@ extension InsightsView {
             )
         }
 
-        // All Time — uses usageTokens (input+output) to exclude cache inflation
+        // All Time — uses totalTokens (all types) to match model breakdown and chart data
         insightRow(
             label: "All Time",
-            value: "\(TokenFormatter.format(snapshot.totalUsageTokens)) tokens \u{00B7} \(snapshot.totalSessions) sessions",
-            tooltip: "Cumulative input + output tokens across all sessions"
+            value: "\(TokenFormatter.format(snapshot.totalTokens)) tokens \u{00B7} \(snapshot.totalSessions) sessions",
+            tooltip: "Cumulative tokens across all sessions"
         )
-        .accessibilityLabel("All time: \(TokenFormatter.format(snapshot.totalUsageTokens)) tokens, \(snapshot.totalSessions) sessions")
+        .accessibilityLabel("All time: \(TokenFormatter.format(snapshot.totalTokens)) tokens, \(snapshot.totalSessions) sessions")
 
     }
 

--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -92,7 +92,7 @@ struct ProjectUsageSection: View {
     // MARK: - Header
 
     private var headerRow: some View {
-        let totalTokensText = TokenFormatter.format(snapshot.totalProjectUsageTokens)
+        let totalTokensText = TokenFormatter.format(snapshot.totalProjectTokens)
         let costText = "~\(ModelPricing.formatCompactCost(snapshot.totalProjectCost))"
         return HStack {
             CollapsibleSectionHeader(
@@ -159,7 +159,7 @@ struct ProjectUsageSection: View {
     // MARK: - Project row
 
     private func projectRow(_ project: ProjectTokenSummary, index: Int) -> some View {
-        let tokensText = TokenFormatter.format(project.usageTokens)
+        let tokensText = TokenFormatter.format(project.totalTokens)
         let costText = "~\(ModelPricing.formatCompactCost(project.estimatedCost))"
         let copyText = "\(project.projectName) \u{00B7} \(costText) \u{00B7} \(tokensText)"
         return HStack(spacing: Spacing.gap) {

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -104,6 +104,7 @@ struct UsageBar: View {
                     Text(TokenFormatter.format(tokenTotal))
                         .font(Typography.monoCaption)
                         .foregroundStyle(ThemeColors.secondaryLabel)
+                        .frame(width: Layout.tokenColumn, alignment: .trailing)
                         .copyable("\(tokenTotal) tokens")
                 }
                 Text("\(Int(displayPercent))%")

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -103,7 +103,7 @@ struct UsageBar: View {
                 if tokenTotal > 0 {
                     Text(TokenFormatter.format(tokenTotal))
                         .font(Typography.monoCaption)
-                        .foregroundStyle(.white.opacity(0.2))
+                        .foregroundStyle(.white.opacity(0.7))
                         .frame(width: Layout.tokenColumn, alignment: .trailing)
                         .copyable("\(tokenTotal) tokens")
                 }

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FiveHourBarSection: View {
     let limits: RateLimitUsage
     let source: RateLimitSource?
+    var tokenTotal: Int = 0
 
     var body: some View {
         UsageBar(
@@ -13,7 +14,8 @@ struct FiveHourBarSection: View {
             source: source,
             isBinding: limits.representativeClaim == RateLimitUsage.fiveHourWindow,
             isThrottled: limits.isWindowThrottled(RateLimitUsage.fiveHourWindow),
-            estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.fiveHourWindow)
+            estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.fiveHourWindow),
+            tokenTotal: tokenTotal
         )
         .padding(.horizontal, Spacing.sectionHorizontal)
         .padding(.vertical, Spacing.section)
@@ -24,6 +26,7 @@ struct FiveHourBarSection: View {
 struct SevenDayBarSection: View {
     let limits: RateLimitUsage
     let source: RateLimitSource?
+    var tokenTotal: Int = 0
 
     var body: some View {
         UsageBar(
@@ -33,7 +36,8 @@ struct SevenDayBarSection: View {
             source: source,
             isBinding: limits.representativeClaim == RateLimitUsage.sevenDayWindow,
             isThrottled: limits.isWindowThrottled(RateLimitUsage.sevenDayWindow),
-            estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.sevenDayWindow)
+            estimatedTimeToLimit: limits.estimatedTimeToLimit(for: RateLimitUsage.sevenDayWindow),
+            tokenTotal: tokenTotal
         )
         .padding(.horizontal, Spacing.sectionHorizontal)
         .padding(.vertical, Spacing.section)
@@ -48,6 +52,7 @@ struct UsageBar: View {
     var isBinding: Bool = false
     var isThrottled: Bool = false
     var estimatedTimeToLimit: TimeInterval?
+    var tokenTotal: Int = 0
 
     /// Display percent — clamps to 100 when throttled so the UI doesn't show "99% Throttled".
     private var displayPercent: Double { isThrottled ? max(percent, 100) : percent }
@@ -95,6 +100,12 @@ struct UsageBar: View {
                     }
                 }
                 Spacer()
+                if tokenTotal > 0 {
+                    Text(TokenFormatter.format(tokenTotal))
+                        .font(Typography.monoCaption)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
+                        .copyable("\(tokenTotal) tokens")
+                }
                 Text("\(Int(displayPercent))%")
                     .font(Typography.monoValue)
                     .copyable("\(Int(displayPercent))%")

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -103,7 +103,7 @@ struct UsageBar: View {
                 if tokenTotal > 0 {
                     Text(TokenFormatter.format(tokenTotal))
                         .font(Typography.monoCaption)
-                        .foregroundStyle(ThemeColors.tertiaryLabel)
+                        .foregroundStyle(.white.opacity(0.2))
                         .frame(width: Layout.tokenColumn, alignment: .trailing)
                         .copyable("\(tokenTotal) tokens")
                 }

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -103,7 +103,7 @@ struct UsageBar: View {
                 if tokenTotal > 0 {
                     Text(TokenFormatter.format(tokenTotal))
                         .font(Typography.monoCaption)
-                        .foregroundStyle(ThemeColors.secondaryLabel)
+                        .foregroundStyle(ThemeColors.tertiaryLabel)
                         .frame(width: Layout.tokenColumn, alignment: .trailing)
                         .copyable("\(tokenTotal) tokens")
                 }

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -157,7 +157,7 @@ public struct UsagePopoverView: View {
                     switch mode {
                     case .fiveHour:
                         if let limits = snapshot.rateLimits {
-                            FiveHourBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.fiveHourTokens)
+                            FiveHourBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.fiveHourWindowTokens(resetsAt: limits.fiveHourReset))
                             StyledDivider()
                         } else if snapshot.isUsingLocalEstimate {
                             LocalEstimateSection(
@@ -172,7 +172,7 @@ public struct UsagePopoverView: View {
                         }
                     case .sevenDay:
                         if let limits = snapshot.rateLimits {
-                            SevenDayBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.sevenDayTokens)
+                            SevenDayBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.sevenDayWindowTokens(resetsAt: limits.sevenDayReset))
                             StyledDivider()
                         } else if snapshot.isUsingLocalEstimate {
                             LocalEstimateSection(

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -157,7 +157,7 @@ public struct UsagePopoverView: View {
                     switch mode {
                     case .fiveHour:
                         if let limits = snapshot.rateLimits {
-                            FiveHourBarSection(limits: limits, source: snapshot.rateLimitSource)
+                            FiveHourBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.fiveHourTokens)
                             StyledDivider()
                         } else if snapshot.isUsingLocalEstimate {
                             LocalEstimateSection(
@@ -172,7 +172,7 @@ public struct UsagePopoverView: View {
                         }
                     case .sevenDay:
                         if let limits = snapshot.rateLimits {
-                            SevenDayBarSection(limits: limits, source: snapshot.rateLimitSource)
+                            SevenDayBarSection(limits: limits, source: snapshot.rateLimitSource, tokenTotal: snapshot.sevenDayTokens)
                             StyledDivider()
                         } else if snapshot.isUsingLocalEstimate {
                             LocalEstimateSection(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.1.4] — 2026-04-08
+
+### Fixed
+- **Consistent token counting** — all display areas (charts, summaries, model breakdown, projects, All Time) now use the same token counting method (all 4 types: input, output, cache read, cache write), fixing massive discrepancies where 7D chart showed 200K while the summary said 515.9M
+- **"vs yesterday"/"vs last week" compared messages, not tokens** — trend comparisons now use token counts matching the charts
+- **12M stat showed current month only** — now shows full 12-month total to match 5H/7D pattern
+- **Projects could exceed All Time** — added JSONL floor guarantee so All Time is never less than Projects
+- **Billion formatting** — TokenFormatter and chart axes now handle billion-scale values (previously 1.5B displayed as "1500M")
+
+### Added
+- **Token totals on rate limit bars** — 5-Hour and 7-Day bars show total tokens consumed in the active window, aligned to the actual rate limit boundary so the count resets with the window
+
 ## [2.1.3] — 2026-04-08
 
 ### Fixed

--- a/Tests/AIBatteryCoreTests/Utilities/TokenFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/TokenFormatterTests.swift
@@ -60,6 +60,24 @@ struct TokenFormatterTests {
         #expect(TokenFormatter.format(150_000_000) == "150M")
     }
 
+    @Test func format_999M() {
+        #expect(TokenFormatter.format(999_999_999) == "1.0B")
+    }
+
+    // MARK: - Billions (B)
+
+    @Test func format_exactly1B() {
+        #expect(TokenFormatter.format(1_000_000_000) == "1.0B")
+    }
+
+    @Test func format_3_2B() {
+        #expect(TokenFormatter.format(3_200_000_000) == "3.2B")
+    }
+
+    @Test func format_10B() {
+        #expect(TokenFormatter.format(10_000_000_000) == "10B")
+    }
+
     // MARK: - Edge cases
 
     @Test func format_1() {
@@ -90,5 +108,15 @@ struct TokenFormatterTests {
     @Test func format_boundaryAt10M() {
         #expect(TokenFormatter.format(9_999_999) == "10.0M")
         #expect(TokenFormatter.format(10_000_000) == "10M")
+    }
+
+    @Test func format_boundaryAt1B() {
+        #expect(TokenFormatter.format(999_999_999) == "1.0B")
+        #expect(TokenFormatter.format(1_000_000_000) == "1.0B")
+    }
+
+    @Test func format_boundaryAt10B() {
+        #expect(TokenFormatter.format(9_999_999_999) == "10.0B")
+        #expect(TokenFormatter.format(10_000_000_000) == "10B")
     }
 }

--- a/Tests/AIBatteryCoreTests/Views/ActivityTrendTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/ActivityTrendTests.swift
@@ -11,40 +11,37 @@ struct ActivityTrendTests {
     @Test func changeVsYesterday_positive() {
         let cal = Calendar.current
         let now = Date()
+        let todayStr = DateFormatters.dateKey.string(from: now)
         let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(todayMessages: 15, dailyActivity: [
-            DailyActivity(date: yesterdayStr, messageCount: 10, sessionCount: 1, toolCallCount: 0)
-        ])
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 15000, yesterdayStr: 10000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "↑")
-        #expect(change?.label == "+5 vs yesterday")
+        #expect(change?.label == "+50% vs yesterday")
     }
 
     @Test func changeVsYesterday_negative() {
         let cal = Calendar.current
         let now = Date()
+        let todayStr = DateFormatters.dateKey.string(from: now)
         let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(todayMessages: 5, dailyActivity: [
-            DailyActivity(date: yesterdayStr, messageCount: 10, sessionCount: 1, toolCallCount: 0)
-        ])
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 5000, yesterdayStr: 10000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "↓")
-        #expect(change?.label == "-5 vs yesterday")
+        #expect(change?.label == "-50% vs yesterday")
     }
 
     @Test func changeVsYesterday_same() {
         let cal = Calendar.current
         let now = Date()
+        let todayStr = DateFormatters.dateKey.string(from: now)
         let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(todayMessages: 10, dailyActivity: [
-            DailyActivity(date: yesterdayStr, messageCount: 10, sessionCount: 1, toolCallCount: 0)
-        ])
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 10000, yesterdayStr: 10000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "→")
     }
 
     @Test func changeVsYesterday_nilWhenNoYesterdayData() {
-        let snapshot = makeSnapshot(todayMessages: 10, dailyActivity: [])
+        let snapshot = makeSnapshot(dailyTokenTotals: [:])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot)
         #expect(change == nil)
     }
@@ -105,7 +102,8 @@ struct ActivityTrendTests {
 
     private func makeSnapshot(
         todayMessages: Int = 0,
-        dailyActivity: [DailyActivity] = []
+        dailyActivity: [DailyActivity] = [],
+        dailyTokenTotals: [String: Int] = [:]
     ) -> UsageSnapshot {
         let stats = UsageSnapshot.computeActivityStats(dailyActivity)
         return UsageSnapshot(
@@ -132,7 +130,7 @@ struct ActivityTrendTests {
             fiveHourTokens: 0,
             sevenDayTokens: 0,
             fiveHourTokenBuckets: [:],
-            dailyTokenTotals: [:],
+            dailyTokenTotals: dailyTokenTotals,
             todayModelTokens: [],
             weekModelTokens: [],
             monthModelTokens: [],


### PR DESCRIPTION
## Summary

Unified token counting across all display areas, added token totals to rate limit bars with window-aligned counting, and fixed trend comparisons.

### Bugs fixed

- **7D/12M charts wrong scale**: `dailyTokenTotals` used input+output only while summaries used all tokens. Cache dominates (~99%), so 7D chart showed ~200K while summary said "515.9M tokens in 7d"
- **"All Time" mismatched model breakdown**: Showed 10M (usage-only) while model rows summed to 5.4B (all tokens)
- **Projects section mismatched**: Header/rows used usage-only tokens while model breakdown used all tokens
- **Projects could exceed All Time**: JSONL-only Projects vs stats-cache-based All Time could diverge when stats-cache is stale — added JSONL floor guarantee
- **Collapsed insights summary**: Manually summed input+output, missing cache tokens
- **"vs yesterday"/"vs last week" compared messages, not tokens**: Charts show tokens but trend comparisons used message counts
- **12M stat showed current month only**: Now shows full 12-month total to match 5H/7D pattern
- **Formatters couldn't display billions**: 1.5B would show as "1500M"

### Features

- **Token totals on rate limit bars**: 5-Hour and 7-Day bars show tokens consumed in the active window, aligned to the actual rate limit boundary via `resetsAt`. When a window resets, the count starts from 0.

### Changes (12 files, +148 -44)

| File | Change |
|------|--------|
| `UsageSnapshot.swift` | Added `fiveHourWindowTokens(resetsAt:)` and `sevenDayWindowTokens(resetsAt:)` for window-aligned counting |
| `UsageAggregator.swift` | `dailyTokenTotals` uses all tokens; JSONL floor for All Time >= Projects; removed dead variable |
| `UsageBarsSection.swift` | Added `tokenTotal` to UsageBar with 70% white color and column alignment |
| `UsagePopoverView.swift` | Pass window-aligned token totals to bar sections |
| `ActivityChartTrend.swift` | Trend comparisons use tokens; 12M stat shows full 12-month total |
| `TokenFormatter.swift` | Billion-scale formatting with 999M→1.0B rollover |
| `InsightsRowsAndHover.swift` | "All Time" uses `totalTokens`; `compactCount()` handles billions |
| `ActivityChartView.swift` | Collapsed summary uses `totalTokens` |
| `ProjectUsageSection.swift` | Header/rows use `totalTokens` |
| `TokenFormatterTests.swift` | +6 billion-scale tests |
| `ActivityTrendTests.swift` | Updated for token-based comparisons |

## Test plan

- [ ] **5-Hour bar**: token total resets when window resets, aligns with rate limit %
- [ ] **7-Day bar**: token total resets when window resets, aligns with rate limit %
- [ ] **7D chart**: Y-axis scale matches "X tokens in 7d" summary
- [ ] **12M chart**: scale matches model breakdown; stat shows 12-month total
- [ ] **All Time** total >= sum of model breakdown rows
- [ ] **Projects** total never exceeds All Time total
- [ ] **"vs yesterday"/"vs last week"**: shows % change based on tokens
- [ ] **Large values**: display as "X.XB" not "XXXXM"
- [ ] **Collapsed Insights**: shows correct token-based trend or summary