### PR TITLE
ci: build tests in Build step so --skip-build can find them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: swift --version
 
       - name: Build
-        run: swift build
+        run: swift build --build-tests
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: spm-${{ runner.os }}-
 
       - name: Build
-        run: swift build
+        run: swift build --build-tests
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary

The v2.1.8 release run failed at the **Run tests** step:

```
Failed to open test bundle at path .../AIBatteryPackageTests.xctest/Contents/MacOS/AIBatteryPackageTests:
  dlopen(...): no such file
```

The release and CI workflows split build and test for speed: `swift build` first, then `swift test --skip-build`. But `swift build` does **not** produce the test bundle — SPM only builds the test target when `--build-tests` is passed.

This worked by accident in past runs because the SPM cache restore-key happened to include a previously-built test bundle. v2.1.8 changed test sources (added `LocalUsageEstimateTests.swift`, modified four other test files), the cache miss / staleness exposed the latent bug, and the dlopen failed with no bundle on disk.

Fix: explicit `swift build --build-tests` in both `release.yml` and `ci.yml`.

## Test plan

- [x] Identical pattern fixed in both workflows so CI runs match Release runs
- [ ] After merge: re-tag v2.1.8 (delete + recreate) so the release workflow re-fires with the fix