### PR TITLE
chore: ignore local agent + planning scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ build/
 *.swo
 *~
 package-lock.json
+
+# Local agent + planning scratch (not checked in)
+.build-local/
+.claude/
+.gstack/
+.planning/quick/


### PR DESCRIPTION
## Summary

`.build-local/`, `.claude/`, `.gstack/`, and `.planning/quick/` show up untracked on every fresh checkout because local tooling writes to them, but they aren't project source. Adding to `.gitignore` so `git status` stops surfacing them.

`.planning/` itself stays tracked (e.g. `.planning/research/`, `.planning/MILESTONES.md`) — only `.planning/quick/` is ignored.

## Test plan

- [x] `git check-ignore .build-local/ .claude/ .gstack/ .planning/quick/` returns matches
- [x] `git ls-files .planning/` still lists tracked planning docs (research/, milestones/, etc.)
- [x] `git status` is clean after the change