### PR TITLE
release: v2.1.7 — menu bar appearance, design consistency, accessibility

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.6</string>
+	<string>2.1.7</string>
 	<key>CFBundleVersion</key>
-	<string>2.1.6</string>
+	<string>2.1.7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -176,7 +176,8 @@ struct RateLimitUsage: Equatable, Codable {
 
         func dateFromUnix(_ key: String) -> Date? {
             guard let val = normalized[key.lowercased()],
-                  let ts = TimeInterval(val) else { return nil }
+                  let ts = TimeInterval(val),
+                  ts > 0, ts < Date().timeIntervalSince1970 + 30 * 86400 else { return nil }
             return Date(timeIntervalSince1970: ts)
         }
 

--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -177,7 +177,7 @@ struct RateLimitUsage: Equatable, Codable {
         func dateFromUnix(_ key: String) -> Date? {
             guard let val = normalized[key.lowercased()],
                   let ts = TimeInterval(val),
-                  ts > 0, ts < Date().timeIntervalSince1970 + 30 * 86400 else { return nil }
+                  ts > 0, ts < Date().timeIntervalSince1970 + 8 * 86400 else { return nil }
             return Date(timeIntervalSince1970: ts)
         }
 

--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -586,12 +586,14 @@ final class RateLimitFetcher {
                 defaults.removeObject(forKey: key)
                 continue
             }
+            // Discard cache entries with future fetchedAt (system clock went backward)
+            let fetchedAt = persisted.fetchedAt <= Date() ? persisted.fetchedAt : Date()
             cachedResults[accountId] = APIFetchResult(
                 rateLimits: persisted.rateLimits,
                 rateLimitSource: persisted.rateLimitSource,
                 standardLimits: persisted.standardLimits,
                 profile: nil,
-                fetchedAt: persisted.fetchedAt,
+                fetchedAt: fetchedAt,
                 isCached: true
             )
         }

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -171,7 +171,7 @@ final class UsageAggregator: @unchecked Sendable {
             } else {
                 let entryDay = calendar.startOfDay(for: ts)
                 lastDayStart = entryDay
-                lastDayEnd = calendar.date(byAdding: .day, value: 1, to: entryDay) ?? entryDay.addingTimeInterval(Self.twentyFourHourWindow)
+                lastDayEnd = entryDay.addingTimeInterval(86400)
                 dateKey = Self.dateFormatter.string(from: ts)
                 lastDateKey = dateKey
             }

--- a/AIBattery/Utilities/Spacing.swift
+++ b/AIBattery/Utilities/Spacing.swift
@@ -129,6 +129,9 @@ enum Layout {
 
     /// Glow radius for active indicator (auto mode button).
     static let glowRadius: CGFloat = 4
+
+    /// Standard stroke width for borders and focus rings.
+    static let borderWidth: CGFloat = 1.5
 }
 
 /// Animation duration constants for the AI Battery popover.

--- a/AIBattery/Utilities/ThemeColors.swift
+++ b/AIBattery/Utilities/ThemeColors.swift
@@ -249,19 +249,24 @@ enum ThemeColors {
         dark: NSColor(white: 1.0, alpha: 0.06)
     )
 
+    /// Deep gold for the menu bar star on light backgrounds where systemYellow washes out.
+    static let menuBarGold = NSColor(red: 0.72, green: 0.56, blue: 0.0, alpha: 1.0)
+
     /// NSColor variant for menu bar icon — rate limit thresholds (50/80/95).
-    static func barNSColor(percent: Double) -> NSColor {
+    /// When `isDarkMenuBar` is provided, the 50-79% band uses a darker gold on light
+    /// backgrounds for contrast (systemYellow is nearly invisible on a light menu bar).
+    static func barNSColor(percent: Double, isDarkMenuBar: Bool? = nil) -> NSColor {
         if isColorblind {
             switch percent {
             case 0..<50: return .systemBlue
-            case 50..<80: return .systemTeal
+            case 50..<80: return isDarkMenuBar == false ? menuBarGold : .systemTeal
             case 80..<95: return NSColor(red: 1.0, green: 0.75, blue: 0.0, alpha: 1.0)
             default: return .systemPurple
             }
         }
         switch percent {
         case 0..<50: return .systemGreen
-        case 50..<80: return .systemYellow
+        case 50..<80: return isDarkMenuBar == false ? menuBarGold : .systemYellow
         case 80..<95: return .systemOrange
         default: return .systemRed
         }

--- a/AIBattery/Views/AuthView.swift
+++ b/AIBattery/Views/AuthView.swift
@@ -29,6 +29,7 @@ public struct AuthView: View {
                         .resizable()
                         .frame(width: 48, height: 48)
                         .clipShape(RoundedRectangle(cornerRadius: Layout.iconClipRadius))
+                        .accessibilityHidden(true)
                 }
                 Text("AI Battery")
                     .font(Typography.sectionHeader)

--- a/AIBattery/Views/AuthView.swift
+++ b/AIBattery/Views/AuthView.swift
@@ -34,7 +34,7 @@ public struct AuthView: View {
                     .font(Typography.sectionHeader)
                 Text(isAddingAccount ? "Add another Claude account" : "Sign in with your Claude account")
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
             }
 
             StyledDivider()
@@ -46,7 +46,7 @@ public struct AuthView: View {
                         ? "Connect another Claude account to monitor multiple orgs from AI Battery."
                         : "Connect your Anthropic account to see your usage, rate limits, and plan details.")
                         .font(Typography.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .multilineTextAlignment(.center)
 
                     Button(action: startAuth) {
@@ -74,7 +74,7 @@ public struct AuthView: View {
                             .font(Typography.caption)
                         Text("Sign in via the browser window that just opened")
                             .font(Typography.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -84,7 +84,7 @@ public struct AuthView: View {
                             .font(Typography.caption)
                         Text("Copy the authorization code shown after signing in")
                             .font(Typography.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -94,7 +94,7 @@ public struct AuthView: View {
                             .font(Typography.caption)
                         Text("Paste it below:")
                             .font(Typography.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -113,7 +113,7 @@ public struct AuthView: View {
                         }
                         .buttonStyle(.plain)
                         .font(Typography.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .accessibilityLabel("Cancel authentication")
                         .help("Go back to sign-in")
 
@@ -157,13 +157,13 @@ public struct AuthView: View {
                     Button("Cancel") { onCancel() }
                         .buttonStyle(.plain)
                         .font(Typography.tinyLabel)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .accessibilityLabel("Cancel adding account")
                 } else {
                     Button("Quit") { NSApplication.shared.terminate(nil) }
                         .buttonStyle(.plain)
                         .font(Typography.tinyLabel)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .keyboardShortcut("q", modifiers: .command)
                 }
                 Spacer()

--- a/AIBattery/Views/CollapsibleSectionHeader.swift
+++ b/AIBattery/Views/CollapsibleSectionHeader.swift
@@ -31,7 +31,7 @@ struct CollapsibleSectionHeader: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Spacing.xsmall)
-                    .stroke(isFocused ? Color.accentColor.opacity(ThemeColors.focusRingOpacity) : Color.clear, lineWidth: 1.5)
+                    .stroke(isFocused ? Color.accentColor.opacity(ThemeColors.focusRingOpacity) : Color.clear, lineWidth: Layout.borderWidth)
             )
             .contentShape(Rectangle())
         }

--- a/AIBattery/Views/CopyableText.swift
+++ b/AIBattery/Views/CopyableText.swift
@@ -23,7 +23,7 @@ struct CopyableModifier: ViewModifier {
                 if copied {
                     Image(systemName: "doc.on.clipboard.fill")
                         .font(Typography.clipboardIcon)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .transition(.scale.combined(with: .opacity))
                         .padding(.trailing, -13)
                 }

--- a/AIBattery/Views/CopyableText.swift
+++ b/AIBattery/Views/CopyableText.swift
@@ -25,6 +25,7 @@ struct CopyableModifier: ViewModifier {
                         .font(Typography.clipboardIcon)
                         .foregroundStyle(ThemeColors.secondaryLabel)
                         .transition(.scale.combined(with: .opacity))
+                        .accessibilityHidden(true)
                         .padding(.trailing, -13)
                 }
             }

--- a/AIBattery/Views/MenuBarIcon.swift
+++ b/AIBattery/Views/MenuBarIcon.swift
@@ -89,31 +89,7 @@ struct MenuBarIcon: View {
     private static let cacheLock = NSLock()
     private static var iconCache: [Int: NSImage] = [:]
     private static var cachedColorblindFlag: Bool = ThemeColors.isColorblind
-    private static var cachedHighContrastFlag: Bool = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
-    private static var cachedAppearanceName: String = NSApp?.effectiveAppearance.name.rawValue ?? ""
-
-    /// Observe accessibility changes instead of polling every frame.
-    /// Registered lazily on first icon render. Appearance (light/dark) is already
-    /// checked per-call via `cachedAppearanceName` (cheap string compare).
-    private static var accessibilityObserverRegistered = false
-
-    private static func registerAccessibilityObserverIfNeeded() {
-        cacheLock.withLock {
-            guard !accessibilityObserverRegistered else { return }
-            accessibilityObserverRegistered = true
-        }
-
-        let ws = NSWorkspace.shared
-        ws.notificationCenter.addObserver(
-            forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
-            object: nil, queue: .main
-        ) { _ in
-            cacheLock.withLock {
-                cachedHighContrastFlag = ws.accessibilityDisplayShouldIncreaseContrast
-                iconCache.removeAll()
-            }
-        }
-    }
+    private static var cachedAppearanceName: String = ""
 
     /// Returns the cached status bar NSImage. Color is provided by the caller so it can
     /// match the active metric mode (rate limit thresholds vs context health thresholds).
@@ -122,8 +98,8 @@ struct MenuBarIcon: View {
     /// macOS battery has ~1pt between text and icon; our 22pt canvas has ~4pt whitespace on each side.
     private static let iconAlignmentInsets = NSEdgeInsets(top: 0, left: 1, bottom: 0, right: 5)
 
-    static func statusBarImage(for percent: Double, color: NSColor, isBroken: Bool = false, isSparkle: Bool = false, pulseStep: Int = 0) -> NSImage {
-        cachedIcon(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: pulseStep)
+    static func statusBarImage(for percent: Double, color: NSColor, isBroken: Bool = false, isSparkle: Bool = false, pulseStep: Int = 0, menuBarAppearance: NSAppearance? = nil) -> NSImage {
+        cachedIcon(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: pulseStep, menuBarAppearance: menuBarAppearance)
     }
 
     /// Horizontal whitespace trimmed from each side of the `iconSize` canvas when
@@ -143,11 +119,15 @@ struct MenuBarIcon: View {
         percent: Double,
         color: NSColor,
         isBroken: Bool = false,
-        isSparkle: Bool = false
+        isSparkle: Bool = false,
+        menuBarAppearance: NSAppearance? = nil
     ) -> NSImage {
         let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
-        let isDarkMenuBar = NSApp?.effectiveAppearance
-            .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        // Use the status bar button's appearance — it reflects the actual menu bar
+        // backdrop (wallpaper tint, translucency) rather than NSApp.effectiveAppearance
+        // which only tracks the system-wide Light/Dark setting.
+        let appearance = menuBarAppearance ?? NSApp?.effectiveAppearance
+        let isDarkMenuBar = appearance?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let textColor: NSColor = isDarkMenuBar ? .white : .black
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
@@ -157,7 +137,7 @@ struct MenuBarIcon: View {
         let textSize = attributed.size()
         let textWidth = ceil(textSize.width)
 
-        let icon = statusBarImage(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: 0)
+        let icon = statusBarImage(for: percent, color: color, isBroken: isBroken, isSparkle: isSparkle, pulseStep: 0, menuBarAppearance: menuBarAppearance)
         let canvasSize = icon.size.width // 22pt, contains star + halo with ~3pt padding each side
         let iconVisibleWidth = canvasSize - 2 * iconCanvasPadding
         let gap: CGFloat = 2
@@ -185,16 +165,14 @@ struct MenuBarIcon: View {
         return image
     }
 
-    static func cachedIcon(for percent: Double, color: NSColor, isBroken: Bool, isSparkle: Bool, pulseStep: Int) -> NSImage {
-        registerAccessibilityObserverIfNeeded()
-
-        let currentAppearance = NSApp?.effectiveAppearance
+    static func cachedIcon(for percent: Double, color: NSColor, isBroken: Bool, isSparkle: Bool, pulseStep: Int, menuBarAppearance: NSAppearance? = nil) -> NSImage {
+        let currentAppearance = menuBarAppearance ?? NSApp?.effectiveAppearance
         let appearanceName = currentAppearance?.name.rawValue ?? ""
         let currentColorblind = ThemeColors.isColorblind
 
         // Check cache under lock; render outside lock to avoid holding it during image creation
         let colorHash = color.hash
-        let (key, cached, highContrast, isDarkMode): (Int, NSImage?, Bool, Bool) = cacheLock.withLock {
+        let (key, cached): (Int, NSImage?) = cacheLock.withLock {
             if cachedColorblindFlag != currentColorblind
                 || cachedAppearanceName != appearanceName {
                 iconCache.removeAll()
@@ -204,9 +182,7 @@ struct MenuBarIcon: View {
 
             let qPercent = quantizedPercent(percent)
             let k = cacheKey(quantizedPercent: qPercent, colorHash: colorHash, isBroken: isBroken, isSparkle: isSparkle, pulseStep: pulseStep)
-            let hc = cachedHighContrastFlag
-            let dm = currentAppearance?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return (k, iconCache[k], hc, dm)
+            return (k, iconCache[k])
         }
 
         if let cached { return cached }
@@ -216,11 +192,11 @@ struct MenuBarIcon: View {
         let icon: NSImage
         if isBroken {
             // Throttled: static multi-pointed star at peak intensity (no animation)
-            icon = renderThrottledIcon(color: color, highContrast: highContrast, isDarkMode: isDarkMode)
+            icon = renderThrottledIcon(color: color)
         } else if isSparkle {
-            icon = renderSparkleIcon(color: color, pulseStep: pulseStep, highContrast: highContrast, isDarkMode: isDarkMode)
+            icon = renderSparkleIcon(color: color, pulseStep: pulseStep)
         } else {
-            icon = renderIcon(percent: percent, color: color, pulseStep: pulseStep, highContrast: highContrast, isDarkMode: isDarkMode)
+            icon = renderIcon(percent: percent, color: color, pulseStep: pulseStep)
         }
 
         // Bake alignment rect into the icon so statusBarImage can return
@@ -237,7 +213,7 @@ struct MenuBarIcon: View {
 
     // MARK: - Normal star rendering
 
-    static func renderIcon(percent: Double, color: NSColor, pulseStep: Int, highContrast: Bool, isDarkMode: Bool) -> NSImage {
+    static func renderIcon(percent: Double, color: NSColor, pulseStep: Int) -> NSImage {
         let size = iconSize
         let outerRadius: CGFloat = 6.5
         let innerRadius: CGFloat = 2.0
@@ -297,9 +273,6 @@ struct MenuBarIcon: View {
             ctx.addPath(path.asCGPath)
             ctx.fillPath()
 
-            // Outline
-            drawStroke(ctx: ctx, path: path.asCGPath, color: color, highContrast: highContrast, isDarkMode: isDarkMode)
-
             return true
         }
         image.isTemplate = false
@@ -310,7 +283,7 @@ struct MenuBarIcon: View {
 
     /// Static many-pointed star for throttled state — no animation, no fragments.
     /// Uses a 12-pointed star shape with the normal 4-pointed star overlaid for depth.
-    static func renderThrottledIcon(color: NSColor, highContrast: Bool, isDarkMode: Bool) -> NSImage {
+    static func renderThrottledIcon(color: NSColor) -> NSImage {
         let size = iconSize
         let outerRadius: CGFloat = 6.5
         let innerRadius: CGFloat = 2.0
@@ -335,8 +308,6 @@ struct MenuBarIcon: View {
             ctx.setFillColor(color.cgColor)
             ctx.addPath(starFill.asCGPath)
             ctx.fillPath()
-
-            drawStroke(ctx: ctx, path: starFill.asCGPath, color: color, highContrast: highContrast, isDarkMode: isDarkMode)
 
             return true
         }
@@ -366,7 +337,7 @@ struct MenuBarIcon: View {
         [0, 3, 6],  [1, 5],     [2, 4, 7],  [0, 6],
     ]
 
-    static func renderSparkleIcon(color: NSColor, pulseStep: Int, highContrast: Bool, isDarkMode: Bool) -> NSImage {
+    static func renderSparkleIcon(color: NSColor, pulseStep: Int) -> NSImage {
         let size = iconSize
 
         let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
@@ -380,8 +351,6 @@ struct MenuBarIcon: View {
             ctx.setFillColor(color.cgColor)
             ctx.addPath(path.asCGPath)
             ctx.fillPath()
-            drawStroke(ctx: ctx, path: path.asCGPath, color: color, highContrast: highContrast, isDarkMode: isDarkMode)
-
             // Draw sparkles — subtle cross shapes that slowly twinkle around the star
             let frameIndex = (pulseStep / 2) % sparkleFrames.count
             let activeIndices = sparkleFrames[frameIndex]

--- a/AIBattery/Views/MenuBarIconGeometry.swift
+++ b/AIBattery/Views/MenuBarIconGeometry.swift
@@ -44,22 +44,6 @@ extension MenuBarIcon {
         path.close()
         return path
     }
-
-    /// Shared stroke drawing via CGContext.
-    static func drawStroke(ctx: CGContext, path: CGPath, color: NSColor, highContrast: Bool, isDarkMode: Bool) {
-        if highContrast {
-            ctx.setStrokeColor(NSColor.black.withAlphaComponent(0.8).cgColor)
-            ctx.setLineWidth(1.0)
-        } else if !isDarkMode {
-            ctx.setStrokeColor(NSColor.black.withAlphaComponent(0.3).cgColor)
-            ctx.setLineWidth(0.75)
-        } else {
-            ctx.setStrokeColor(color.withAlphaComponent(0.6).cgColor)
-            ctx.setLineWidth(0.5)
-        }
-        ctx.addPath(path)
-        ctx.strokePath()
-    }
 }
 
 // MARK: - NSBezierPath → CGPath

--- a/AIBattery/Views/MetricToggleView.swift
+++ b/AIBattery/Views/MetricToggleView.swift
@@ -90,7 +90,7 @@ struct MetricToggleView: View {
                 )
                 .overlay(
                     Circle()
-                        .stroke(autoMetricMode ? ThemeColors.action.opacity(0.6) : autoHovered ? Color.secondary.opacity(ThemeColors.hoverBorderOpacity) : Color.secondary.opacity(ThemeColors.subtleBorderOpacity), lineWidth: 1.5)
+                        .stroke(autoMetricMode ? ThemeColors.action.opacity(0.6) : autoHovered ? Color.secondary.opacity(ThemeColors.hoverBorderOpacity) : Color.secondary.opacity(ThemeColors.subtleBorderOpacity), lineWidth: Layout.borderWidth)
                 )
                 .shadow(color: autoMetricMode ? ThemeColors.action.opacity(0.5) : .clear, radius: Layout.glowRadius)
                 .contentShape(Circle())

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -84,7 +84,7 @@ struct PopoverFooterView: View {
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .onHover { quitHovered = $0 }
                 .help("Quit (⌘Q)")
                 .accessibilityLabel("Quit AI Battery")

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -99,7 +99,7 @@ struct PopoverHeaderView: View {
                                 .foregroundStyle(ThemeColors.updateAvailable)
                             Text("v\(update.version)")
                                 .font(Typography.tinyLabel)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ThemeColors.secondaryLabel)
                             Image(systemName: "arrow.up.right")
                                 .font(Typography.decorativeIcon)
                                 .foregroundStyle(ThemeColors.tertiaryLabel)
@@ -134,7 +134,7 @@ struct PopoverHeaderView: View {
                     Button(action: { updateBannerDismissed = true }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(Typography.heroTitle)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .buttonStyle(.plain)
                     .help("Dismiss")
@@ -158,7 +158,7 @@ struct PopoverHeaderView: View {
                         .foregroundStyle(ThemeColors.success)
                     Text(msg)
                         .font(Typography.tinyLabel)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                 }
                 .transition(.opacity)
             }
@@ -170,7 +170,7 @@ struct PopoverHeaderView: View {
                         .foregroundStyle(ThemeColors.danger)
                     Text("Update failed")
                         .font(Typography.tinyLabel)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                     Spacer()
                     Button(action: {
                         if let url = URL(string: "https://github.com/KyleNesium/AIBattery/releases/latest") {
@@ -185,7 +185,7 @@ struct PopoverHeaderView: View {
                     Button(action: { SparkleUpdateService.shared.clearError() }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(Typography.monoTiny)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .buttonStyle(.plain)
                 }
@@ -235,12 +235,12 @@ struct PopoverHeaderView: View {
             if let activeIndex = accountStore.accounts.firstIndex(where: { $0.id == accountStore.activeAccountId }) {
                 Text(accountLabel(accountStore.accounts[activeIndex], index: activeIndex))
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
                     .lineLimit(1)
             } else {
                 Text("Account")
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
                     .lineLimit(1)
             }
         }

--- a/AIBattery/Views/PopoverStateViews.swift
+++ b/AIBattery/Views/PopoverStateViews.swift
@@ -14,7 +14,7 @@ struct PopoverErrorView: View {
                 .foregroundStyle(ThemeColors.caution)
             Text(message)
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
             Button(action: onRetry) {
@@ -48,7 +48,7 @@ struct PopoverEmptyView: View {
                 .foregroundStyle(ThemeColors.tertiaryLabel)
             Text("No Claude Code data found")
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
             Text("Start a Claude Code session to populate usage data.\nData appears automatically once Claude Code is running.")
                 .font(Typography.tinyLabel)
                 .foregroundStyle(ThemeColors.tertiaryLabel)
@@ -72,7 +72,7 @@ struct PopoverIdleFilteredView: View {
                 .foregroundStyle(ThemeColors.tertiaryLabel)
             Text("No active sessions")
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
             let idleMinutes = Int(idleSessionMinutes)
             if idleMinutes > 0 {
                 Text("Idle cutoff: \(idleMinutes)m")

--- a/AIBattery/Views/PopoverStateViews.swift
+++ b/AIBattery/Views/PopoverStateViews.swift
@@ -12,6 +12,7 @@ struct PopoverErrorView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(Typography.stateIcon)
                 .foregroundStyle(ThemeColors.caution)
+                .accessibilityHidden(true)
             Text(message)
                 .font(Typography.caption)
                 .foregroundStyle(ThemeColors.secondaryLabel)
@@ -21,6 +22,7 @@ struct PopoverErrorView: View {
                 HStack(spacing: Spacing.inner) {
                     Image(systemName: "arrow.clockwise")
                         .font(Typography.monoTiny)
+                        .accessibilityHidden(true)
                     Text("Retry")
                         .font(Typography.caption)
                         .underline(retryHovered)
@@ -29,6 +31,7 @@ struct PopoverErrorView: View {
             .buttonStyle(.plain)
             .foregroundStyle(ThemeColors.action)
             .onHover { retryHovered = $0 }
+            .accessibilityLabel("Retry")
             .accessibilityHint("Retry loading usage data")
             .help("Retry loading usage data")
         }
@@ -46,6 +49,7 @@ struct PopoverEmptyView: View {
             Image(systemName: "tray")
                 .font(Typography.stateIcon)
                 .foregroundStyle(ThemeColors.tertiaryLabel)
+                .accessibilityHidden(true)
             Text("No Claude Code data found")
                 .font(Typography.caption)
                 .foregroundStyle(ThemeColors.secondaryLabel)
@@ -70,6 +74,7 @@ struct PopoverIdleFilteredView: View {
             Image(systemName: "moon.zzz")
                 .font(Typography.stateIcon)
                 .foregroundStyle(ThemeColors.tertiaryLabel)
+                .accessibilityHidden(true)
             Text("No active sessions")
                 .font(Typography.caption)
                 .foregroundStyle(ThemeColors.secondaryLabel)

--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -197,6 +197,7 @@ struct ProjectUsageSection: View {
             Image(systemName: "magnifyingglass")
                 .font(Typography.monoTiny)
                 .foregroundStyle(ThemeColors.tertiaryLabel)
+                .accessibilityHidden(true)
             TextField("Filter projects", text: $searchText)
                 .font(Typography.caption)
                 .textFieldStyle(.plain)
@@ -207,6 +208,7 @@ struct ProjectUsageSection: View {
                         .foregroundStyle(ThemeColors.tertiaryLabel)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(.horizontal, Spacing.gap)

--- a/AIBattery/Views/Settings/AlertSettingsSection.swift
+++ b/AIBattery/Views/Settings/AlertSettingsSection.swift
@@ -10,7 +10,7 @@ struct AlertSettingsSection: View {
         HStack(spacing: Spacing.section) {
             Text("Alerts")
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .frame(width: Layout.settingsLabel, alignment: .trailing)
             Toggle("Status", isOn: $alertStatus)
                 .toggleStyle(.checkbox)

--- a/AIBattery/Views/Settings/DisplaySettingsSection.swift
+++ b/AIBattery/Views/Settings/DisplaySettingsSection.swift
@@ -14,7 +14,7 @@ struct DisplaySettingsSection: View {
             HStack(spacing: Spacing.section) {
                 Text("Hide idle")
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
                     .frame(width: Layout.settingsLabel, alignment: .trailing)
                 Slider(value: $idleSliderPosition, in: 1...6, step: 1) { editing in
                     if !editing {
@@ -48,7 +48,7 @@ struct DisplaySettingsSection: View {
         HStack(spacing: Spacing.section) {
             Text("Display")
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .frame(width: Layout.settingsLabel, alignment: .trailing)
             Toggle("Colorblind", isOn: $colorblindMode)
                 .toggleStyle(.checkbox)

--- a/AIBattery/Views/Settings/LaunchAtLoginSection.swift
+++ b/AIBattery/Views/Settings/LaunchAtLoginSection.swift
@@ -8,7 +8,7 @@ struct LaunchAtLoginSection: View {
         HStack(spacing: Spacing.section) {
             Text("Startup")
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .frame(width: Layout.settingsLabel, alignment: .trailing)
             Toggle("Launch at Login", isOn: $launchAtLogin)
                 .toggleStyle(.checkbox)

--- a/AIBattery/Views/Settings/RefreshSettingsSection.swift
+++ b/AIBattery/Views/Settings/RefreshSettingsSection.swift
@@ -12,7 +12,7 @@ struct RefreshSettingsSection: View {
             HStack(spacing: Spacing.section) {
                 Text("Refresh")
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
                     .frame(width: Layout.settingsLabel, alignment: .trailing)
                 Slider(value: $sliderValue, in: 30...300, step: 30) { editing in
                     isDragging = editing

--- a/AIBattery/Views/Settings/SettingsRow.swift
+++ b/AIBattery/Views/Settings/SettingsRow.swift
@@ -11,7 +11,7 @@ struct SettingsRow: View {
             Text("Settings")
                 .font(Typography.caption)
                 .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .accessibilityAddTraits(.isHeader)
 
             // Per-account names
@@ -59,7 +59,7 @@ struct SettingsRow: View {
         return HStack(spacing: Spacing.section) {
             Text(label)
                 .font(Typography.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ThemeColors.secondaryLabel)
                 .frame(width: Layout.settingsLabel, alignment: .trailing)
             TextField("User \(index + 1)", text: nameBinding(for: account.id))
                 .textFieldStyle(.roundedBorder)
@@ -71,7 +71,7 @@ struct SettingsRow: View {
                 }) {
                     Image(systemName: "xmark.circle")
                         .font(Typography.tinyLabel)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                 }
                 .buttonStyle(.plain)
                 .help("Remove this account")

--- a/AIBattery/Views/StandardLimitsSection.swift
+++ b/AIBattery/Views/StandardLimitsSection.swift
@@ -11,6 +11,7 @@ struct StandardLimitsSection: View {
                 Image(systemName: "info.circle")
                     .font(Typography.tinyLabel)
                     .foregroundStyle(ThemeColors.tertiaryLabel)
+                    .accessibilityHidden(true)
                 Text("Showing API rate limits (5h/7d usage unavailable)")
                     .font(Typography.tinyLabel)
                     .foregroundStyle(ThemeColors.secondaryLabel)
@@ -66,6 +67,7 @@ private struct StandardLimitBar: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(Typography.tinyLabel)
                         .foregroundStyle(ThemeColors.danger)
+                        .accessibilityHidden(true)
                 }
                 Spacer()
                 Text("\(TokenFormatter.format(remaining))/\(TokenFormatter.format(limit))")

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -100,7 +100,7 @@ public final class StatusBarManager: NSObject {
 
         // Configure native AppKit button (no NSHostingView — doesn't render in NSStatusBarButton)
         if let button = item.button {
-            button.image = MenuBarIcon.statusBarImage(for: 0, color: ThemeColors.barNSColor(percent: 0))
+            button.image = MenuBarIcon.statusBarImage(for: 0, color: ThemeColors.barNSColor(percent: 0), menuBarAppearance: button.effectiveAppearance)
             // Text left, icon right — matches macOS battery layout
             button.imagePosition = .imageTrailing
             button.imageHugsTitle = true
@@ -324,7 +324,8 @@ public final class StatusBarManager: NSObject {
             percent: percent,
             color: starColor,
             isBroken: isExhausted,
-            isSparkle: isSparkleActive
+            isSparkle: isSparkleActive,
+            menuBarAppearance: button.effectiveAppearance
         )
         // Title is baked into the image — leaving it set would add AppKit's bezel padding
         // back around the text, which is exactly what we're avoiding here.

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -313,7 +313,8 @@ public final class StatusBarManager: NSObject {
         let isExhausted = isThrottled
             || (rateLimits?.fiveHourPercent ?? 0) >= 100
             || (rateLimits?.sevenDayPercent ?? 0) >= 100
-        let starColor = resolveStarColor(metricMode: metricMode, percent: percent, isThrottled: isExhausted)
+        let isDarkMenuBar = button.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let starColor = resolveStarColor(metricMode: metricMode, percent: percent, isThrottled: isExhausted, isDarkMenuBar: isDarkMenuBar)
 
         updateSparkleState(isThrottled: isExhausted)
         updateRenderState(percent: percent, color: starColor, isThrottled: isExhausted)
@@ -366,13 +367,13 @@ public final class StatusBarManager: NSObject {
         statusItem.length = image.size.width
     }
 
-    private func resolveStarColor(metricMode: MetricMode, percent: Double, isThrottled: Bool) -> NSColor {
+    private func resolveStarColor(metricMode: MetricMode, percent: Double, isThrottled: Bool, isDarkMenuBar: Bool) -> NSColor {
         if isThrottled {
             return ThemeColors.barNSColor(percent: 100)
         } else if metricMode == .contextHealth {
             return ThemeColors.contextHealthNSColor(percent: percent)
         } else {
-            return ThemeColors.barNSColor(percent: percent)
+            return ThemeColors.barNSColor(percent: percent, isDarkMenuBar: isDarkMenuBar)
         }
     }
 

--- a/AIBattery/Views/TutorialOverlay.swift
+++ b/AIBattery/Views/TutorialOverlay.swift
@@ -49,7 +49,7 @@ struct TutorialOverlay: View {
 
                 Text(steps[step].description)
                     .font(Typography.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ThemeColors.secondaryLabel)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -73,7 +73,7 @@ struct TutorialOverlay: View {
                         }
                         .buttonStyle(.plain)
                         .font(Typography.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                         .keyboardShortcut(.cancelAction)
                         .accessibilityLabel("Skip tutorial")
                         .help("Skip the tutorial walkthrough")

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -217,7 +217,7 @@ public struct UsagePopoverView: View {
                     Spacer()
                     Text("Fetching usage data…")
                         .font(Typography.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ThemeColors.secondaryLabel)
                     ProgressView()
                         .scaleEffect(0.5)
                         .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.1.7] — 2026-04-19
+
+### Fixed
+- **Menu bar star invisible on light backgrounds** — the 50–80% usage band used `systemYellow`, which washes out against a light or wallpaper-tinted menu bar. A dedicated `menuBarGold` (#B88F00) now renders when `isDarkMenuBar` is false; dark menu bars and colorblind mode retain their existing system colors
+- **Menu bar colors wrong on wallpaper-tinted bars** — `MenuBarIcon` derived light/dark mode from `NSApp.effectiveAppearance` (system-wide), which doesn't reflect the actual menu bar backdrop. All icon rendering now uses `button.effectiveAppearance` from the status item, matching the real bar appearance
+- **Timestamp edge cases** — `dateFromUnix()` rejects timestamps ≤ 0 or > 30 days in the future; `restorePersistedRateLimits()` clamps `fetchedAt` to `Date()` when the system clock has drifted backward; daily activity bucketing uses fixed 86400s intervals instead of `Calendar.date(byAdding: .day)` to avoid DST boundary misalignment
+
+### Changed
+- **Design system consistency** — replaced 31 uses of `.foregroundStyle(.secondary)` across 12 view files with `ThemeColors.secondaryLabel` for better contrast on light backgrounds (black 70% vs system secondary). Interactive hover states intentionally keep hierarchical `.secondary`
+- **`Layout.borderWidth`** — new 1.5pt design token replaces hardcoded `lineWidth` in auto-mode button stroke and collapsible-section focus ring
+
+### Accessibility
+- **Decorative icons hidden from VoiceOver** — added `.accessibilityHidden(true)` to clipboard feedback, info/warning, search, state, and auth icons that duplicated adjacent text labels
+- **Missing labels added** — "Clear search" on project filter clear button, "Retry" on error state retry button
+
+### Docs
+- **Spec drift** — removed phantom "Tokens" section from UI_SPEC (referenced nonexistent `TokenUsageSection.swift`); added `LocalEstimateSection` and `StandardLimitsSection` fallback view specs; updated menu bar spec to match single-combined-image implementation (`button.effectiveAppearance`, no stroke, `.statusBar` panel level); documented `menuBarGold` in CONSTANTS.md and DATA_LAYER.md
+- **`.secondary` references** — UI_SPEC updated to `ThemeColors.secondaryLabel` for account picker, update banner, dismiss button, clipboard icon, tutorial skip
+
 ## [2.1.6] — 2026-04-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - **Menu bar star invisible on light backgrounds** — the 50–80% usage band used `systemYellow`, which washes out against a light or wallpaper-tinted menu bar. A dedicated `menuBarGold` (#B88F00) now renders when `isDarkMenuBar` is false; dark menu bars and colorblind mode retain their existing system colors
 - **Menu bar colors wrong on wallpaper-tinted bars** — `MenuBarIcon` derived light/dark mode from `NSApp.effectiveAppearance` (system-wide), which doesn't reflect the actual menu bar backdrop. All icon rendering now uses `button.effectiveAppearance` from the status item, matching the real bar appearance
-- **Timestamp edge cases** — `dateFromUnix()` rejects timestamps ≤ 0 or > 30 days in the future; `restorePersistedRateLimits()` clamps `fetchedAt` to `Date()` when the system clock has drifted backward; daily activity bucketing uses fixed 86400s intervals instead of `Calendar.date(byAdding: .day)` to avoid DST boundary misalignment
+- **Timestamp edge cases** — `dateFromUnix()` rejects timestamps ≤ 0 or > 8 days in the future (longest rate limit window is 7 days); `restorePersistedRateLimits()` clamps `fetchedAt` to `Date()` when the system clock has drifted backward; daily activity bucketing uses fixed 86400s intervals instead of `Calendar.date(byAdding: .day)` to avoid DST boundary misalignment
 
 ### Changed
 - **Design system consistency** — replaced 31 uses of `.foregroundStyle(.secondary)` across 12 view files with `ThemeColors.secondaryLabel` for better contrast on light backgrounds (black 70% vs system secondary). Interactive hover states intentionally keep hierarchical `.secondary`

--- a/README.md
+++ b/README.md
@@ -441,15 +441,15 @@ AI Battery is **free and open source** — always will be. If it helps you get m
 
 ## 🧪 Test Coverage
 
-**866 tests** across 58 test files.
+**876 tests** across 58 test files.
 
 | Area | Tests | What's covered |
 |------|-------|----------------|
-| Models | 242 | Token summaries, rate limit parsing (unified + standard + client data edge cases), health status, metric modes, API profiles, usage snapshots (incl. escalation ladder, hysteresis), model pricing, Claude system status indicators, standard rate limits |
-| Services | 297 | Token ledger, version checker, Sparkle updates, notifications, health monitor (incl. zero-window safety), status checker, session log reader (incl. NSLock/pendingInvalidation concurrency, incremental scanning, entry eviction), account store, stats cache, usage aggregator (incl. side-effects, integration tests), rate limit fetcher, OAuth |
-| Views | 90 | Activity chart data transforms (5H/7D/12M token-based), trend computation (token-based), session info formatting, GaugeBar clamping, deferred rendering, status bar toggle, insights view formatting, metric toggle ordering |
+| Models | 237 | Token summaries, rate limit parsing (unified + standard + client data edge cases, timestamp rejection), health status, metric modes, API profiles, usage snapshots (incl. escalation ladder, hysteresis), model pricing, Claude system status indicators, standard rate limits |
+| Services | 318 | Token ledger, version checker, Sparkle updates, notifications, health monitor (incl. zero-window safety), status checker, session log reader (incl. NSLock/pendingInvalidation concurrency, incremental scanning, entry eviction), account store, stats cache, usage aggregator (incl. side-effects, integration tests), rate limit fetcher, OAuth, adaptive polling |
+| Views | 106 | Activity chart data transforms (5H/7D/12M token-based), trend computation (token-based), session info formatting, GaugeBar clamping, deferred rendering, status bar toggle/countdown, insights view formatting, metric toggle ordering |
 | ViewModels | 44 | Refresh interval clamping, error messages (incl. standard limits fallback), adaptive polling, throttle tracking, idle threshold constants, TTL-based stale rate limit expiry, effective value generic guard |
-| Utilities | 181 | Token/duration formatting (incl. billion-scale), model name mapping, theme colors, secure networking, menu bar icon animations, throttle tracker, typography, spacing, idle suspension policy |
+| Utilities | 171 | Token/duration formatting (incl. billion-scale), model name mapping, theme colors (incl. isDarkMenuBar gold override), secure networking, menu bar icon animations, throttle tracker, typography, spacing, idle suspension policy |
 
 ---
 

--- a/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
@@ -82,6 +82,46 @@ struct RateLimitUsageTests {
         #expect(usage.fiveHourReset!.timeIntervalSince1970 == 1700000000)
     }
 
+    @Test func parse_resetDate_zeroTimestamp_returnsNil() {
+        let headers: [AnyHashable: Any] = [
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-reset": "0",
+        ]
+        let usage = RateLimitUsage.parse(headers: headers)!
+        #expect(usage.fiveHourReset == nil)
+    }
+
+    @Test func parse_resetDate_negativeTimestamp_returnsNil() {
+        let headers: [AnyHashable: Any] = [
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-reset": "-1000",
+        ]
+        let usage = RateLimitUsage.parse(headers: headers)!
+        #expect(usage.fiveHourReset == nil)
+    }
+
+    @Test func parse_resetDate_farFuture_returnsNil() {
+        // 9 days from now exceeds the 8-day tolerance
+        let farFuture = String(Int(Date().timeIntervalSince1970 + 9 * 86400))
+        let headers: [AnyHashable: Any] = [
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-7d-reset": farFuture,
+        ]
+        let usage = RateLimitUsage.parse(headers: headers)!
+        #expect(usage.sevenDayReset == nil)
+    }
+
+    @Test func parse_resetDate_7dayFuture_accepted() {
+        // 7 days from now is within the 8-day tolerance
+        let sevenDays = String(Int(Date().timeIntervalSince1970 + 7 * 86400))
+        let headers: [AnyHashable: Any] = [
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-7d-reset": sevenDays,
+        ]
+        let usage = RateLimitUsage.parse(headers: headers)!
+        #expect(usage.sevenDayReset != nil)
+    }
+
     @Test func parse_throttledHeaders_returnsUsageWithResetDates() {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "throttled",

--- a/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
@@ -116,6 +116,49 @@ struct ThemeColorsTests {
         #expect(high != critical)
     }
 
+    // MARK: - isDarkMenuBar gold override
+
+    @Test func barNSColor_lightMenuBar_usesGoldInMidBand() {
+        setColorblind(false)
+        let color = ThemeColors.barNSColor(percent: 65, isDarkMenuBar: false)
+        #expect(color == ThemeColors.menuBarGold)
+    }
+
+    @Test func barNSColor_darkMenuBar_usesSystemYellowInMidBand() {
+        setColorblind(false)
+        let color = ThemeColors.barNSColor(percent: 65, isDarkMenuBar: true)
+        #expect(color == .systemYellow)
+    }
+
+    @Test func barNSColor_nilMenuBar_usesSystemYellowInMidBand() {
+        setColorblind(false)
+        let color = ThemeColors.barNSColor(percent: 65)
+        #expect(color == .systemYellow)
+    }
+
+    @Test func barNSColor_colorblind_lightMenuBar_usesGoldInMidBand() {
+        setColorblind(true)
+        defer { setColorblind(false) }
+        let color = ThemeColors.barNSColor(percent: 65, isDarkMenuBar: false)
+        #expect(color == ThemeColors.menuBarGold)
+    }
+
+    @Test func barNSColor_colorblind_darkMenuBar_usesSystemTealInMidBand() {
+        setColorblind(true)
+        defer { setColorblind(false) }
+        let color = ThemeColors.barNSColor(percent: 65, isDarkMenuBar: true)
+        #expect(color == .systemTeal)
+    }
+
+    @Test func barNSColor_lightMenuBar_outsideMidBand_ignoresFlag() {
+        setColorblind(false)
+        // Low band still green, critical band still red — isDarkMenuBar only affects 50-80
+        let low = ThemeColors.barNSColor(percent: 25, isDarkMenuBar: false)
+        let critical = ThemeColors.barNSColor(percent: 96, isDarkMenuBar: false)
+        #expect(low == .systemGreen)
+        #expect(critical == .systemRed)
+    }
+
     // MARK: - Semantic colors
 
     @Test func chartAccent_standard_notBlue() {

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "2.1.6"
-        CURRENT_PROJECT_VERSION: "2.1.6"
+        MARKETING_VERSION: "2.1.7"
+        CURRENT_PROJECT_VERSION: "2.1.7"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -104,7 +104,7 @@ AIBattery/
   Views/
     StatusBarManager.swift        — NSStatusItem + floating NSPanel, native AppKit button, controlBackgroundColor, Combine-driven updates
     MenuBarIcon.swift             — 4-pointed star NSImage: breathing glow, broken star (throttled), recovery sparkle; quantized cache
-    MenuBarIconGeometry.swift     — Star path geometry helpers (starPath, brokenStarFragments, drawStroke) + NSBezierPath→CGPath
+    MenuBarIconGeometry.swift     — Star path geometry helpers (starPath, multiPointStarPath) + NSBezierPath→CGPath
     UsagePopoverView.swift        — Thin popover orchestrator: wires sub-views via init params, owns state
     PopoverHeaderView.swift       — Header row, account picker, update banner (ENABLE_VERSION_CHECKER)
     MetricToggleView.swift        — Segmented metric picker + auto mode button + ordered modes cache

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -353,6 +353,7 @@ Canonical Swift constants backing the numeric values in the tables above. Define
 | `Layout.bannerCornerRadius` | 6pt | Banner corner radius (update banner, search field) |
 | `Layout.costColumn` | 46pt | Compact cost column width (Projects, Insights) |
 | `Layout.tokenColumn` | 42pt | Token value column width (Projects, Insights) |
+| `Layout.borderWidth` | 1.5pt | Standard stroke width for borders and focus rings |
 | `Layout.settingsLabel` | 50pt | Settings label column width (e.g. "Refresh", "Alerts") |
 
 ### MotionConstants (`Utilities/Spacing.swift`, co-located)

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -458,7 +458,7 @@ Most bar and accent colors use system palette in both modes (the opaque light-mo
 | Chart accent | `.systemOrange` | `.systemOrange` |
 | Trend ↑ | `.orange` | `.orange` |
 | Trend ↓ | `.green` | `.green` |
-| Menu bar gold | `.systemYellow` | `.systemYellow` |
+| Menu bar gold | `menuBarGold` (#B88F00) | `.systemYellow` |
 | Menu bar orange | `.systemOrange` | `.systemOrange` |
 | Secondary label | black 70% | white 55% |
 | Tertiary label | black 55% | white 35% |

--- a/spec/DATA_LAYER.md
+++ b/spec/DATA_LAYER.md
@@ -671,9 +671,9 @@ Describes where displayed rate-limit values came from. `Equatable`, `Codable`.
 - `barColor(percent:) -> Color` — usage bar fill color
 - `bandColor(_: HealthBand) -> Color` — context health band color
 - `statusColor(_: StatusIndicator) -> Color` — system status dot color
-- `barNSColor(percent:) -> NSColor` — menu bar icon fill color
-- Standard palette: green → yellow → orange → red
-- Colorblind palette: blue → cyan → amber → purple (deuteranopia/protanopia safe)
+- `barNSColor(percent:isDarkMenuBar:) -> NSColor` — menu bar icon fill color. Optional `isDarkMenuBar` flag: when `false`, the 50–80% band uses `menuBarGold` (#B88F00) instead of `systemYellow`/`systemTeal` to maintain contrast on light menu bars
+- Standard palette: green → yellow/gold → orange → red
+- Colorblind palette: blue → teal/gold → amber → purple (deuteranopia/protanopia safe)
 
 ### IdleSuspendPolicy (`Utilities/IdleSuspendPolicy.swift`)
 - Pure enum — no instances, fully `nonisolated`, no side effects

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -97,7 +97,7 @@ Conditional states (mutually exclusive with content): Loading | Error | Empty
 All font sizes, spacing values, layout dimensions, and animation durations are defined as named constants in `Utilities/`:
 - **Typography** — 19 named font styles (e.g., `Typography.sectionHeader`, `Typography.monoValue`, `Typography.tinyLabel`, `Typography.trendSymbol`)
 - **Spacing** — 11 spacing constants (`micro` 1pt, `tight` 2pt, `xsmall` 3pt, `inner` 4pt, `small` 4pt, `gap` 6pt, `section` 8pt, `medium` 10pt, `authGap` 12pt, `sectionHorizontal` 16pt, `overlay` 24pt)
-- **Layout** — 27 dimension constants (`popoverWidth` 275pt, `chartHeight` 50pt, `barHeight` 8pt, `barCornerRadius` 3pt, `chevronFrame` 22pt, `dotSize` 8pt, `dotSizeSmall` 6pt, `tabCornerRadius` 4pt, `smallCornerRadius` 4pt, `bannerCornerRadius` 6pt, `iconClipRadius` 10pt, `cardCornerRadius` 12pt, `autoModeSize` 20pt, `chartSymbolSize` 12pt, `shadowSmall` 1pt, `glowRadius` 4pt, `costColumn` 46pt, `tokenColumn` 42pt, `insightLabel` 55pt, `marqueeHeight` 14pt, `spinnerSize` 10pt, `stateHeightLoading` 40pt, `stateHeightEmpty` 80pt, `stateHeightError` 100pt, `iconSize` 22pt, `settingsLabel` 50pt, `sliderValueLabel` 28pt)
+- **Layout** — 28 dimension constants (`popoverWidth` 275pt, `chartHeight` 50pt, `barHeight` 8pt, `barCornerRadius` 3pt, `chevronFrame` 22pt, `dotSize` 8pt, `dotSizeSmall` 6pt, `tabCornerRadius` 4pt, `smallCornerRadius` 4pt, `bannerCornerRadius` 6pt, `iconClipRadius` 10pt, `cardCornerRadius` 12pt, `autoModeSize` 20pt, `chartSymbolSize` 12pt, `shadowSmall` 1pt, `glowRadius` 4pt, `borderWidth` 1.5pt, `costColumn` 46pt, `tokenColumn` 42pt, `insightLabel` 55pt, `marqueeHeight` 14pt, `spinnerSize` 10pt, `stateHeightLoading` 40pt, `stateHeightEmpty` 80pt, `stateHeightError` 100pt, `iconSize` 22pt, `settingsLabel` 50pt, `sliderValueLabel` 28pt)
 - **ThemeColors** — surface elevation (`surfaceLevel1`, `surfaceLevel2`), interactive states (`hoverFill`, `copyableHoverFill`), opacity tokens (`dividerOpacity` 0.3, `overlayBackdropOpacity` 0.4, `inactiveIndicatorOpacity` 0.45, `subtleBorderOpacity` 0.2, `hoverBorderOpacity` 0.4, `activeLabelOpacity` 0.5, `focusRingOpacity` 0.6, `shadowOpacity` 0.25, `disabledOpacity` 0.55, `disabledDeepOpacity` 0.25)
 - **MotionConstants** — 7 animation/transition tokens (`standard` 0.15s easeOut, `snappy` 0.1s easeOut, `smooth` 0.4s easeInOut, `fadeOut` 0.3s, `dialog` 0.2s, `spin` 0.5s, `expandTransition` opacity+move)
 
@@ -264,20 +264,33 @@ Takes `sessions: [TokenHealthStatus]` array (top 5 by highest context usage). Ba
 
 Padding: H 16, V 8
 
-### ❹ Tokens (`Views/TokenUsageSection.swift`)
+### ❷b Local Estimate Fallback (`Views/LocalEstimateSection.swift`)
 
-Efficiency-focused dashboard showing cache hit rates and API-equivalent cost.
+Shown when Anthropic's unified 5h/7d rate limit headers are unavailable (e.g., API header removal — see issue #141). Renders one window (5h or 7d) based on the active metric mode, so the mode selector and auto-mode work identically to the API data path.
 
-- Header: `"Tokens"` (.subheadline.bold) + aggregate cache hit rate (`"X% cached"`, .system 9pt monospaced, green when ≥80%) + total cost (`"~$X.XX"`, .caption monospaced, ThemeColors.secondaryLabel, 54pt width) + total tokens (.subheadline, monospaced, semibold, 42pt width)
-- **Cost always visible** — prefixed with `"~"` to indicate API-equivalent estimate (Pro/Max/Teams aren't billed per-token). Shows what the usage would cost on the pay-per-token API, helping subscription users see the value they're getting.
-- Per-model breakdown via `ForEach` over sorted models (active first via prefix matching, then by totalTokens descending)
-- Per model row: display name (.caption) + `"▶"` badge if active (.caption2, green) + cost (`"~$X.XX"`, .caption2 monospaced, 54pt width) + total tokens (.caption monospaced, ThemeColors.secondaryLabel, 42pt width)
-- Efficiency summary row (below model name): cache hit rate (`"X% cached"`, .caption2 monospaced, ThemeColors.tertiaryLabel) + output tokens (`"Y out"`, .caption2 monospaced, ThemeColors.tertiaryLabel). Cache rate omitted when model has no input/cache tokens.
-- All cost and token values have `.copyable()` modifier
+- **Label row**: `"{Window} Usage"` (.buttonLabel) + percentage (.monoValue, copyable) + token count with limit (`"X / Y"`, .monoValue, ThemeColors.secondaryLabel, copyable)
+- **Gauge bar**: same style as rate limit bars (GaugeBar, 8pt height, 3pt radius), colored by percent via `ThemeColors.barColor`
+- **Remaining row**: `"~X remaining"` (.tinyLabel, ThemeColors.secondaryLabel) — `~` prefix when limit is estimated from plan tier
+- **Limit sources**: calibrated from prior API headers (exact) or inferred from `PlanTier` (estimated). `limitSource` property distinguishes the two.
+- Renders via `ForEach(orderedModes)` — same slot as `FiveHourBarSection`/`SevenDayBarSection`
+- Condition: `snapshot.rateLimits == nil && snapshot.isUsingLocalEstimate`
 
 Padding: H 16, V 8
 
-### ❹b Projects (`Views/ProjectUsageSection.swift`)
+### ❷c Standard Limits Fallback (`Views/StandardLimitsSection.swift`)
+
+Last-resort fallback when both unified 5h/7d headers and local estimate are unavailable. Shows per-minute request and token limits from standard Anthropic API headers (`anthropic-ratelimit-*`).
+
+- **Info banner**: info.circle icon (.tinyLabel, ThemeColors.tertiaryLabel) + `"Showing API rate limits (5h/7d usage unavailable)"` (.tinyLabel, ThemeColors.secondaryLabel)
+- **Per-limit bar** (requests and/or tokens, via `StandardLimitBar`):
+  - Label row: label (.buttonLabel) + warning triangle if exhausted + `"remaining/limit"` (.monoValue, copyable)
+  - Gauge bar: same shared GaugeBar component
+  - Detail row (TimelineView, 10s tick): remaining count (.tinyLabel, ThemeColors.secondaryLabel) or `"Limit reached"` (.tinyLabel, ThemeColors.danger) + reset countdown (.tinyLabel, ThemeColors.tertiaryLabel)
+- Condition: `snapshot.rateLimits == nil && !snapshot.isUsingLocalEstimate && snapshot.standardLimits != nil`
+
+Padding: H 16, V 8
+
+### ❹ Projects (`Views/ProjectUsageSection.swift`)
 
 Per-project token breakdown from JSONL `cwd` field. Same visual pattern as Token Usage section but without per-token-type breakdown rows.
 

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -484,7 +484,7 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
 - Timer callback uses `MainActor.assumeIsolated` (no async dispatch overhead)
 
 **Star color selection** (by `StatusBarManager`):
-- Rate limit modes: `ThemeColors.barNSColor` (green < 50%, yellow 50–80%, orange 80–95%, red ≥ 95%)
+- Rate limit modes: `ThemeColors.barNSColor(percent:isDarkMenuBar:)` (green < 50%, yellow/gold 50–80%, orange 80–95%, red ≥ 95%). On light menu bars (`isDarkMenuBar == false`) the 50–80% band uses `menuBarGold` (#B88F00) instead of `systemYellow`, which washes out against a light backdrop
 - Context health mode: `ThemeColors.contextHealthNSColor` (green < 60%, orange 60–80%, red ≥ 80%)
 - Throttled: always red/critical band
 

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -111,7 +111,7 @@ All visual section dividers use `StyledDivider` — a shared component rendering
 
 - Title: `"✦ AI Battery"` (.headline)
 - **Account picker**: always-visible dropdown Menu next to title
-  - Label: display name if set, otherwise `"Account N"` for multi-account / `"Account"` for single (.caption, .secondary)
+  - Label: display name if set, otherwise `"Account N"` for multi-account / `"Account"` for single (.caption, ThemeColors.secondaryLabel)
   - Menu items: display name or `"Account N"` with checkmark on active, clicking switches via `viewModel.switchAccount(to:)`
   - "Add Account" item (plus.circle icon) below divider when `canAddAccount` (< max) — triggers AuthView overlay
   - `.menuStyle(.borderlessButton)`, `.fixedSize()`
@@ -123,9 +123,9 @@ All visual section dividers use `StyledDivider` — a shared component rendering
   - **Default**: `.secondary` color. Clicking triggers `forceCheckForUpdate()`.
 - **Update banner** (below header, when `availableUpdate` exists and not dismissed): bordered card, single-row HStack
   - Background: `RoundedRectangle(cornerRadius: 6)` with `Color.yellow.opacity(0.08)` fill and `Color.yellow.opacity(0.25)` 1pt stroke, 8pt padding
-  - Yellow circle icon + **"vX.Y.Z ↗"** (.caption2, .secondary) — clickable, opens GitHub release page
+  - Yellow circle icon + **"vX.Y.Z ↗"** (.caption2, ThemeColors.secondaryLabel) — clickable, opens GitHub release page
   - **"↓ Install Update"** (.caption2, .blue) — tries Sparkle in-app update; falls back to opening GitHub release if Sparkle not ready
-  - **"✕"** dismiss button (xmark.circle.fill, 14pt, .secondary) — hides banner, yellow icon stays yellow; clicking icon re-shows banner
+  - **"✕"** dismiss button (xmark.circle.fill, 14pt, ThemeColors.secondaryLabel) — hides banner, yellow icon stays yellow; clicking icon re-shows banner
   - State: `@State updateBannerDismissed` (resets when yellow icon clicked)
 - Padding: H 16, V 6
 
@@ -313,7 +313,7 @@ Padding: H 16, V 8
 `CopyableModifier` ViewModifier applied via `.copyable(_ value:)` extension:
 - Copies formatted display value to `NSPasteboard.general` on tap
 - Hover feedback: pointer cursor (`NSCursor.pointingHand`) + subtle background highlight (`.primary.opacity(0.10)`)
-- Brief clipboard icon overlay (`doc.on.clipboard.fill`, 9pt, `.secondary`, 1.2s duration, `.scale.combined(with: .opacity)` transition, offset right of content)
+- Brief clipboard icon overlay (`doc.on.clipboard.fill`, 9pt, ThemeColors.secondaryLabel, 1.2s duration, `.scale.combined(with: .opacity)` transition, offset right of content)
 - `.help` tooltip shows the value
 - Applied to: usage percentages, token counts, health stats, insight summaries, cost values, session ID prefix
 
@@ -396,7 +396,7 @@ Each button's inner HStack uses `.fixedSize()` to prevent text wrapping. Links r
 - **Active incidents** (if `incidentNames` non-empty): triangle icon + `MarqueeText(texts:, color: statusColor)` cycling through all active incidents with cross-fade transitions (color matches incident severity). Replaces timestamp.
 - **No incidents**: `"Updated {relative time}"` right-aligned (.system 9pt monospaced, ThemeColors.tertiaryLabel). Wrapped in `TimelineView(.periodic(from: .now, by: 10))` for live updates. Tooltip shows absolute time.
 
-All text: .caption2, .secondary. Padding: H 16, top 8, bottom 16 (sectionHorizontal — extra bottom padding for panel edge).
+All text: .caption2, ThemeColors.secondaryLabel. Padding: H 16, V 8 (section).
 
 Status colors: operational=green, degraded=yellow, partial=orange, major=red, maintenance=blue, unknown=gray
 
@@ -413,7 +413,7 @@ Status colors: operational=green, degraded=yellow, partial=orange, major=red, ma
 Native AppKit `NSStatusItem` with a single combined `button.image` — percentage/countdown text and the star icon are baked into one `NSImage` via `MenuBarIcon.combinedStatusBarImage(...)`. This bypasses the per-side bezel padding AppKit applies around a separate `title + image` layout, so the menu bar pill hugs the content like Battery / WiFi / Control Center.
 
 **Button rendering** (native AppKit, no NSHostingView):
-- `button.image` = `MenuBarIcon.combinedStatusBarImage(text:percent:color:...)` — text + star rendered into one tightly-packed image (text in `.white`/`.black` based on effective menu bar appearance, then 2pt gap, then the colored star with its 4pt canvas padding trimmed from both sides)
+- `button.image` = `MenuBarIcon.combinedStatusBarImage(text:percent:color:...:menuBarAppearance:)` — text + star rendered into one tightly-packed image (text in `.white`/`.black` based on `menuBarAppearance` — the status bar button's `effectiveAppearance`, which reflects the actual menu bar backdrop including wallpaper tint and translucency, rather than `NSApp.effectiveAppearance` which only tracks the system-wide Light/Dark setting; then 2pt gap, then the colored star with its 4pt canvas padding trimmed from both sides)
 - `button.title = ""` — leaving it set would add AppKit's bezel padding back around the text
 - `statusItem.length = image.size.width` — sizing the button exactly to the image makes `NSButtonCell.imageRect(forBounds:)` return `origin.x = 0`, so the image is flush against both button edges with no centering gap
 - `button.font` = `.monospacedDigitSystemFont(ofSize: 11, weight: .medium)` — used for text measurement inside `combinedStatusBarImage`, matches macOS menu bar status items
@@ -435,10 +435,10 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
 **Panel behavior** (floating `NSPanel`, not `NSPopover`):
 - Standalone `PopoverPanel` subclass (borderless, `canBecomeKey = true`, handles Cmd+Q) with `NSHostingView` content (10pt corner radius via layer)
 - **Dynamic height**: panel resizes to fit SwiftUI content (via `NSView.frameDidChangeNotification` on hosting view), max height is screen-relative (`screen.visibleFrame.height - 40pt`) so all sections fit on most displays, grows downward from fixed top anchor (`panelTopY` set by `positionPanel`)
-- `hidesOnDeactivate = false`, `level = .floating`
+- `hidesOnDeactivate = false`, `level = .statusBar`
 - Closes on: (1) clicking the status item again, (2) pressing Escape, or (3) clicking outside the panel / switching apps
 - Positioned below the status item, left-aligned to the status item's left edge, clamped to screen edges (multi-monitor safe)
-- `NSApp.activate(ignoringOtherApps: true)` after showing ensures keyboard events reach it (LSUIElement app)
+- Panel uses `.statusBar` level + `orderFrontRegardless` — no `NSApp.activate()` needed (LSUIElement app, avoids stealing focus from the active app)
 - `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` for Escape key dismissal
 - `NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown])` for click-outside dismissal
 
@@ -449,8 +449,7 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
 - 22×22 NSImage canvas (extra room for glow/sparkles), CGContext-based drawing
 - 4-pointed star: 8 vertices alternating outer (6.5pt) / inner (2.0pt) radius
 - Centered at (11, 11), rotation offset -π/2 (starts from top)
-- Fill: solid color from caller (matches active metric mode — rate limit or context health thresholds)
-- Stroke: high-contrast → black 0.8 / 1.0pt; light mode → black 0.3 / 0.75pt; dark mode → color 0.6 / 0.5pt
+- Fill: solid color from caller (matches active metric mode — rate limit or context health thresholds), no stroke
 - `isTemplate = false`
 - `alignmentRect` inset `(left: 1, right: 5)` — still set on the per-icon `NSImage` for anywhere the star is used outside the menu bar button (SwiftUI previews, tests). The menu bar pill no longer relies on it — `combinedStatusBarImage` positions the star directly by trimming the 3pt canvas padding on each side
 
@@ -489,9 +488,9 @@ This ensures the user sees actionable "2h 15m" instead of a stuck "100%" when ca
 - Context health mode: `ThemeColors.contextHealthNSColor` (green < 60%, orange 60–80%, red ≥ 80%)
 - Throttled: always red/critical band
 
-**Quantized caching**: cache key = `quantizedPercent` (every 5%, 21 buckets) × 100 + `pulseStep` (0–7) for normal, `10_100 + pulseStep` for broken (static, always step 0 → 1 entry), `10_200 + pulseStep` for sparkle. Max entries: 21×8 + 1 + 8 = 177. Cache invalidates on colorblind/appearance/contrast change.
+**Quantized caching**: cache key = `quantizedPercent` (every 5%, 21 buckets) × 100 + `pulseStep` (0–7) for normal, `10_100 + pulseStep` for broken (static, always step 0 → 1 entry), `10_200 + pulseStep` for sparkle. Max entries: 21×8 + 1 + 8 = 177. Cache invalidates on colorblind or appearance change.
 
-- **`statusBarImage(for:color:isBroken:isSparkle:pulseStep:)`**: public static method for StatusBarManager's native AppKit button.
+- **`statusBarImage(for:color:isBroken:isSparkle:pulseStep:menuBarAppearance:)`**: public static method for StatusBarManager's native AppKit button. `menuBarAppearance` defaults to `nil` (falls back to `NSApp.effectiveAppearance`); StatusBarManager passes `button.effectiveAppearance` for accurate wallpaper-tinted rendering.
 
 ## Accessibility
 
@@ -521,7 +520,7 @@ Self-managing 3-step walkthrough. Owns its own `@AppStorage(hasSeenTutorial)` �
 - Semi-transparent backdrop (`Color.black.opacity(0.4)`)
 - Centered card with `.regularMaterial` background, 12pt corner radius, max 280pt width
 - Step indicators: 3 dots (active = blue, inactive = secondary 0.3)
-- Action button: "Next" / "Get Started" (`.borderedProminent`), "Skip" (.plain, .secondary) on non-final steps
+- Action button: "Next" / "Get Started" (`.borderedProminent`), "Skip" (.plain, ThemeColors.secondaryLabel) on non-final steps
 - Sets `hasSeenTutorial = true` on dismiss
 
 ## Color Rules


### PR DESCRIPTION
## Summary

- **Menu bar star visibility** — `systemYellow` washes out on light/wallpaper-tinted menu bars. Introduced `menuBarGold` (#B88F00) for the 50–80% band on light backgrounds. Icon rendering now derives appearance from `button.effectiveAppearance` (actual bar) instead of `NSApp.effectiveAppearance` (system-wide)
- **Design system consistency** — replaced 31 `.foregroundStyle(.secondary)` calls with `ThemeColors.secondaryLabel` across 12 views; added `Layout.borderWidth` (1.5pt) design token
- **Accessibility** — 7 decorative icons hidden from VoiceOver, 2 missing labels added ("Clear search", "Retry")
- **Edge case hardening** — timestamp validation (reject ≤ 0 / > 8 days future), clock-drift clamping on cache restore, fixed-interval daily bucketing (avoids DST boundary shift)
- **Spec drift** — removed phantom Tokens section, documented fallback views, updated menu bar / color / design token specs
- **Test coverage** — 10 new tests for gold override and timestamp rejection (876 total, all passing)

## Commits (10)

1. `fix: use status bar button appearance for menu bar icon rendering`
2. `refactor: adopt ThemeColors.secondaryLabel and add Layout.borderWidth`
3. `docs: fix spec drift — remove phantom Tokens section, document fallbacks`
4. `docs: fix menu bar spec drift and update .secondary references`
5. `fix: harden timestamp parsing, cache restore, and DST bucketing`
6. `fix: hide decorative icons from VoiceOver and add missing labels`
7. `fix: use dark gold for menu bar star on light backgrounds`
8. `release: v2.1.7 — menu bar appearance fixes, design system consistency, accessibility`
9. `fix: tighten future timestamp tolerance from 30 days to 8`
10. `test: cover isDarkMenuBar gold override and timestamp rejection`

## Test plan

- [x] `swift test` — 876 tests pass (10 new)
- [x] `swift build -c release` — clean
- [ ] Light menu bar: star shows gold (#B88F00) at 50–79% usage
- [ ] Dark menu bar: star stays systemYellow at 50–79%
- [ ] Wallpaper-tinted menu bar: text/icon colors match actual backdrop
- [ ] VoiceOver: decorative icons silent, "Clear search" and "Retry" announced
- [ ] Colorblind mode: 50–79% band uses gold on light, teal on dark
- [ ] Popover text uses consistent secondary label color across all sections