### PR TITLE
chore(v2.3): Phase 1 — SwiftLint + SwiftFormat baseline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+    paths:
+      - '**.swift'
+      - '.swiftlint.yml'
+      - '.swiftformat'
+      - '.github/workflows/lint.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: SwiftLint + SwiftFormat
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install lint tools
+        run: |
+          brew install swiftlint swiftformat
+          swiftlint --version
+          swiftformat --version
+
+      - name: SwiftFormat (lint mode)
+        run: |
+          set +e
+          swiftformat --lint AIBattery/ AIBatteryApp/ Tests/ 2>&1 | tee swiftformat.log
+          set -e
+          if grep -qE 'Source input did not pass lint check' swiftformat.log; then
+            echo "::error::SwiftFormat found unformatted code. Run: swiftformat AIBattery/ AIBatteryApp/ Tests/"
+            exit 1
+          fi
+          echo "SwiftFormat OK"
+
+      - name: SwiftLint
+        run: |
+          set +e
+          swiftlint --quiet 2>&1 | tee swiftlint.log
+          set -e
+          errors=$(grep -c ": error:" swiftlint.log || true)
+          warnings=$(grep -c ": warning:" swiftlint.log || true)
+          echo "SwiftLint: ${errors} error(s), ${warnings} warning(s)"
+          if [ "${errors}" -gt 0 ]; then
+            echo "::error::SwiftLint found ${errors} error(s)"
+            exit 1
+          fi
+          # Warnings are informational in Phase 1 baseline; CI passes.

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,48 @@
+# SwiftFormat configuration for AIBattery
+# Match existing house style: minimal rules, no aggressive rewrites.
+# Phase 1 baseline — add rules incrementally as the codebase tolerates them.
+
+--swiftversion 5.9
+
+# Paths to format
+--exclude .build,build,Package.resolved,**/.build,**/.swiftpm,scripts
+
+# House style (inferred from existing code)
+--binary-grouping none
+--decimal-grouping 3,4
+--hex-grouping none
+--ifdef no-indent
+--no-space-operators ...,..<
+--octal-grouping none
+--pattern-let inline
+--strip-unused-args closure-only
+--wrap-collections before-first
+--wrap-parameters before-first
+
+# Indentation
+--indent 4
+--indentcase false
+--smarttabs enabled
+
+# Spacing
+--maxwidth none
+--ranges spaced
+
+# Disable rules that conflict with established style or are cosmetic-noisy.
+# Re-enable selectively as we refactor (see CHANGELOG [Unreleased]).
+--disable sortImports
+--disable docComments
+--disable modifierOrder
+--disable redundantSelf
+--disable andOperator
+--disable wrapPropertyBodies
+--disable wrapMultilineStatementBraces
+--disable preferKeyPath
+--disable hoistPatternLet
+--disable redundantInternal
+--disable opaqueGenericParameters
+--disable redundantNilInit
+--disable strongifiedSelf
+--disable unusedArguments
+--disable wrapEnumCases
+--disable redundantBackticks

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,69 @@
+# SwiftLint configuration for AIBattery
+# Phase 1 baseline — conservative rules. Tighten as the codebase tolerates it.
+
+included:
+  - AIBattery
+  - AIBatteryApp
+  - Tests
+
+excluded:
+  - .build
+  - .swiftpm
+  - Tests/AIBatteryCoreTests/Fixtures
+  - scripts
+
+# Disable rules that conflict with established style, SwiftFormat output,
+# or known SwiftUI patterns. Re-enable selectively as we refactor.
+disabled_rules:
+  - line_length                           # Long doc lines are intentional
+  - type_body_length                      # 5 large types — Phase 4 splits them
+  - function_body_length                  # Some intentionally long (decoders, formatters)
+  - file_length                           # Will tighten after Phase 4 splits
+  - cyclomatic_complexity                 # Will tighten after Phase 4 splits
+  - identifier_name                       # Allow short names like `k`, `m`, `b`
+  - todo                                  # No TODOs to enforce; pure noise
+  - nesting                               # SwiftUI views nest deeply by design
+  - large_tuple                           # Pure builder structs use tuples
+  - trailing_comma                        # SwiftFormat owns trailing commas
+  - statement_position                    # Existing else/catch newline style preserved
+  - multiple_closures_with_trailing_closure  # SwiftUI Button(action:label:) is canonical
+  - implicit_optional_initialization      # Existing `Type? = nil` style preserved
+  - for_where                             # 1 site, intentional
+  - function_parameter_count              # 1 site (MenuBarMultiAccountText), fix on extract
+  - redundant_discardable_let             # Single site, low value
+  - vertical_whitespace_closing_braces    # Single site, low value
+  - non_optional_string_data_conversion   # Swift 5.9 String(data:encoding:) idiom
+
+# Opt-in rules that catch real issues
+opt_in_rules:
+  - force_unwrapping
+  - redundant_nil_coalescing
+  - prefer_zero_over_explicit_init
+  - sorted_first_last
+  - toggle_bool
+# Intentionally NOT enabled:
+# - empty_count / empty_string: false-positive prone (ActivityChartPoint.count is
+#   a token count, not a collection count; tests compare string equality to "")
+
+analyzer_rules:
+  - unused_import
+  - unused_declaration
+
+# Tunings for kept rules
+force_cast:
+  severity: warning
+force_try:
+  severity: warning
+
+# Force-unwrap warnings are advisory; reviewed call-sites are documented inline.
+force_unwrapping:
+  severity: warning
+
+# Custom rule: discourage Timer.publish (banned per CLAUDE.md regression history)
+custom_rules:
+  no_timer_publish:
+    name: "Timer.publish ban"
+    regex: 'Timer\.publish\('
+    message: "Timer.publish causes timer accumulation freezes in SwiftUI views. Use TimelineView instead."
+    severity: error
+    excluded: ".*Tests/.*"

--- a/AIBattery/Models/ClaudeSystemStatus.swift
+++ b/AIBattery/Models/ClaudeSystemStatus.swift
@@ -36,35 +36,35 @@ enum StatusIndicator: String {
 
     var severity: Int {
         switch self {
-        case .operational: return 0
-        case .maintenance: return 1
-        case .degradedPerformance: return 2
-        case .partialOutage: return 3
-        case .majorOutage: return 4
-        case .unknown: return -1
+        case .operational: 0
+        case .maintenance: 1
+        case .degradedPerformance: 2
+        case .partialOutage: 3
+        case .majorOutage: 4
+        case .unknown: -1
         }
     }
 
     /// Human-readable display name for notifications and UI.
     var displayName: String {
         switch self {
-        case .operational: return "operational"
-        case .degradedPerformance: return "degraded performance"
-        case .partialOutage: return "partial outage"
-        case .majorOutage: return "major outage"
-        case .maintenance: return "maintenance"
-        case .unknown: return "unknown"
+        case .operational: "operational"
+        case .degradedPerformance: "degraded performance"
+        case .partialOutage: "partial outage"
+        case .majorOutage: "major outage"
+        case .maintenance: "maintenance"
+        case .unknown: "unknown"
         }
     }
 
     static func from(_ string: String) -> StatusIndicator {
         switch string.lowercased() {
-        case "none", "operational": return .operational
-        case "minor", "degraded_performance", "elevated": return .degradedPerformance
-        case "major", "partial_outage": return .partialOutage
-        case "critical", "major_outage": return .majorOutage
-        case "maintenance", "under_maintenance": return .maintenance
-        default: return .unknown
+        case "none", "operational": .operational
+        case "minor", "degraded_performance", "elevated": .degradedPerformance
+        case "major", "partial_outage": .partialOutage
+        case "critical", "major_outage": .majorOutage
+        case "maintenance", "under_maintenance": .maintenance
+        default: .unknown
         }
     }
 }

--- a/AIBattery/Models/MetricMode.swift
+++ b/AIBattery/Models/MetricMode.swift
@@ -6,18 +6,18 @@ enum MetricMode: String, CaseIterable {
 
     var label: String {
         switch self {
-        case .fiveHour: return "5-Hour"
-        case .sevenDay: return "7-Day"
-        case .contextHealth: return "Context"
+        case .fiveHour: "5-Hour"
+        case .sevenDay: "7-Day"
+        case .contextHealth: "Context"
         }
     }
 
     /// Label for the 3-segment picker.
     var shortLabel: String {
         switch self {
-        case .fiveHour: return "5 Hour"
-        case .sevenDay: return "7 Day"
-        case .contextHealth: return "Context"
+        case .fiveHour: "5 Hour"
+        case .sevenDay: "7 Day"
+        case .contextHealth: "Context"
         }
     }
 

--- a/AIBattery/Models/ModelPricing.swift
+++ b/AIBattery/Models/ModelPricing.swift
@@ -40,10 +40,10 @@ struct ModelPricing {
         if cost < 1 {
             return String(format: "$%.2f", cost)
         }
-        if cost < 1000 {
+        if cost < 1_000 {
             return String(format: "$%.0f", cost)
         }
-        let k = cost / 1000
+        let k = cost / 1_000
         return k == k.rounded() ? "$\(Int(k))K" : String(format: "$%.1fK", k)
     }
 

--- a/AIBattery/Models/PlanTier.swift
+++ b/AIBattery/Models/PlanTier.swift
@@ -6,18 +6,18 @@ import Foundation
 /// estimates. They serve as defaults until auto-calibrated by a 429 event or
 /// restored API utilization headers (see `LocalUsageEstimate.calibrate`).
 enum PlanTier: String, CaseIterable, Codable {
-    case pro = "pro"
-    case max5x = "max5x"
-    case max20x = "max20x"
-    case team = "team"
+    case pro
+    case max5x
+    case max20x
+    case team
 
     /// User-facing label.
     var displayName: String {
         switch self {
-        case .pro: return "Pro"
-        case .max5x: return "Max 5×"
-        case .max20x: return "Max 20×"
-        case .team: return "Team"
+        case .pro: "Pro"
+        case .max5x: "Max 5×"
+        case .max20x: "Max 20×"
+        case .team: "Team"
         }
     }
 
@@ -25,20 +25,20 @@ enum PlanTier: String, CaseIterable, Codable {
     /// Community-derived estimates — auto-calibrated when a 429 is detected.
     var estimatedFiveHourLimit: Int {
         switch self {
-        case .pro: return 7_000_000
-        case .max5x: return 35_000_000
-        case .max20x: return 140_000_000
-        case .team: return 10_000_000
+        case .pro: 7_000_000
+        case .max5x: 35_000_000
+        case .max20x: 140_000_000
+        case .team: 10_000_000
         }
     }
 
     /// Estimated 7-day token budget (all token types: input + output + cache).
     var estimatedSevenDayLimit: Int {
         switch self {
-        case .pro: return 35_000_000
-        case .max5x: return 175_000_000
-        case .max20x: return 700_000_000
-        case .team: return 50_000_000
+        case .pro: 35_000_000
+        case .max5x: 175_000_000
+        case .max20x: 700_000_000
+        case .team: 50_000_000
         }
     }
 

--- a/AIBattery/Models/ProjectTokenSummary.swift
+++ b/AIBattery/Models/ProjectTokenSummary.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 struct ProjectTokenSummary: Identifiable, Equatable {
-    let id: String              // full cwd path (unique key; "Other" for nil cwd)
+    let id: String // full cwd path (unique key; "Other" for nil cwd)
     let projectName: String
     let inputTokens: Int
     let outputTokens: Int
     let cacheReadTokens: Int
     let cacheWriteTokens: Int
-    let estimatedCost: Double   // pre-computed from per-entry model pricing
+    let estimatedCost: Double // pre-computed from per-entry model pricing
 
     var totalTokens: Int {
         inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens

--- a/AIBattery/Models/RateLimitSource.swift
+++ b/AIBattery/Models/RateLimitSource.swift
@@ -9,22 +9,22 @@ enum RateLimitSource: String, Equatable, Codable {
     var shortLabel: String {
         switch self {
         case .oauthUsageEndpoint:
-            return "Via Anthropic API"
+            "Via Anthropic API"
         case .claudeCodeClientData:
-            return "Via Claude Code"
+            "Via Claude Code"
         case .anthropicAPIHeaders:
-            return "Via Anthropic API"
+            "Via Anthropic API"
         }
     }
 
     var explanation: String {
         switch self {
         case .oauthUsageEndpoint:
-            return "Usage data from Anthropic OAuth usage endpoint."
+            "Usage data from Anthropic OAuth usage endpoint."
         case .claudeCodeClientData:
-            return "Usage data from Claude Code account metadata."
+            "Usage data from Claude Code account metadata."
         case .anthropicAPIHeaders:
-            return "Usage data from Anthropic API response headers."
+            "Usage data from Anthropic API response headers."
         }
     }
 }

--- a/AIBattery/Models/RateLimitUsage.swift
+++ b/AIBattery/Models/RateLimitUsage.swift
@@ -27,9 +27,9 @@ struct RateLimitUsage: Equatable, Codable {
     let representativeClaim: String
 
     /// 5-hour window
-    let fiveHourUtilization: Double   // 0.0 – 1.0
+    let fiveHourUtilization: Double // 0.0 – 1.0
     let fiveHourReset: Date?
-    let fiveHourStatus: String        // "allowed" or "throttled"
+    let fiveHourStatus: String // "allowed" or "throttled"
 
     /// 7-day window
     let sevenDayUtilization: Double
@@ -37,15 +37,15 @@ struct RateLimitUsage: Equatable, Codable {
     let sevenDayStatus: String
 
     /// Overall status
-    let overallStatus: String         // "allowed" or "throttled"
+    let overallStatus: String // "allowed" or "throttled"
 
     // MARK: - Convenience
 
     /// The utilization percentage of the binding window (0–100).
     var requestsPercentUsed: Double {
         switch representativeClaim {
-        case Self.sevenDayWindow: return sevenDayUtilization * 100.0
-        default: return fiveHourUtilization * 100.0
+        case Self.sevenDayWindow: sevenDayUtilization * 100.0
+        default: fiveHourUtilization * 100.0
         }
     }
 
@@ -58,16 +58,16 @@ struct RateLimitUsage: Equatable, Codable {
     /// Reset date of the binding window.
     var bindingReset: Date? {
         switch representativeClaim {
-        case Self.sevenDayWindow: return sevenDayReset
-        default: return fiveHourReset
+        case Self.sevenDayWindow: sevenDayReset
+        default: fiveHourReset
         }
     }
 
     /// Human-readable label for the binding window.
     var bindingWindowLabel: String {
         switch representativeClaim {
-        case Self.sevenDayWindow: return "7-day"
-        default: return "5-hour"
+        case Self.sevenDayWindow: "7-day"
+        default: "5-hour"
         }
     }
 
@@ -85,9 +85,9 @@ struct RateLimitUsage: Equatable, Codable {
     func isWindowThrottled(_ window: String) -> Bool {
         switch window {
         case Self.sevenDayWindow:
-            return sevenDayStatus == "throttled"
+            sevenDayStatus == "throttled"
         default:
-            return fiveHourStatus == "throttled"
+            fiveHourStatus == "throttled"
         }
     }
 
@@ -117,12 +117,10 @@ struct RateLimitUsage: Equatable, Codable {
         let sevenDayExpired = (sevenDayReset.map { $0 <= now } ?? false)
         guard fiveHourExpired || sevenDayExpired else { return self }
 
-        let bindingExpired: Bool = {
-            switch representativeClaim {
-            case Self.sevenDayWindow: return sevenDayExpired
-            default: return fiveHourExpired
-            }
-        }()
+        let bindingExpired: Bool = switch representativeClaim {
+        case Self.sevenDayWindow: sevenDayExpired
+        default: fiveHourExpired
+        }
 
         return RateLimitUsage(
             representativeClaim: representativeClaim,
@@ -149,12 +147,10 @@ struct RateLimitUsage: Equatable, Codable {
     /// based on current utilization and time remaining until reset.
     /// Returns nil if utilization is too low or the estimate exceeds reset time.
     func estimatedTimeToLimit(for window: String) -> TimeInterval? {
-        let (utilization, reset): (Double, Date?) = {
-            switch window {
-            case Self.sevenDayWindow: return (sevenDayUtilization, sevenDayReset)
-            default: return (fiveHourUtilization, fiveHourReset)
-            }
-        }()
+        let (utilization, reset): (Double, Date?) = switch window {
+        case Self.sevenDayWindow: (sevenDayUtilization, sevenDayReset)
+        default: (fiveHourUtilization, fiveHourReset)
+        }
 
         guard utilization > 0.20, let reset else { return nil }
 
@@ -162,7 +158,7 @@ struct RateLimitUsage: Equatable, Codable {
         guard remaining > 0 else { return nil }
 
         // Window duration inferred from window type
-        let windowDuration: TimeInterval = window == Self.sevenDayWindow ? 7 * 24 * 3600 : 5 * 3600
+        let windowDuration: TimeInterval = window == Self.sevenDayWindow ? 7 * 24 * 3_600 : 5 * 3_600
         let elapsed = windowDuration - remaining
 
         guard elapsed > 60 else { return nil } // Need meaningful elapsed time
@@ -206,7 +202,7 @@ struct RateLimitUsage: Equatable, Codable {
         func dateFromUnix(_ key: String) -> Date? {
             guard let val = normalized[key.lowercased()],
                   let ts = TimeInterval(val),
-                  ts > 0, ts < Date().timeIntervalSince1970 + 8 * 86400 else { return nil }
+                  ts > 0, ts < Date().timeIntervalSince1970 + 8 * 86_400 else { return nil }
             return Date(timeIntervalSince1970: ts)
         }
 
@@ -269,12 +265,12 @@ struct RateLimitUsage: Equatable, Codable {
         func parseDate(_ value: Any?) -> Date? {
             if let number = value as? NSNumber {
                 let raw = number.doubleValue
-                let seconds = raw > 10_000_000_000 ? raw / 1000.0 : raw
+                let seconds = raw > 10_000_000_000 ? raw / 1_000.0 : raw
                 return Date(timeIntervalSince1970: seconds)
             }
             if let text = value as? String {
                 if let unix = TimeInterval(text) {
-                    let seconds = unix > 10_000_000_000 ? unix / 1000.0 : unix
+                    let seconds = unix > 10_000_000_000 ? unix / 1_000.0 : unix
                     return Date(timeIntervalSince1970: seconds)
                 }
                 let iso = ISO8601DateFormatter()

--- a/AIBattery/Models/StandardRateLimits.swift
+++ b/AIBattery/Models/StandardRateLimits.swift
@@ -89,7 +89,7 @@ struct StandardRateLimits: Equatable, Codable {
         )
 
         guard (requestsLimit != nil && requestsRemaining != nil)
-           || (tokensLimit != nil && tokensRemaining != nil) else {
+            || (tokensLimit != nil && tokensRemaining != nil) else {
             return nil
         }
 

--- a/AIBattery/Models/StatsCache.swift
+++ b/AIBattery/Models/StatsCache.swift
@@ -70,6 +70,6 @@ struct LongestSession: Codable {
     let timestamp: String
 
     var durationFormatted: String {
-        DurationFormatter.compact(TimeInterval(duration) / 1000)
+        DurationFormatter.compact(TimeInterval(duration) / 1_000)
     }
 }

--- a/AIBattery/Models/TokenHealthStatus.swift
+++ b/AIBattery/Models/TokenHealthStatus.swift
@@ -31,13 +31,13 @@ struct HealthWarning: Identifiable, Equatable {
 
 /// Complete health assessment for a session.
 struct TokenHealthStatus: Identifiable, Equatable {
-    let id: String  // sessionId
+    let id: String // sessionId
     let band: HealthBand
     let usagePercentage: Double
     let totalUsed: Int
     let contextWindow: Int
-    let usableWindow: Int       // contextWindow × 0.8 (auto-compact threshold)
-    let remainingTokens: Int    // usableWindow - totalUsed
+    let usableWindow: Int // contextWindow × 0.8 (auto-compact threshold)
+    let remainingTokens: Int // usableWindow - totalUsed
     let inputTokens: Int
     let outputTokens: Int
     let cacheReadTokens: Int
@@ -50,7 +50,7 @@ struct TokenHealthStatus: Identifiable, Equatable {
     let gitBranch: String?
     let sessionStart: Date?
     let sessionDuration: TimeInterval?
-    let lastActivity: Date?           // timestamp of most recent entry in this session
+    let lastActivity: Date? // timestamp of most recent entry in this session
 
     /// Placeholder for defensive code paths that should never be reached.
     static let empty = TokenHealthStatus(
@@ -65,11 +65,11 @@ struct TokenHealthStatus: Identifiable, Equatable {
     var suggestedAction: String? {
         switch band {
         case .orange:
-            return "Consider trimming context or starting a fresh conversation soon."
+            "Consider trimming context or starting a fresh conversation soon."
         case .red:
-            return "Start a new conversation for best results. Context degradation is likely."
+            "Start a new conversation for best results. Context degradation is likely."
         case .green, .unknown:
-            return nil
+            nil
         }
     }
 }

--- a/AIBattery/Models/TrendDirection.swift
+++ b/AIBattery/Models/TrendDirection.swift
@@ -4,17 +4,17 @@ enum TrendDirection {
 
     var symbol: String {
         switch self {
-        case .up: return "\u{2191}"    // ↑
-        case .down: return "\u{2193}"  // ↓
-        case .flat: return "\u{2192}"  // →
+        case .up: "\u{2191}" // ↑
+        case .down: "\u{2193}" // ↓
+        case .flat: "\u{2192}" // →
         }
     }
 
     var accessibilityLabel: String {
         switch self {
-        case .up: return "increasing"
-        case .down: return "decreasing"
-        case .flat: return "stable"
+        case .up: "increasing"
+        case .down: "decreasing"
+        case .flat: "stable"
         }
     }
 }

--- a/AIBattery/Models/UsageSnapshot.swift
+++ b/AIBattery/Models/UsageSnapshot.swift
@@ -42,6 +42,7 @@ struct UsageSnapshot: Equatable {
             && lhs.busiestDayOfWeek?.name == rhs.busiestDayOfWeek?.name
             && lhs.busiestDayOfWeek?.averageCount == rhs.busiestDayOfWeek?.averageCount
     }
+
     /// Weekday symbols from the user's current calendar (Sunday = index 0).
     private static let weekdaySymbols = Calendar.current.weekdaySymbols
 
@@ -104,15 +105,15 @@ struct UsageSnapshot: Equatable {
     func percent(for mode: MetricMode) -> Double {
         switch mode {
         case .fiveHour:
-            return rateLimits?.fiveHourPercent
+            rateLimits?.fiveHourPercent
                 ?? LocalUsageEstimate.fiveHourPercent(tokens: fiveHourTokens)
                 ?? 0
         case .sevenDay:
-            return rateLimits?.sevenDayPercent
+            rateLimits?.sevenDayPercent
                 ?? LocalUsageEstimate.sevenDayPercent(tokens: sevenDayTokens)
                 ?? 0
         case .contextHealth:
-            return topSessionHealths.first?.usagePercentage
+            topSessionHealths.first?.usagePercentage
                 ?? tokenHealth?.usagePercentage
                 ?? 0
         }
@@ -125,7 +126,7 @@ struct UsageSnapshot: Equatable {
         guard let resetsAt else { return fiveHourTokens }
         let remaining = resetsAt.timeIntervalSinceNow
         guard remaining > 0 else { return fiveHourTokens }
-        let elapsed = 5 * 3600.0 - remaining
+        let elapsed = 5 * 3_600.0 - remaining
         guard elapsed > 0 else { return 0 }
         // Each bucket = 15 min. Bucket 19 = now, bucket 0 = 5h ago.
         let bucketsElapsed = min(20, Int(elapsed / 900) + 1)
@@ -139,7 +140,7 @@ struct UsageSnapshot: Equatable {
         guard let resetsAt else { return sevenDayTokens }
         let remaining = resetsAt.timeIntervalSinceNow
         guard remaining > 0 else { return sevenDayTokens }
-        let elapsed = 7 * 24 * 3600.0 - remaining
+        let elapsed = 7 * 24 * 3_600.0 - remaining
         guard elapsed > 0 else { return 0 }
         let windowStart = Date().addingTimeInterval(-elapsed)
         let windowStartKey = DateFormatters.dateKey.string(from: windowStart)
@@ -165,7 +166,7 @@ struct UsageSnapshot: Equatable {
 
     /// Maximum age (in seconds) for a session to be considered active.
     /// Sessions with no activity within this window are excluded from context health.
-    static let sessionStalenessInterval: TimeInterval = 30 * 60  // 30 minutes
+    static let sessionStalenessInterval: TimeInterval = 30 * 60 // 30 minutes
 
     /// Whether any tracked session has been active within the staleness window.
     var hasActiveSession: Bool {
@@ -216,7 +217,7 @@ struct UsageSnapshot: Equatable {
     /// - Returns: The mode to display (may be `previous` if hysteresis holds)
     static func applyHysteresis(candidate: MetricMode, previous: MetricMode?, snapshot: UsageSnapshot) -> MetricMode {
         // No previous state — first poll or after reset
-        guard let previous = previous else { return candidate }
+        guard let previous else { return candidate }
 
         // Throttle always wins immediately (Tier 1 bypass)
         if let rl = snapshot.rateLimits, rl.isThrottled { return candidate }
@@ -359,7 +360,6 @@ struct UsageSnapshot: Equatable {
 
     // Top sessions sorted by highest context usage (up to 5, within last 24h)
     let topSessionHealths: [TokenHealthStatus]
-
 }
 
 struct ModelTokenSummary: Identifiable, Equatable {

--- a/AIBattery/Services/FileWatcher.swift
+++ b/AIBattery/Services/FileWatcher.swift
@@ -210,5 +210,7 @@ final class FileWatcher {
 
 private final class WeakBox<T: AnyObject> {
     weak var value: T?
-    init(_ value: T) { self.value = value }
+    init(_ value: T) {
+        self.value = value
+    }
 }

--- a/AIBattery/Services/LaunchAtLoginManager.swift
+++ b/AIBattery/Services/LaunchAtLoginManager.swift
@@ -7,12 +7,10 @@ import ServiceManagement
 /// when the binary is re-signed (e.g. after a Sparkle update). `reregisterIfNeeded()`
 /// detects this drift and re-registers on every launch.
 public enum LaunchAtLoginManager {
-    @available(macOS 13.0, *)
     static var isEnabled: Bool {
         SMAppService.mainApp.status == .enabled
     }
 
-    @available(macOS 13.0, *)
     static func setEnabled(_ enabled: Bool) {
         do {
             if enabled {
@@ -29,7 +27,6 @@ public enum LaunchAtLoginManager {
 
     /// Re-register if the user preference is on but the system registration was lost
     /// (e.g. after ad-hoc re-signing from a Sparkle update).
-    @available(macOS 13.0, *)
     public static func reregisterIfNeeded() {
         let wantsLaunchAtLogin = UserDefaults.standard.bool(forKey: UserDefaultsKeys.launchAtLogin)
         guard wantsLaunchAtLogin else { return }

--- a/AIBattery/Services/NotificationManager.swift
+++ b/AIBattery/Services/NotificationManager.swift
@@ -166,7 +166,9 @@ public final class NotificationManager {
         if anyEnabled {
             defaults.set(true, forKey: UserDefaultsKeys.alertStatus)
         }
-        for key in legacyAlertKeys { defaults.removeObject(forKey: key) }
+        for key in legacyAlertKeys {
+            defaults.removeObject(forKey: key)
+        }
         defaults.set(true, forKey: migrationKey)
     }
 

--- a/AIBattery/Services/OAuthManager.swift
+++ b/AIBattery/Services/OAuthManager.swift
@@ -150,21 +150,21 @@ public final class OAuthManager: ObservableObject {
 
         var userMessage: String {
             switch self {
-            case .noVerifier: return "Auth flow not started. Please click Authenticate first."
-            case .invalidCode: return "Invalid authorization code. Please try again."
-            case .expired: return "Authorization code expired. Please re-authenticate."
-            case .networkError: return "Network error. Check your connection and try again."
-            case .serverError(let code): return "Anthropic's server returned \(code). This is a temporary issue on their end — please try again in a moment."
-            case .maxAccountsReached: return "Maximum of \(AccountStore.maxAccounts) accounts reached. Remove one before adding another."
-            case .unknownError(let msg): return msg
+            case .noVerifier: "Auth flow not started. Please click Authenticate first."
+            case .invalidCode: "Invalid authorization code. Please try again."
+            case .expired: "Authorization code expired. Please re-authenticate."
+            case .networkError: "Network error. Check your connection and try again."
+            case .serverError(let code): "Anthropic's server returned \(code). This is a temporary issue on their end — please try again in a moment."
+            case .maxAccountsReached: "Maximum of \(AccountStore.maxAccounts) accounts reached. Remove one before adding another."
+            case .unknownError(let msg): msg
             }
         }
 
         /// Whether this error is transient and the caller should preserve auth state.
         var isTransient: Bool {
             switch self {
-            case .networkError, .serverError: return true
-            default: return false
+            case .networkError, .serverError: true
+            default: false
             }
         }
     }
@@ -399,7 +399,8 @@ public final class OAuthManager: ObservableObject {
                     // Honor Retry-After header on 429 if present (capped at 30s via RateLimitFetcher)
                     if http.statusCode == 429,
                        let delay = RateLimitFetcher.parseRetryAfter(
-                           http.value(forHTTPHeaderField: "Retry-After")) {
+                           http.value(forHTTPHeaderField: "Retry-After")
+                       ) {
                         try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                     }
                     lastError = .serverError(http.statusCode)
@@ -612,7 +613,6 @@ public final class OAuthManager: ObservableObject {
         UserDefaults.standard.set(true, forKey: migrationKey)
         AppLogger.oauth.info("Migrated Keychain items to ThisDeviceOnly accessibility")
     }
-
 }
 
 // MARK: - Base64URL encoding (RFC 7636)

--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -251,7 +251,7 @@ final class RateLimitFetcher {
         let body: [String: Any] = [
             "model": model,
             "messages": [["role": "user", "content": "."]],
-            "max_tokens": 1
+            "max_tokens": 1,
         ]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
             AppLogger.network.warning("RateLimitFetcher: failed to serialize request body")
@@ -648,5 +648,4 @@ final class RateLimitFetcher {
             )
         }
     }
-
 }

--- a/AIBattery/Services/SessionLogReader.swift
+++ b/AIBattery/Services/SessionLogReader.swift
@@ -279,12 +279,11 @@ final class SessionLogReader: @unchecked Sendable {
         guard fm.fileExists(atPath: projectsURL.path) else { return [] }
 
         // Determine if we must do a full enumeration (TTL expired) or can skip unchanged dirs
-        let forceFullEnum: Bool
-        if let lastEnum = lastFullEnumerationDate,
-           Date().timeIntervalSince(lastEnum) < Self.discoveryTTL {
-            forceFullEnum = false
+        let forceFullEnum = if let lastEnum = lastFullEnumerationDate,
+                               Date().timeIntervalSince(lastEnum) < Self.discoveryTTL {
+            false
         } else {
-            forceFullEnum = true
+            true
         }
 
         var newDirModDates: [String: Date] = [:]
@@ -358,7 +357,9 @@ final class SessionLogReader: @unchecked Sendable {
 
         // Remove stale directory entries (deleted project dirs)
         let staleDirs = discoveredFilesByDir.keys.filter { !currentDirPaths.contains($0) }
-        for key in staleDirs { discoveredFilesByDir.removeValue(forKey: key) }
+        for key in staleDirs {
+            discoveredFilesByDir.removeValue(forKey: key)
+        }
 
         // Flatten all per-directory caches into the result
         let jsonlFiles = Array(discoveredFilesByDir.values.flatMap { $0 })
@@ -391,7 +392,7 @@ final class SessionLogReader: @unchecked Sendable {
         var entries: [AssistantUsageEntry] = []
         let decoder = Self.jsonDecoder
 
-        let bufferSize = 64 * 1024 // 64KB chunks
+        let bufferSize = 64 * 1_024 // 64KB chunks
         let maxLineSize = 1_048_576 // 1MB — skip lines longer than this (malformed/corrupt)
         var leftover = Data()
 
@@ -472,11 +473,10 @@ final class SessionLogReader: @unchecked Sendable {
         // after cache eviction produces the same ID (preserving deduplication).
         let messageId = message.id ?? entry.uuid
             ?? "\(entry.sessionId ?? ""):\(entry.timestamp ?? ""):\(usage.inputTokens ?? 0):\(usage.outputTokens ?? 0)"
-        let timestamp: Date
-        if let ts = entry.timestamp {
-            timestamp = isoFormatter.date(from: ts) ?? Date()
+        let timestamp: Date = if let ts = entry.timestamp {
+            isoFormatter.date(from: ts) ?? Date()
         } else {
-            timestamp = Date()
+            Date()
         }
 
         let toolCallCount = message.content?.filter { $0.type == "tool_use" }.count ?? 0

--- a/AIBattery/Services/SingleInstanceGuard.swift
+++ b/AIBattery/Services/SingleInstanceGuard.swift
@@ -10,7 +10,6 @@ import AppKit
 /// bundle identifier, which cleans up zombie processes that may have survived
 /// a crash or force-quit (preventing RBSRequestErrorDomain Code=5).
 public enum SingleInstanceGuard {
-
     private static let lockPath: String = {
         guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             fatalError("Application Support directory unavailable")

--- a/AIBattery/Services/SparkleUpdateService.swift
+++ b/AIBattery/Services/SparkleUpdateService.swift
@@ -41,7 +41,9 @@ public final class SparkleUpdateService {
     public var lastError: String? { delegate.lastError }
 
     /// Clear the Sparkle error state.
-    public func clearError() { delegate.clearError() }
+    public func clearError() {
+        delegate.clearError()
+    }
 
     /// Trigger the Sparkle update flow. Temporarily becomes a regular app
     /// so Sparkle's dialog appears in front (LSUIElement apps have no dock presence).

--- a/AIBattery/Services/TokenHealthMonitor.swift
+++ b/AIBattery/Services/TokenHealthMonitor.swift
@@ -42,7 +42,7 @@ final class TokenHealthMonitor {
             } else {
                 // Stop scanning once we hit a different session far enough back
                 // (current session entries tend to be clustered near the end)
-                if entries[i].timestamp < cutoff.addingTimeInterval(-3600) { break }
+                if entries[i].timestamp < cutoff.addingTimeInterval(-3_600) { break }
             }
         }
 
@@ -149,13 +149,12 @@ final class TokenHealthMonitor {
         let remaining = max(usableWindow - totalUsed, 0)
 
         // Determine band
-        let band: HealthBand
-        if usagePercentage >= config.redThreshold {
-            band = .red
+        let band: HealthBand = if usagePercentage >= config.redThreshold {
+            .red
         } else if usagePercentage >= config.greenThreshold {
-            band = .orange
+            .orange
         } else {
-            band = .green
+            .green
         }
 
         // Collect warnings

--- a/AIBattery/Services/UsageAggregator.swift
+++ b/AIBattery/Services/UsageAggregator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class UsageAggregator: @unchecked Sendable {
     /// Side effects that must be applied on @MainActor after aggregate returns.
-    struct SideEffects: Sendable {
+    struct SideEffects {
         let activeUserModel: String?
         let observedModels: [String]
         let accountId: String?
@@ -29,9 +29,9 @@ final class UsageAggregator: @unchecked Sendable {
     // MARK: - Time window constants
 
     /// 5-hour sliding window for rate limit estimation (seconds).
-    private static let fiveHourWindow: TimeInterval = 5 * 3600
+    private static let fiveHourWindow: TimeInterval = 5 * 3_600
     /// 24-hour trailing window for chart display (seconds).
-    private static let twentyFourHourWindow: TimeInterval = 86400
+    private static let twentyFourHourWindow: TimeInterval = 86_400
     /// Number of 15-minute buckets in the 5-hour insights chart.
     private static let fiveHourBucketCount = 20
     /// Duration of each insights chart bucket (seconds).
@@ -159,7 +159,7 @@ final class UsageAggregator: @unchecked Sendable {
         // and only recompute when timestamp crosses the boundary.
         var lastDayStart: Date = .distantPast
         var lastDayEnd: Date = .distantPast
-        var lastDateKey: String = ""
+        var lastDateKey = ""
 
         for entry in allEntries {
             let ts = entry.timestamp
@@ -171,7 +171,7 @@ final class UsageAggregator: @unchecked Sendable {
             } else {
                 let entryDay = calendar.startOfDay(for: ts)
                 lastDayStart = entryDay
-                lastDayEnd = entryDay.addingTimeInterval(86400)
+                lastDayEnd = entryDay.addingTimeInterval(86_400)
                 dateKey = Self.dateFormatter.string(from: ts)
                 lastDateKey = dateKey
             }
@@ -308,11 +308,10 @@ final class UsageAggregator: @unchecked Sendable {
         let rawModelTokens = Self.buildModelTokens(from: modelTokensMap)
 
         // Merge with persistent ledger — preserves high-water marks across stats-cache rebuilds.
-        let modelTokens: [ModelTokenSummary]
-        if let accountId {
-            modelTokens = TokenLedger.shared.merge(rawModelTokens, accountId: accountId)
+        let modelTokens: [ModelTokenSummary] = if let accountId {
+            TokenLedger.shared.merge(rawModelTokens, accountId: accountId)
         } else {
-            modelTokens = rawModelTokens
+            rawModelTokens
         }
 
         // First session date
@@ -512,5 +511,4 @@ final class UsageAggregator: @unchecked Sendable {
             )
         }.sorted { $0.totalTokens > $1.totalTokens }
     }
-
 }

--- a/AIBattery/Services/VersionChecker.swift
+++ b/AIBattery/Services/VersionChecker.swift
@@ -7,8 +7,8 @@ public final class VersionChecker {
     public static let shared = VersionChecker()
 
     struct UpdateInfo {
-        let version: String  // e.g. "1.2.0"
-        let url: String      // release page URL
+        let version: String // e.g. "1.2.0"
+        let url: String // release page URL
     }
 
     private let releaseURL: URL
@@ -23,14 +23,14 @@ public final class VersionChecker {
     private convenience init() {
         self.init(
             releaseURL: URL(string: "https://api.github.com/repos/KyleNesium/AIBattery/releases/latest")!,
-            checkInterval: 86400
+            checkInterval: 86_400
         )
         restoreFromDefaults()
     }
 
     /// Testable init — accepts a custom URL and cache interval.
     /// Does NOT restore from UserDefaults to keep tests isolated.
-    init(releaseURL: URL, checkInterval: TimeInterval = 86400) {
+    init(releaseURL: URL, checkInterval: TimeInterval = 86_400) {
         self.releaseURL = releaseURL
         self.checkInterval = checkInterval
     }

--- a/AIBattery/Utilities/DurationFormatter.swift
+++ b/AIBattery/Utilities/DurationFormatter.swift
@@ -8,8 +8,8 @@ enum DurationFormatter {
     static func compact(_ seconds: TimeInterval) -> String {
         guard seconds > 0 else { return "0s" }
         let totalSeconds = Int(seconds)
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
         if hours >= 24 {
             let days = hours / 24
             return "\(days)d \(hours % 24)h"

--- a/AIBattery/Utilities/ThemeColors.swift
+++ b/AIBattery/Utilities/ThemeColors.swift
@@ -13,18 +13,18 @@ enum ThemeColors {
     private(set) static var isColorblind: Bool = UserDefaults.standard.bool(forKey: UserDefaultsKeys.colorblindMode)
 
     /// One-time KVO registration to keep isColorblind in sync with UserDefaults.
-    private static let observer: NSObjectProtocol = {
-        NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { _ in
-            isColorblind = UserDefaults.standard.bool(forKey: UserDefaultsKeys.colorblindMode)
-        }
-    }()
+    private static let observer: NSObjectProtocol = NotificationCenter.default.addObserver(
+        forName: UserDefaults.didChangeNotification,
+        object: nil,
+        queue: .main
+    ) { _ in
+        isColorblind = UserDefaults.standard.bool(forKey: UserDefaultsKeys.colorblindMode)
+    }
 
     /// Call once at app launch to ensure the observer is registered.
-    static func registerObserver() { _ = observer }
+    static func registerObserver() {
+        _ = observer
+    }
 
     /// Re-read the colorblind flag from UserDefaults. Used by tests after changing the preference.
     static func refreshColorblindFlag() {
@@ -128,9 +128,9 @@ enum ThemeColors {
     /// Color for trend direction arrows.
     static func trendColor(_ direction: TrendDirection) -> Color {
         switch direction {
-        case .up: return isColorblind ? amber : .orange
-        case .down: return isColorblind ? .cyan : .green
-        case .flat: return .primary.opacity(0.5)
+        case .up: isColorblind ? amber : .orange
+        case .down: isColorblind ? .cyan : .green
+        case .flat: .primary.opacity(0.5)
         }
     }
 

--- a/AIBattery/Utilities/ThrottleTracker.swift
+++ b/AIBattery/Utilities/ThrottleTracker.swift
@@ -4,7 +4,6 @@ import Foundation
 /// Detects normal → throttled/exhausted transitions and manages timestamp storage.
 /// Extracted from UsageViewModel for testability without global mutable state.
 struct ThrottleTracker {
-
     /// Whether the previous evaluation saw a throttled/exhausted state.
     private(set) var wasThrottled = false
 
@@ -38,7 +37,7 @@ struct ThrottleTracker {
 
     /// Append a new timestamp and prune entries older than 30 days.
     static func appendAndPrune(timestamps: [Double], newTimestamp: Double) -> [Double] {
-        let cutoff = newTimestamp - 30 * 86400
+        let cutoff = newTimestamp - 30 * 86_400
         var result = timestamps.filter { $0 >= cutoff }
         result.append(newTimestamp)
         return result
@@ -46,7 +45,7 @@ struct ThrottleTracker {
 
     /// Count timestamps within a given number of days from now.
     static func count(timestamps: [Double], days: Int) -> Int {
-        let cutoff = Date().timeIntervalSince1970 - Double(days) * 86400
+        let cutoff = Date().timeIntervalSince1970 - Double(days) * 86_400
         return timestamps.filter { $0 >= cutoff }.count
     }
 }

--- a/AIBattery/Utilities/TokenFormatter.swift
+++ b/AIBattery/Utilities/TokenFormatter.swift
@@ -21,5 +21,4 @@ enum TokenFormatter {
             return b < 10 ? String(format: "%.1fB", b) : String(format: "%.0fB", b)
         }
     }
-
 }

--- a/AIBattery/Utilities/Typography.swift
+++ b/AIBattery/Utilities/Typography.swift
@@ -12,7 +12,6 @@ import SwiftUI
 ///
 /// Pattern matches ThemeColors: caseless enum used as a pure namespace.
 enum Typography {
-
     // MARK: - Scale anchors (fixed pt)
 
     /// Icon-only minimum — 9pt. Not for text; only SF Symbols.

--- a/AIBattery/ViewModels/UsageViewModel.swift
+++ b/AIBattery/ViewModels/UsageViewModel.swift
@@ -57,7 +57,7 @@ public final class UsageViewModel: ObservableObject {
     /// The unified headers arrive intermittently (~10% of polls) — expiring them
     /// causes the UI to flip between API data and local estimates.
     /// 24 hours ensures we hold through overnight sleep cycles.
-    static let rateLimitStaleTTL: TimeInterval = 86400
+    static let rateLimitStaleTTL: TimeInterval = 86_400
 
     /// Short delay before the first API poll so data appears quickly without blocking launch.
     private static let initialPollDelay: TimeInterval = 2
@@ -191,7 +191,9 @@ public final class UsageViewModel: ObservableObject {
                 }
                 return inner
             }
-            for (id, limits) in fetched { collected[id] = limits }
+            for (id, limits) in fetched {
+                collected[id] = limits
+            }
         }
 
         perAccountRateLimits = collected
@@ -369,14 +371,13 @@ public final class UsageViewModel: ObservableObject {
 
         async let fetchedStatus = StatusChecker.shared.fetchStatus()
 
-        let api: APIFetchResult
-        if let token = accessToken, let id = accountId {
-            api = await RateLimitFetcher.shared.fetch(accessToken: token, accountId: id)
+        let api: APIFetchResult = if let token = accessToken, let id = accountId {
+            await RateLimitFetcher.shared.fetch(accessToken: token, accountId: id)
         } else {
-            api = APIFetchResult(rateLimits: nil, profile: nil)
+            APIFetchResult(rateLimits: nil, profile: nil)
         }
 
-        return (api, await fetchedStatus)
+        return await (api, fetchedStatus)
     }
 
     private func resolveAccountIdentity(
@@ -390,7 +391,7 @@ public final class UsageViewModel: ObservableObject {
         if account.isPendingIdentity {
             if let orgId = api.profile?.organizationId {
                 oauthManager.resolveAccountIdentity(tempId: id, realOrgId: orgId)
-            } else if Date().timeIntervalSince(account.addedAt) > 3600 {
+            } else if Date().timeIntervalSince(account.addedAt) > 3_600 {
                 errorMessage = "Account identity could not be confirmed. Try removing and re-adding this account."
             }
         }

--- a/AIBattery/Views/ActivityChartData.swift
+++ b/AIBattery/Views/ActivityChartData.swift
@@ -3,7 +3,6 @@ import Foundation
 /// Pure data transformations for activity charts — extracted from InsightsView for testability.
 /// All chart modes show token counts (all types) rather than message counts.
 enum ActivityChartData {
-
     struct DailyPoint: Identifiable {
         var id: String { key }
         let key: String
@@ -13,8 +12,8 @@ enum ActivityChartData {
 
     struct FiveHourPoint: Identifiable {
         var id: Int { offset }
-        let offset: Int  // 0 = oldest (5h ago), 19 = most recent
-        let count: Int   // tokens in this 15-minute bucket
+        let offset: Int // 0 = oldest (5h ago), 19 = most recent
+        let count: Int // tokens in this 15-minute bucket
     }
 
     struct MonthlyPoint: Identifiable {

--- a/AIBattery/Views/ActivityChartTrend.swift
+++ b/AIBattery/Views/ActivityChartTrend.swift
@@ -22,7 +22,6 @@ struct ActivityTrendData {
 
 @MainActor
 enum ActivityTrendComputation {
-
     static func compute(
         mode: ActivityChartMode,
         snapshot: UsageSnapshot,
@@ -138,11 +137,11 @@ enum ActivityTrendComputation {
 
     private static func changeInfo(diff: Int, suffix: String) -> ActivityChangeInfo {
         if diff > 0 {
-            return ActivityChangeInfo(symbol: "↑", label: "+\(diff) \(suffix)", color: ThemeColors.trendColor(.up))
+            ActivityChangeInfo(symbol: "↑", label: "+\(diff) \(suffix)", color: ThemeColors.trendColor(.up))
         } else if diff < 0 {
-            return ActivityChangeInfo(symbol: "↓", label: "\(diff) \(suffix)", color: ThemeColors.trendColor(.down))
+            ActivityChangeInfo(symbol: "↓", label: "\(diff) \(suffix)", color: ThemeColors.trendColor(.down))
         } else {
-            return ActivityChangeInfo(symbol: "→", label: "same as \(suffix.replacingOccurrences(of: "vs ", with: ""))", color: ThemeColors.secondaryLabel)
+            ActivityChangeInfo(symbol: "→", label: "same as \(suffix.replacingOccurrences(of: "vs ", with: ""))", color: ThemeColors.secondaryLabel)
         }
     }
 

--- a/AIBattery/Views/ActivityChartView.swift
+++ b/AIBattery/Views/ActivityChartView.swift
@@ -85,9 +85,9 @@ struct InsightsView: View {
     /// Check source data directly — avoids recomputing chart data just for an emptiness check.
     private var isEmpty: Bool {
         switch mode {
-        case .fiveHour: return snapshot?.fiveHourTokens ?? 0 == 0
-        case .sevenDay: return snapshot?.sevenDayTokens ?? 0 == 0
-        case .monthly: return snapshot?.dailyTokenTotals.values.reduce(0, +) ?? 0 == 0
+        case .fiveHour: snapshot?.fiveHourTokens ?? 0 == 0
+        case .sevenDay: snapshot?.sevenDayTokens ?? 0 == 0
+        case .monthly: snapshot?.dailyTokenTotals.values.reduce(0, +) ?? 0 == 0
         }
     }
 
@@ -160,14 +160,14 @@ struct InsightsView: View {
                 .transition(MotionConstants.expandTransition)
             } else {
                 VStack(alignment: .leading, spacing: Spacing.gap) {
-                switch mode {
-                case .sevenDay:
-                    dailyChart
-                case .fiveHour:
-                    fiveHourChart
-                case .monthly:
-                    monthlyChart
-                }
+                    switch mode {
+                    case .sevenDay:
+                        dailyChart
+                    case .fiveHour:
+                        fiveHourChart
+                    case .monthly:
+                        monthlyChart
+                    }
                 }
                 .id(mode)
                 .transition(.opacity)
@@ -177,16 +177,16 @@ struct InsightsView: View {
             // Trend + cost + history — visually grouped
             if !collapsed, let snapshot {
                 VStack(alignment: .leading, spacing: Spacing.gap) {
-                trendSummary(snapshot)
-                    .accessibilityElement(children: .combine)
+                    trendSummary(snapshot)
+                        .accessibilityElement(children: .combine)
 
-                if !windowedModelTokens.isEmpty {
+                    if !windowedModelTokens.isEmpty {
+                        StyledDivider()
+                        costSection(snapshot)
+                    }
+
                     StyledDivider()
-                    costSection(snapshot)
-                }
-
-                StyledDivider()
-                insightRows(snapshot)
+                    insightRows(snapshot)
                 }
                 .transition(MotionConstants.expandTransition)
             }

--- a/AIBattery/Views/InsightsCharts.swift
+++ b/AIBattery/Views/InsightsCharts.swift
@@ -4,7 +4,6 @@ import Charts
 // MARK: - Chart styling and chart views
 
 extension InsightsView {
-
     // MARK: - Shared chart styling
 
     /// Shared area gradient used by all three chart modes.
@@ -97,7 +96,7 @@ extension InsightsView {
                 selectedDailyId = data
                     .min(by: {
                         abs($0.date.timeIntervalSinceReferenceDate - ts)
-                        < abs($1.date.timeIntervalSinceReferenceDate - ts)
+                            < abs($1.date.timeIntervalSinceReferenceDate - ts)
                     })?.id
             } onEnd: {
                 selectedDailyId = nil
@@ -255,7 +254,7 @@ extension InsightsView {
                 selectedMonthlyId = data
                     .min(by: {
                         abs($0.date.timeIntervalSinceReferenceDate - ts)
-                        < abs($1.date.timeIntervalSinceReferenceDate - ts)
+                            < abs($1.date.timeIntervalSinceReferenceDate - ts)
                     })?.id
             } onEnd: {
                 selectedMonthlyId = nil

--- a/AIBattery/Views/InsightsRowsAndHover.swift
+++ b/AIBattery/Views/InsightsRowsAndHover.swift
@@ -4,7 +4,6 @@ import Charts
 // MARK: - Insight rows, hover helpers, and static formatters
 
 extension InsightsView {
-
     // MARK: - Insight rows (merged from former Insights section)
 
     static let insightLabelWidth: CGFloat = Layout.insightLabel
@@ -38,7 +37,6 @@ extension InsightsView {
             tooltip: "Cumulative tokens across all sessions"
         )
         .accessibilityLabel("All time: \(TokenFormatter.format(snapshot.totalTokens)) tokens, \(snapshot.totalSessions) sessions")
-
     }
 
     func insightRow(
@@ -184,7 +182,7 @@ extension InsightsView {
     /// Full HH:00 format for chart x-axis labels (e.g. "06:00", "18:00").
     /// Distinct from formatHourLabel which returns "HH" only (used in tooltips/trend with manual :00 suffix).
     static func formatHourLabelFull(_ hour: Int) -> String {
-        return String(format: "%02d:00", max(0, min(23, hour)))
+        String(format: "%02d:00", max(0, min(23, hour)))
     }
 
     /// Returns the subset of dates to label on the 12M x-axis:
@@ -198,7 +196,7 @@ extension InsightsView {
         return allDates.filter { date in
             let month = cal.component(.month, from: date)
             let year = cal.component(.year, from: date)
-            let isQuarterly = (month % 3 == 1)   // Jan(1), Apr(4), Jul(7), Oct(10)
+            let isQuarterly = (month % 3 == 1) // Jan(1), Apr(4), Jul(7), Oct(10)
             let isCurrent = (month == currentMonth && year == currentYear)
             return isQuarterly || isCurrent
         }

--- a/AIBattery/Views/InsightsTrendCostSection.swift
+++ b/AIBattery/Views/InsightsTrendCostSection.swift
@@ -3,7 +3,6 @@ import SwiftUI
 // MARK: - Trend summary and cost breakdown
 
 extension InsightsView {
-
     // MARK: - Trend
 
     func trendSummary(_ snapshot: UsageSnapshot) -> some View {

--- a/AIBattery/Views/LocalEstimateSection.swift
+++ b/AIBattery/Views/LocalEstimateSection.swift
@@ -46,7 +46,6 @@ struct LocalEstimateSection: View {
         .padding(.vertical, Spacing.section)
     }
 
-    @ViewBuilder
     private func localUsageBar(label: String, tokens: Int, percent: Double?, limit: Int?) -> some View {
         VStack(alignment: .leading, spacing: Spacing.inner) {
             HStack {

--- a/AIBattery/Views/MenuBarIcon.swift
+++ b/AIBattery/Views/MenuBarIcon.swift
@@ -39,10 +39,10 @@ struct MenuBarIcon: View {
     /// Only called for percent >= 30 (below that, sparkle mode is used instead).
     static func starScaleRange(for percent: Double) -> (min: CGFloat, max: CGFloat) {
         switch percent {
-        case ..<60:  return (1.00, 1.08)
-        case ..<80:  return (1.00, 1.10)
-        case ..<95:  return (1.00, 1.12)
-        default:     return (1.00, 1.14)
+        case ..<60: (1.00, 1.08)
+        case ..<80: (1.00, 1.10)
+        case ..<95: (1.00, 1.12)
+        default: (1.00, 1.14)
         }
     }
 
@@ -50,9 +50,9 @@ struct MenuBarIcon: View {
     /// Below 80% no halo is drawn (timer is stopped, static icon only).
     static func glowAlphaRange(for percent: Double) -> (min: CGFloat, max: CGFloat) {
         switch percent {
-        case ..<80:  return (0.0, 0.0)
-        case ..<95:  return (0.08, 0.25)
-        default:     return (0.12, 0.32)
+        case ..<80: (0.0, 0.0)
+        case ..<95: (0.08, 0.25)
+        default: (0.12, 0.32)
         }
     }
 
@@ -131,7 +131,7 @@ struct MenuBarIcon: View {
         let textColor: NSColor = isDarkMenuBar ? .white : .black
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: textColor
+            .foregroundColor: textColor,
         ]
         let attributed = NSAttributedString(string: text, attributes: attributes)
         let textSize = attributed.size()
@@ -189,14 +189,13 @@ struct MenuBarIcon: View {
 
         // Render without holding the lock — NSImage creation is thread-safe
         // but can be slow; no need to serialize rendering across threads.
-        let icon: NSImage
-        if isBroken {
+        let icon: NSImage = if isBroken {
             // Throttled: static multi-pointed star at peak intensity (no animation)
-            icon = renderThrottledIcon(color: color)
+            renderThrottledIcon(color: color)
         } else if isSparkle {
-            icon = renderSparkleIcon(color: color, pulseStep: pulseStep)
+            renderSparkleIcon(color: color, pulseStep: pulseStep)
         } else {
-            icon = renderIcon(percent: percent, color: color, pulseStep: pulseStep)
+            renderIcon(percent: percent, color: color, pulseStep: pulseStep)
         }
 
         // Bake alignment rect into the icon so statusBarImage can return
@@ -320,21 +319,21 @@ struct MenuBarIcon: View {
     /// Pre-computed sparkle positions: angle (radians) and distance from center.
     /// 8 sparkles arranged around the star — close enough to be visible at menu bar size.
     private static let sparklePositions: [(angle: CGFloat, dist: CGFloat)] = [
-        (0.0,   8.2),   // right
-        (0.8,   8.8),   // upper right
-        (1.57,  8.0),   // top
-        (2.4,   8.6),   // upper left
-        (3.14,  8.2),   // left
-        (3.9,   8.8),   // lower left
-        (4.71,  8.0),   // bottom
-        (5.5,   8.6),   // lower right
+        (0.0, 8.2), // right
+        (0.8, 8.8), // upper right
+        (1.57, 8.0), // top
+        (2.4, 8.6), // upper left
+        (3.14, 8.2), // left
+        (3.9, 8.8), // lower left
+        (4.71, 8.0), // bottom
+        (5.5, 8.6), // lower right
     ]
 
     /// Each pulse step shows a different subset of sparkles (indices into sparklePositions).
     /// 8 frames with 2-3 sparkles each — celebratory twinkling for recovery.
     private static let sparkleFrames: [[Int]] = [
-        [0, 4],     [1, 5],     [2, 6],     [3, 7],
-        [0, 3, 6],  [1, 5],     [2, 4, 7],  [0, 6],
+        [0, 4], [1, 5], [2, 6], [3, 7],
+        [0, 3, 6], [1, 5], [2, 4, 7], [0, 6],
     ]
 
     static func renderSparkleIcon(color: NSColor, pulseStep: Int) -> NSImage {
@@ -378,5 +377,4 @@ struct MenuBarIcon: View {
     }
 
     // Geometry helpers and NSBezierPath extension in MenuBarIconGeometry.swift
-
 }

--- a/AIBattery/Views/MenuBarIconGeometry.swift
+++ b/AIBattery/Views/MenuBarIconGeometry.swift
@@ -3,7 +3,6 @@ import AppKit
 // MARK: - Star geometry helpers (extracted from MenuBarIcon)
 
 extension MenuBarIcon {
-
     /// N-pointed star path for glow effects: alternating outer/inner vertices.
     static func multiPointStarPath(center: NSPoint, outerRadius: CGFloat, innerRadius: CGFloat, points: Int) -> NSBezierPath {
         let path = NSBezierPath()

--- a/AIBattery/Views/MenuBarMultiAccountText.swift
+++ b/AIBattery/Views/MenuBarMultiAccountText.swift
@@ -115,11 +115,10 @@ enum MenuBarMultiAccountText {
                 .min()
             let activeReset = activeRateLimits.flatMap { countdownResetDate($0, now) }
             let reset = [multiReset, activeReset].compactMap { $0 }.min()
-            let text: String
-            if let reset {
-                text = RateLimitUsage.countdownText(to: reset)
+            let text: String = if let reset {
+                RateLimitUsage.countdownText(to: reset)
             } else {
-                text = multi.text
+                multi.text
             }
             return Display(
                 text: text,
@@ -130,11 +129,10 @@ enum MenuBarMultiAccountText {
             )
         } else {
             let activeReset = activeRateLimits.flatMap { countdownResetDate($0, now) }
-            let text: String
-            if let activeReset {
-                text = RateLimitUsage.countdownText(to: activeReset)
+            let text: String = if let activeReset {
+                RateLimitUsage.countdownText(to: activeReset)
             } else {
-                text = "\(Int(activePercent))%"
+                "\(Int(activePercent))%"
             }
             return Display(
                 text: text,
@@ -160,9 +158,9 @@ enum MenuBarMultiAccountText {
 
     private static func percent(for usage: RateLimitUsage, mode: MetricMode) -> Double {
         switch mode {
-        case .fiveHour: return usage.fiveHourPercent
-        case .sevenDay: return usage.sevenDayPercent
-        case .contextHealth: return usage.fiveHourPercent // belt-and-suspenders fallback
+        case .fiveHour: usage.fiveHourPercent
+        case .sevenDay: usage.sevenDayPercent
+        case .contextHealth: usage.fiveHourPercent // belt-and-suspenders fallback
         }
     }
 

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -149,8 +149,8 @@ struct PopoverFooterView: View {
         let elapsed = Date().timeIntervalSince(date)
         if elapsed < 5 { return "just now" }
         if elapsed < 60 { return "\(Int(elapsed))s ago" }
-        if elapsed < 3600 { return "\(Int(elapsed / 60))m ago" }
-        return "\(Int(elapsed / 3600))h ago"
+        if elapsed < 3_600 { return "\(Int(elapsed / 60))m ago" }
+        return "\(Int(elapsed / 3_600))h ago"
     }
 
     static let absoluteFormatter: DateFormatter = {
@@ -166,12 +166,12 @@ struct PopoverFooterView: View {
 
     private var statusTooltip: String {
         switch systemIndicator {
-        case .operational: return "All systems operational"
-        case .degradedPerformance: return "Degraded performance"
-        case .partialOutage: return "Partial outage"
-        case .majorOutage: return "Major outage"
-        case .maintenance: return "Under maintenance"
-        case .unknown, .none: return "Check system status"
+        case .operational: "All systems operational"
+        case .degradedPerformance: "Degraded performance"
+        case .partialOutage: "Partial outage"
+        case .majorOutage: "Major outage"
+        case .maintenance: "Under maintenance"
+        case .unknown, .none: "Check system status"
         }
     }
 }

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -61,8 +61,8 @@ struct PopoverHeaderView: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(
                     availableUpdate != nil ? ThemeColors.updateAvailable
-                    : updateCheckMessage != nil ? ThemeColors.success
-                    : updateHovered ? .primary : .secondary
+                        : updateCheckMessage != nil ? ThemeColors.success
+                        : updateHovered ? .primary : .secondary
                 )
                 .onHover { updateHovered = $0 }
                 .help(availableUpdate.map { "v\($0.version) available" } ?? "Check for updates")

--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -55,19 +55,19 @@ struct ProjectUsageSection: View {
 
             if !collapsed && !snapshot.projectTokens.isEmpty {
                 VStack(alignment: .leading, spacing: Spacing.gap) {
-                // Search field when expanded
-                if showAll {
-                    searchField
-                }
+                    // Search field when expanded
+                    if showAll {
+                        searchField
+                    }
 
-                ForEach(Array(displayedProjects.enumerated()), id: \.element.id) { index, project in
-                    projectRow(project, index: index)
-                }
+                    ForEach(Array(displayedProjects.enumerated()), id: \.element.id) { index, project in
+                        projectRow(project, index: index)
+                    }
 
-                // Combined controls row: show more/less + sort
-                if hasMore || snapshot.projectTokens.count > 1 {
-                    controlsRow
-                }
+                    // Combined controls row: show more/less + sort
+                    if hasMore || snapshot.projectTokens.count > 1 {
+                        controlsRow
+                    }
                 }
                 .transition(MotionConstants.expandTransition)
             }
@@ -230,19 +230,19 @@ private enum ProjectSortMode: CaseIterable {
 
     var label: String {
         switch self {
-        case .tokensDesc: return "tokens"
-        case .costDesc: return "cost ↓"
-        case .costAsc: return "cost ↑"
-        case .name: return "name"
+        case .tokensDesc: "tokens"
+        case .costDesc: "cost ↓"
+        case .costAsc: "cost ↑"
+        case .name: "name"
         }
     }
 
     var icon: String {
         switch self {
-        case .tokensDesc: return "arrow.down"
-        case .costDesc: return "arrow.down"
-        case .costAsc: return "arrow.up"
-        case .name: return "textformat.abc"
+        case .tokensDesc: "arrow.down"
+        case .costDesc: "arrow.down"
+        case .costAsc: "arrow.up"
+        case .name: "textformat.abc"
         }
     }
 

--- a/AIBattery/Views/Settings/DisplaySettingsSection.swift
+++ b/AIBattery/Views/Settings/DisplaySettingsSection.swift
@@ -23,20 +23,20 @@ struct DisplaySettingsSection: View {
                         idleSessionMinutes = Self.idleSteps[max(0, min(Int(idleSliderPosition) - 1, Self.idleSteps.count - 1))]
                     }
                 }
-                    .onAppear {
-                        if let idx = Self.idleSteps.firstIndex(of: idleSessionMinutes) {
-                            idleSliderPosition = Double(idx + 1)
-                        } else {
-                            idleSliderPosition = 6
-                        }
+                .onAppear {
+                    if let idx = Self.idleSteps.firstIndex(of: idleSessionMinutes) {
+                        idleSliderPosition = Double(idx + 1)
+                    } else {
+                        idleSliderPosition = 6
                     }
-                    .onChange(of: idleSessionMinutes) { newValue in
-                        if let idx = Self.idleSteps.firstIndex(of: newValue) {
-                            idleSliderPosition = Double(idx + 1)
-                        }
+                }
+                .onChange(of: idleSessionMinutes) { newValue in
+                    if let idx = Self.idleSteps.firstIndex(of: newValue) {
+                        idleSliderPosition = Double(idx + 1)
                     }
-                    .accessibilityLabel("Hide idle sessions")
-                    .accessibilityValue(idleLabelForPosition)
+                }
+                .accessibilityLabel("Hide idle sessions")
+                .accessibilityValue(idleLabelForPosition)
                 Text(idleLabelForPosition)
                     .font(Typography.monoCaption)
                     .frame(width: Layout.sliderValueLabel, alignment: .trailing)

--- a/AIBattery/Views/Settings/RefreshSettingsSection.swift
+++ b/AIBattery/Views/Settings/RefreshSettingsSection.swift
@@ -21,9 +21,9 @@ struct RefreshSettingsSection: View {
                         viewModel.updatePollingInterval(sliderValue)
                     }
                 }
-                    .onAppear { sliderValue = refreshInterval }
-                    .accessibilityLabel("Refresh interval")
-                    .accessibilityValue(refreshLabel)
+                .onAppear { sliderValue = refreshInterval }
+                .accessibilityLabel("Refresh interval")
+                .accessibilityValue(refreshLabel)
                 Text(refreshLabel)
                     .font(Typography.monoCaption)
                     .frame(width: Layout.sliderValueLabel, alignment: .trailing)

--- a/AIBattery/Views/StatusBarManager.swift
+++ b/AIBattery/Views/StatusBarManager.swift
@@ -301,7 +301,7 @@ public final class StatusBarManager: NSObject {
         // Pre-warm: force SwiftUI's first layout pass now (at startup) so the first
         // user click doesn't pay the ~500ms+ layout cost. Show the panel offscreen
         // for one frame, then hide it.
-        panel.setFrameOrigin(NSPoint(x: -10000, y: -10000))
+        panel.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
         panel.orderFrontRegardless()
         DispatchQueue.main.async {
             panel.orderOut(nil)
@@ -420,11 +420,11 @@ public final class StatusBarManager: NSObject {
 
     private func resolveStarColor(metricMode: MetricMode, percent: Double, isThrottled: Bool, isDarkMenuBar: Bool) -> NSColor {
         if isThrottled {
-            return ThemeColors.barNSColor(percent: 100)
+            ThemeColors.barNSColor(percent: 100)
         } else if metricMode == .contextHealth {
-            return ThemeColors.contextHealthNSColor(percent: percent)
+            ThemeColors.contextHealthNSColor(percent: percent)
         } else {
-            return ThemeColors.barNSColor(percent: percent, isDarkMenuBar: isDarkMenuBar)
+            ThemeColors.barNSColor(percent: percent, isDarkMenuBar: isDarkMenuBar)
         }
     }
 

--- a/AIBattery/Views/TokenHealthSection.swift
+++ b/AIBattery/Views/TokenHealthSection.swift
@@ -61,68 +61,68 @@ struct TokenHealthSection: View {
 
             if !collapsed {
                 VStack(alignment: .leading, spacing: Spacing.gap) {
-                // Session info on its own line for full width
-                sessionInfoLabel
-                    .id(selectedIndex)
-                    .transition(.asymmetric(
-                        insertion: .opacity.combined(with: .move(edge: .trailing)),
-                        removal: .opacity.combined(with: .move(edge: .leading))
-                    ))
+                    // Session info on its own line for full width
+                    sessionInfoLabel
+                        .id(selectedIndex)
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .move(edge: .trailing)),
+                            removal: .opacity.combined(with: .move(edge: .leading))
+                        ))
 
-                // Gauge bar
-                GaugeBar(percent: health.usagePercentage, barColor: bandColor)
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel("Context usage \(Int(health.usagePercentage)) percent")
-                .accessibilityValue("\(remainingText) tokens remaining")
+                    // Gauge bar
+                    GaugeBar(percent: health.usagePercentage, barColor: bandColor)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Context usage \(Int(health.usagePercentage)) percent")
+                        .accessibilityValue("\(remainingText) tokens remaining")
 
-                // Detail row
-                HStack {
-                    let detailText = "~\(remainingText) of \(usableText) usable"
-                    Text(detailText)
-                        .font(Typography.caption)
-                        .foregroundStyle(ThemeColors.secondaryLabel)
-                        .copyable(detailText)
-                    Spacer()
-                    let turnsModelText = "\(health.turnCount) turns · \(modelDisplay)"
-                    Text(turnsModelText)
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.tertiaryLabel)
-                        .help("Conversation turns in this session")
-                        .copyable(turnsModelText)
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("~\(remainingText) of \(usableText) usable, \(health.turnCount) turns, \(health.model.isEmpty ? "unknown model" : modelDisplay)")
-
-                // Recommended minimum context hint
-                if health.band == .orange || health.band == .red {
-                    let safeMin = health.usableWindow / 5 // 20% of usable window
-                    Text("(keep above ~\(TokenFormatter.format(safeMin)) for best quality)")
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.tertiaryLabel)
-                        .help("Recommended minimum tokens to maintain response quality")
-                }
-
-                // Warnings — tiered by severity
-                ForEach(health.warnings) { warning in
-                    HStack(spacing: Spacing.inner) {
-                        Image(systemName: warningIcon(warning.severity))
+                    // Detail row
+                    HStack {
+                        let detailText = "~\(remainingText) of \(usableText) usable"
+                        Text(detailText)
+                            .font(Typography.caption)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
+                            .copyable(detailText)
+                        Spacer()
+                        let turnsModelText = "\(health.turnCount) turns · \(modelDisplay)"
+                        Text(turnsModelText)
                             .font(Typography.tinyLabel)
-                            .foregroundStyle(warningIconColor(warning.severity))
-                        Text(warning.message)
-                            .font(Typography.tinyLabel)
-                            .foregroundStyle(warningTextColor(warning.severity))
+                            .foregroundStyle(ThemeColors.tertiaryLabel)
+                            .help("Conversation turns in this session")
+                            .copyable(turnsModelText)
                     }
-                    .help(warning.suggestion ?? "")
-                }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("~\(remainingText) of \(usableText) usable, \(health.turnCount) turns, \(health.model.isEmpty ? "unknown model" : modelDisplay)")
 
-                // Suggested action
-                if let action = health.suggestedAction {
-                    Text(action)
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(health.band == .red ? ThemeColors.danger : ThemeColors.caution)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, Spacing.tight)
-                }
+                    // Recommended minimum context hint
+                    if health.band == .orange || health.band == .red {
+                        let safeMin = health.usableWindow / 5 // 20% of usable window
+                        Text("(keep above ~\(TokenFormatter.format(safeMin)) for best quality)")
+                            .font(Typography.tinyLabel)
+                            .foregroundStyle(ThemeColors.tertiaryLabel)
+                            .help("Recommended minimum tokens to maintain response quality")
+                    }
+
+                    // Warnings — tiered by severity
+                    ForEach(health.warnings) { warning in
+                        HStack(spacing: Spacing.inner) {
+                            Image(systemName: warningIcon(warning.severity))
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(warningIconColor(warning.severity))
+                            Text(warning.message)
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(warningTextColor(warning.severity))
+                        }
+                        .help(warning.suggestion ?? "")
+                    }
+
+                    // Suggested action
+                    if let action = health.suggestedAction {
+                        Text(action)
+                            .font(Typography.tinyLabel)
+                            .foregroundStyle(health.band == .red ? ThemeColors.danger : ThemeColors.caution)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, Spacing.tight)
+                    }
                 }
                 .transition(MotionConstants.expandTransition)
             }
@@ -132,7 +132,7 @@ struct TokenHealthSection: View {
         .contentShape(Rectangle())
         .gesture(
             sessions.count > 1 ?
-            DragGesture(minimumDistance: 20)
+                DragGesture(minimumDistance: 20)
                 .onEnded { value in
                     let horizontal = value.translation.width
                     guard abs(horizontal) > abs(value.translation.height) else { return }
@@ -147,7 +147,7 @@ struct TokenHealthSection: View {
                         }
                     }
                 }
-            : nil
+                : nil
         )
         .accessibilityHint(sessions.count > 1 ? "Swipe left or right to browse sessions" : "")
         .onReceive(NotificationCenter.default.publisher(for: .panelKeyPress)) { notification in
@@ -316,24 +316,24 @@ struct TokenHealthSection: View {
 
     private func warningIcon(_ severity: HealthWarning.WarningSeverity) -> String {
         switch severity {
-        case .strong: return "exclamationmark.triangle.fill"
-        case .mild: return "exclamationmark.triangle"
-        case .info: return "info.circle"
+        case .strong: "exclamationmark.triangle.fill"
+        case .mild: "exclamationmark.triangle"
+        case .info: "info.circle"
         }
     }
 
     private func warningIconColor(_ severity: HealthWarning.WarningSeverity) -> Color {
         switch severity {
-        case .strong: return ThemeColors.danger
-        case .mild: return ThemeColors.caution
-        case .info: return ThemeColors.tertiaryLabel
+        case .strong: ThemeColors.danger
+        case .mild: ThemeColors.caution
+        case .info: ThemeColors.tertiaryLabel
         }
     }
 
     private func warningTextColor(_ severity: HealthWarning.WarningSeverity) -> Color {
         switch severity {
-        case .strong, .mild: return ThemeColors.secondaryLabel
-        case .info: return ThemeColors.tertiaryLabel
+        case .strong, .mild: ThemeColors.secondaryLabel
+        case .info: ThemeColors.tertiaryLabel
         }
     }
 }

--- a/AIBattery/Views/TokenHealthSessionInfo.swift
+++ b/AIBattery/Views/TokenHealthSessionInfo.swift
@@ -4,7 +4,6 @@ import Foundation
 
 /// Pure helpers for formatting session metadata — no view code.
 enum SessionInfoFormatter {
-
     /// Project name and branch for display.
     static func labelParts(for health: TokenHealthStatus) -> [String] {
         var parts: [String] = []
@@ -130,7 +129,7 @@ enum SessionInfoFormatter {
     static func formatSessionTime(_ date: Date) -> String {
         let elapsed = Date().timeIntervalSince(date)
         if elapsed < 60 { return "just now" }
-        if elapsed < 3600 { return "\(Int(elapsed / 60))m ago" }
+        if elapsed < 3_600 { return "\(Int(elapsed / 60))m ago" }
         let time = timeFormatter.string(from: date)
 
         if calendar.isDateInToday(date) {

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -58,7 +58,7 @@ struct UsageBar: View {
     private var displayPercent: Double { isThrottled ? max(percent, 100) : percent }
 
     private var headerTooltip: String {
-        var parts: [String] = ["\(label) rate limit: \(Int(displayPercent))% used"]
+        var parts = ["\(label) rate limit: \(Int(displayPercent))% used"]
         if isBinding { parts.append("This window is the binding constraint") }
         if isThrottled { parts.append("Currently rate limited") }
         if let reset = resetsAt {
@@ -113,69 +113,69 @@ struct UsageBar: View {
             }
 
             GaugeBar(percent: displayPercent, barColor: ThemeColors.barColor(percent: displayPercent))
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("\(label) rate limit usage \(Int(displayPercent)) percent")
-            .accessibilityValue(isThrottled ? "Rate limited" : "\(max(0, Int(100 - displayPercent))) percent remaining")
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(label) rate limit usage \(Int(displayPercent)) percent")
+                .accessibilityValue(isThrottled ? "Rate limited" : "\(max(0, Int(100 - displayPercent))) percent remaining")
 
             // TimelineView ticks every second when reset is <60s away for live countdown.
             TimelineView(.periodic(from: .now, by: resetTickInterval)) { context in
-            let now = context.date
-            let resetDiff = resetsAt.map { $0.timeIntervalSince(now) }
-            let expired = (resetDiff ?? 1) <= 0
-            HStack {
-                // Left side: time to limit / status
-                if wasExhausted && expired && displayPercent < 1 {
-                    HStack(spacing: Spacing.inner) {
-                        Image(systemName: "sparkles")
+                let now = context.date
+                let resetDiff = resetsAt.map { $0.timeIntervalSince(now) }
+                let expired = (resetDiff ?? 1) <= 0
+                HStack {
+                    // Left side: time to limit / status
+                    if wasExhausted && expired && displayPercent < 1 {
+                        HStack(spacing: Spacing.inner) {
+                            Image(systemName: "sparkles")
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(ThemeColors.success)
+                            Text("Reset")
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(ThemeColors.success)
+                        }
+                    } else if isThrottled {
+                        Text("Throttled")
                             .font(Typography.tinyLabel)
-                            .foregroundStyle(ThemeColors.success)
-                        Text("Reset")
+                            .foregroundStyle(ThemeColors.danger)
+                    } else if displayPercent >= 100 {
+                        Text("Limit reached")
                             .font(Typography.tinyLabel)
-                            .foregroundStyle(ThemeColors.success)
-                    }
-                } else if isThrottled {
-                    Text("Throttled")
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.danger)
-                } else if displayPercent >= 100 {
-                    Text("Limit reached")
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.danger)
-                } else if let estimate = estimatedTimeToLimit {
-                    let estimateText = "~\(DurationFormatter.compact(estimate)) to limit"
-                    Text(estimateText)
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.caution)
-                        .copyable(estimateText)
-                        .help("Estimated time until rate limit based on current burn rate")
-                } else {
-                    // No burn rate estimate yet — show remaining percentage
-                    let remainingText = "\(max(0, Int(100 - displayPercent)))% remaining"
-                    Text(remainingText)
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.secondaryLabel)
-                        .copyable(remainingText)
-                }
-
-                Spacer()
-
-                // Right side: reset countdown (always shown when available)
-                if let diff = resetDiff {
-                    if diff > 0 {
-                        let resetText = "Resets in \(DurationFormatter.compact(diff))"
-                        Text(resetText)
-                            .font(Typography.tinyLabel)
-                            .foregroundStyle(ThemeColors.tertiaryLabel)
-                            .copyable(resetText)
-                    } else if wasExhausted {
-                        // Reset time is in the past — window is rolling over
-                        Text("Resetting…")
+                            .foregroundStyle(ThemeColors.danger)
+                    } else if let estimate = estimatedTimeToLimit {
+                        let estimateText = "~\(DurationFormatter.compact(estimate)) to limit"
+                        Text(estimateText)
                             .font(Typography.tinyLabel)
                             .foregroundStyle(ThemeColors.caution)
-                            .help("Rate limit window is rolling over — values update shortly")
+                            .copyable(estimateText)
+                            .help("Estimated time until rate limit based on current burn rate")
+                    } else {
+                        // No burn rate estimate yet — show remaining percentage
+                        let remainingText = "\(max(0, Int(100 - displayPercent)))% remaining"
+                        Text(remainingText)
+                            .font(Typography.tinyLabel)
+                            .foregroundStyle(ThemeColors.secondaryLabel)
+                            .copyable(remainingText)
+                    }
+
+                    Spacer()
+
+                    // Right side: reset countdown (always shown when available)
+                    if let diff = resetDiff {
+                        if diff > 0 {
+                            let resetText = "Resets in \(DurationFormatter.compact(diff))"
+                            Text(resetText)
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(ThemeColors.tertiaryLabel)
+                                .copyable(resetText)
+                        } else if wasExhausted {
+                            // Reset time is in the past — window is rolling over
+                            Text("Resetting…")
+                                .font(Typography.tinyLabel)
+                                .foregroundStyle(ThemeColors.caution)
+                                .help("Rate limit window is rolling over — values update shortly")
+                        }
                     }
                 }
-            }
             } // TimelineView
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased] — v2.3 tech debt sprint
+
+### Tooling
+- **SwiftLint + SwiftFormat enforced in CI** — added `.swiftlint.yml`, `.swiftformat`, and a new `lint.yml` workflow that runs on every PR. SwiftFormat enforces a uniform style baseline (107 files normalized in this commit). SwiftLint runs conservatively: 0 errors, force-unwrap as advisory warning, plus a custom rule banning `Timer.publish` (regression class documented in `MEMORY.md` and `spec/ARCHITECTURE.md`) to prevent the freeze it caused in v1.9.4.
+- **Removed redundant `@available(macOS 13.0, *)`** from `LaunchAtLoginManager.swift` (3 sites). The package's deployment floor is already `macOS 13`, so these attributes were no-ops.
+
+### Notes
+- Pure tooling/formatting change. No behaviour change. All 922 tests pass unchanged.
+
 ## [2.2.1] — 2026-05-11
 
 ### Fixed

--- a/Tests/AIBatteryCoreTests/MetricToggleViewTests.swift
+++ b/Tests/AIBatteryCoreTests/MetricToggleViewTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("MetricToggleView ordering logic")
 struct MetricToggleViewTests {
-
     @Test("MetricMode.allCases contains all 3 modes")
     func allCasesContainsAllModes() {
         let allCases = MetricMode.allCases

--- a/Tests/AIBatteryCoreTests/Models/APIFetchResultTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/APIFetchResultTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("APIFetchResult")
 struct APIFetchResultTests {
-
     @Test func defaults_notCachedAndFetchedAtNow() {
         let result = APIFetchResult(rateLimits: nil, profile: nil)
         #expect(result.isCached == false)
@@ -15,11 +14,11 @@ struct APIFetchResultTests {
         let result = APIFetchResult(
             rateLimits: nil,
             profile: nil,
-            fetchedAt: Date(timeIntervalSince1970: 1000),
+            fetchedAt: Date(timeIntervalSince1970: 1_000),
             isCached: true
         )
         #expect(result.isCached == true)
-        #expect(result.fetchedAt == Date(timeIntervalSince1970: 1000))
+        #expect(result.fetchedAt == Date(timeIntervalSince1970: 1_000))
     }
 
     @Test func preserves_rateLimitsAndProfile() {
@@ -78,8 +77,8 @@ struct APIFetchResultTests {
             requestsLimit: 50,
             requestsRemaining: 45,
             requestsReset: nil,
-            tokensLimit: 80000,
-            tokensRemaining: 75000,
+            tokensLimit: 80_000,
+            tokensRemaining: 75_000,
             tokensReset: nil
         )
         let result = APIFetchResult(

--- a/Tests/AIBatteryCoreTests/Models/APIProfileTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/APIProfileTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("APIProfile")
 struct APIProfileTests {
-
     @Test func parse_withOrgId() {
         let headers: [AnyHashable: Any] = [
             "anthropic-organization-id": "org-123",

--- a/Tests/AIBatteryCoreTests/Models/AccountRecordTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/AccountRecordTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("AccountRecord")
 struct AccountRecordTests {
-
     @Test func isPendingIdentity_trueForPendingPrefix() {
         let record = AccountRecord(
             id: "pending-ABC123",
@@ -30,7 +29,7 @@ struct AccountRecordTests {
             id: "org-test",
             displayName: "Test User",
             billingType: "teams",
-            addedAt: Date(timeIntervalSince1970: 1700000000)
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(AccountRecord.self, from: data)
@@ -54,7 +53,7 @@ struct AccountRecordTests {
             id: "pending-xyz",
             displayName: nil,
             billingType: nil,
-            addedAt: Date(timeIntervalSince1970: 1700000000)
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(AccountRecord.self, from: data)

--- a/Tests/AIBatteryCoreTests/Models/ClaudeSystemStatusTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ClaudeSystemStatusTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("ClaudeSystemStatus")
 struct ClaudeSystemStatusTests {
-
     // MARK: - StatusIndicator.from()
 
     @Test func from_operational() {

--- a/Tests/AIBatteryCoreTests/Models/LocalUsageEstimateTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/LocalUsageEstimateTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("LocalUsageEstimate")
 struct LocalUsageEstimateTests {
-
     // MARK: - calibrateFrom429 policy
 
     @MainActor
@@ -41,7 +40,7 @@ struct LocalUsageEstimateTests {
         resetState()
         defer { resetState() }
 
-        LocalUsageEstimate.latestFiveHourTokens = 50_000  // below 100_000 floor
+        LocalUsageEstimate.latestFiveHourTokens = 50_000 // below 100_000 floor
         LocalUsageEstimate.calibrateFrom429()
 
         #expect(LocalUsageEstimate.fiveHourLimit == 0)

--- a/Tests/AIBatteryCoreTests/Models/MetricModeTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/MetricModeTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("MetricMode")
 struct MetricModeTests {
-
     // MARK: - Raw values
 
     @Test func rawValues() {

--- a/Tests/AIBatteryCoreTests/Models/ModelPricingTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ModelPricingTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("ModelPricing")
 struct ModelPricingTests {
-
     // MARK: - Lookup
 
     @Test func pricing_opus4() {
@@ -96,7 +95,7 @@ struct ModelPricingTests {
     }
 
     @Test func totalCost_unknownModel() {
-        let model = ModelTokenSummary(id: "unknown", displayName: "Unknown", inputTokens: 1000, outputTokens: 1000, cacheReadTokens: 0, cacheWriteTokens: 0, estimatedCost: 0)
+        let model = ModelTokenSummary(id: "unknown", displayName: "Unknown", inputTokens: 1_000, outputTokens: 1_000, cacheReadTokens: 0, cacheWriteTokens: 0, estimatedCost: 0)
         #expect(ModelPricing.totalCost(for: [model]) == 0)
     }
 
@@ -129,7 +128,7 @@ struct ModelPricingTests {
         let pricing = ModelPricing(inputPerMillion: 15, outputPerMillion: 75, cacheWritePerMillion: 1.875, cacheReadPerMillion: 1.50)
         let cost = pricing.cost(input: 100_000_000, output: 10_000_000, cacheRead: 50_000_000, cacheWrite: 5_000_000)
         // input: 15 × 100 = 1500, output: 75 × 10 = 750, cacheRead: 1.50 × 50 = 75, cacheWrite: 1.875 × 5 = 9.375
-        #expect(abs(cost - 2334.375) < 0.01)
+        #expect(abs(cost - 2_334.375) < 0.01)
     }
 
     // MARK: - Format edge cases

--- a/Tests/AIBatteryCoreTests/Models/ModelTokenSummaryTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ModelTokenSummaryTests.swift
@@ -3,18 +3,17 @@ import Testing
 
 @Suite("ModelTokenSummary")
 struct ModelTokenSummaryTests {
-
     @Test func totalTokens_allComponents() {
         let summary = ModelTokenSummary(
             id: "claude-opus-4-6",
             displayName: "Opus 4.6",
-            inputTokens: 1000,
+            inputTokens: 1_000,
             outputTokens: 500,
             cacheReadTokens: 200,
             cacheWriteTokens: 100,
             estimatedCost: 0
         )
-        #expect(summary.totalTokens == 1800)
+        #expect(summary.totalTokens == 1_800)
     }
 
     @Test func totalTokens_zeroAll() {
@@ -34,13 +33,13 @@ struct ModelTokenSummaryTests {
         let summary = ModelTokenSummary(
             id: "model",
             displayName: "Model",
-            inputTokens: 5000,
+            inputTokens: 5_000,
             outputTokens: 0,
             cacheReadTokens: 0,
             cacheWriteTokens: 0,
             estimatedCost: 0
         )
-        #expect(summary.totalTokens == 5000)
+        #expect(summary.totalTokens == 5_000)
     }
 
     @Test func id_matchesModelId() {

--- a/Tests/AIBatteryCoreTests/Models/ProjectTokenSummaryTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/ProjectTokenSummaryTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("ProjectTokenSummary")
 struct ProjectTokenSummaryTests {
-
     @Test func totalTokens_sumsAllTypes() {
         let summary = ProjectTokenSummary(
             id: "test",
@@ -15,7 +14,7 @@ struct ProjectTokenSummaryTests {
             cacheWriteTokens: 400,
             estimatedCost: 0.50
         )
-        #expect(summary.totalTokens == 1000)
+        #expect(summary.totalTokens == 1_000)
     }
 
     @Test func totalTokens_zeroWhenAllZero() {
@@ -97,7 +96,7 @@ struct ProjectTokenSummaryTests {
             outputTokens: 200_000_000,
             cacheReadTokens: 800_000_000,
             cacheWriteTokens: 100_000_000,
-            estimatedCost: 5000.0
+            estimatedCost: 5_000.0
         )
         #expect(summary.totalTokens == 1_600_000_000)
     }

--- a/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/RateLimitUsageTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("RateLimitUsage")
 struct RateLimitUsageTests {
-
     // MARK: - Parsing
 
     @Test func parse_fullHeaders() {
@@ -70,55 +69,55 @@ struct RateLimitUsageTests {
         #expect(usage?.sevenDayUtilization == 0)
     }
 
-    @Test func parse_resetDates() {
+    @Test func parse_resetDates() throws {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-5h-reset": "1700000000",
             "anthropic-ratelimit-unified-7d-reset": "1700500000",
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.fiveHourReset != nil)
         #expect(usage.sevenDayReset != nil)
-        #expect(usage.fiveHourReset!.timeIntervalSince1970 == 1700000000)
+        #expect(usage.fiveHourReset?.timeIntervalSince1970 == 1_700_000_000)
     }
 
-    @Test func parse_resetDate_zeroTimestamp_returnsNil() {
+    @Test func parse_resetDate_zeroTimestamp_returnsNil() throws {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-5h-reset": "0",
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.fiveHourReset == nil)
     }
 
-    @Test func parse_resetDate_negativeTimestamp_returnsNil() {
+    @Test func parse_resetDate_negativeTimestamp_returnsNil() throws {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-5h-reset": "-1000",
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.fiveHourReset == nil)
     }
 
-    @Test func parse_resetDate_farFuture_returnsNil() {
+    @Test func parse_resetDate_farFuture_returnsNil() throws {
         // 9 days from now exceeds the 8-day tolerance
-        let farFuture = String(Int(Date().timeIntervalSince1970 + 9 * 86400))
+        let farFuture = String(Int(Date().timeIntervalSince1970 + 9 * 86_400))
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-7d-reset": farFuture,
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.sevenDayReset == nil)
     }
 
-    @Test func parse_resetDate_7dayFuture_accepted() {
+    @Test func parse_resetDate_7dayFuture_accepted() throws {
         // 7 days from now is within the 8-day tolerance
-        let sevenDays = String(Int(Date().timeIntervalSince1970 + 7 * 86400))
+        let sevenDays = String(Int(Date().timeIntervalSince1970 + 7 * 86_400))
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-7d-reset": sevenDays,
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.sevenDayReset != nil)
     }
 
@@ -157,24 +156,24 @@ struct RateLimitUsageTests {
         #expect(usage.isWindowThrottled(RateLimitUsage.sevenDayWindow) == false)
     }
 
-    @Test func parse_clampsUtilizationAboveOne() {
+    @Test func parse_clampsUtilizationAboveOne() throws {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-5h-utilization": "1.5",
             "anthropic-ratelimit-unified-7d-utilization": "2.0",
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.fiveHourUtilization == 1.0)
         #expect(usage.sevenDayUtilization == 1.0)
     }
 
-    @Test func parse_clampsNegativeUtilizationToZero() {
+    @Test func parse_clampsNegativeUtilizationToZero() throws {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-unified-status": "allowed",
             "anthropic-ratelimit-unified-5h-utilization": "-0.5",
             "anthropic-ratelimit-unified-7d-utilization": "-1.0",
         ]
-        let usage = RateLimitUsage.parse(headers: headers)!
+        let usage = try #require(RateLimitUsage.parse(headers: headers))
         #expect(usage.fiveHourUtilization == 0.0)
         #expect(usage.sevenDayUtilization == 0.0)
     }
@@ -204,7 +203,7 @@ struct RateLimitUsageTests {
         #expect(usage?.representativeClaim == "seven_day")
         #expect(usage?.fiveHourUtilization == 0.42)
         #expect(usage?.sevenDayUtilization == 0.85)
-        #expect(usage?.fiveHourReset?.timeIntervalSince1970 == 1700000000)
+        #expect(usage?.fiveHourReset?.timeIntervalSince1970 == 1_700_000_000)
         #expect(usage?.sevenDayStatus == "throttled")
         #expect(usage?.isThrottled == true)
     }
@@ -230,8 +229,8 @@ struct RateLimitUsageTests {
         #expect(usage?.representativeClaim == "seven_day")
         #expect(usage?.fiveHourUtilization == 0.37)
         #expect(usage?.sevenDayUtilization == 0.61)
-        #expect(usage?.fiveHourReset?.timeIntervalSince1970 == 1700000000)
-        #expect(usage?.sevenDayReset?.timeIntervalSince1970 == 1700500000)
+        #expect(usage?.fiveHourReset?.timeIntervalSince1970 == 1_700_000_000)
+        #expect(usage?.sevenDayReset?.timeIntervalSince1970 == 1_700_500_000)
         #expect(usage?.overallStatus == "allowed")
     }
 
@@ -281,13 +280,13 @@ struct RateLimitUsageTests {
     }
 
     @Test func bindingReset_fiveHour() {
-        let date = Date(timeIntervalSince1970: 1700000000)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
         let usage = makeUsage(claim: "five_hour", fiveHourReset: date, sevenDayReset: nil)
         #expect(usage.bindingReset == date)
     }
 
     @Test func bindingReset_sevenDay() {
-        let date = Date(timeIntervalSince1970: 1700500000)
+        let date = Date(timeIntervalSince1970: 1_700_500_000)
         let usage = makeUsage(claim: "seven_day", fiveHourReset: nil, sevenDayReset: date)
         #expect(usage.bindingReset == date)
     }
@@ -379,8 +378,8 @@ struct RateLimitUsageTests {
             claim: "five_hour",
             fiveHourUtil: 0.99,
             sevenDayUtil: 0.50,
-            fiveHourReset: now.addingTimeInterval(-3600),    // 1h ago
-            sevenDayReset: now.addingTimeInterval(-86400),   // 1d ago
+            fiveHourReset: now.addingTimeInterval(-3_600), // 1h ago
+            sevenDayReset: now.addingTimeInterval(-86_400), // 1d ago
             fiveHourStatus: "throttled",
             sevenDayStatus: "throttled",
             status: "throttled"
@@ -400,12 +399,12 @@ struct RateLimitUsageTests {
 
     @Test func withClearedExpiredWindows_onlyFiveHourExpired_keepsSevenDay() {
         let now = Date()
-        let sevenDayResetFuture = now.addingTimeInterval(86400)
+        let sevenDayResetFuture = now.addingTimeInterval(86_400)
         let usage = makeUsage(
             claim: "five_hour",
             fiveHourUtil: 0.99,
             sevenDayUtil: 0.50,
-            fiveHourReset: now.addingTimeInterval(-3600),
+            fiveHourReset: now.addingTimeInterval(-3_600),
             sevenDayReset: sevenDayResetFuture,
             fiveHourStatus: "throttled",
             sevenDayStatus: "allowed",
@@ -428,8 +427,8 @@ struct RateLimitUsageTests {
             claim: "seven_day",
             fiveHourUtil: 0.10,
             sevenDayUtil: 0.99,
-            fiveHourReset: now.addingTimeInterval(-3600),    // expired
-            sevenDayReset: now.addingTimeInterval(86400),    // future, binding
+            fiveHourReset: now.addingTimeInterval(-3_600), // expired
+            sevenDayReset: now.addingTimeInterval(86_400), // future, binding
             fiveHourStatus: "allowed",
             sevenDayStatus: "throttled",
             status: "throttled"
@@ -449,8 +448,8 @@ struct RateLimitUsageTests {
             claim: "five_hour",
             fiveHourUtil: 0.50,
             sevenDayUtil: 0.20,
-            fiveHourReset: now.addingTimeInterval(3600),
-            sevenDayReset: now.addingTimeInterval(86400),
+            fiveHourReset: now.addingTimeInterval(3_600),
+            sevenDayReset: now.addingTimeInterval(86_400),
             status: "allowed"
         )
 
@@ -469,7 +468,7 @@ struct RateLimitUsageTests {
         // 15% utilization — too low to show estimate (threshold is >20%)
         let usage = makeUsage(
             fiveHourUtil: 0.15,
-            fiveHourReset: Date().addingTimeInterval(3 * 3600)
+            fiveHourReset: Date().addingTimeInterval(3 * 3_600)
         )
         #expect(usage.estimatedTimeToLimit(for: "five_hour") == nil)
     }
@@ -479,18 +478,18 @@ struct RateLimitUsageTests {
         #expect(usage.estimatedTimeToLimit(for: "five_hour") == nil)
     }
 
-    @Test func estimatedTimeToLimit_highUtilization_returnsEstimate() {
+    @Test func estimatedTimeToLimit_highUtilization_returnsEstimate() throws {
         // 80% utilization with 2h remaining of a 5h window → 3h elapsed
         // rate = 0.80/10800 ≈ 7.4e-5/s, timeToFull = 0.20/rate ≈ 2700s (45 min)
         // 45 min < 2h remaining, so estimate should be returned
         let usage = makeUsage(
             fiveHourUtil: 0.80,
-            fiveHourReset: Date().addingTimeInterval(2 * 3600)
+            fiveHourReset: Date().addingTimeInterval(2 * 3_600)
         )
         let estimate = usage.estimatedTimeToLimit(for: "five_hour")
         #expect(estimate != nil)
-        #expect(estimate! > 0)
-        #expect(estimate! < 2 * 3600) // Must be before reset
+        #expect(try #require(estimate) > 0)
+        #expect(try #require(estimate) < 2 * 3_600) // Must be before reset
     }
 
     @Test func estimatedTimeToLimit_slowBurnRate_returnsNil() {
@@ -510,7 +509,7 @@ struct RateLimitUsageTests {
         // 2.1 days > 2 days remaining → nil (we'll be fine before reset)
         let usage = makeUsage(
             sevenDayUtil: 0.70,
-            sevenDayReset: Date().addingTimeInterval(2 * 24 * 3600)
+            sevenDayReset: Date().addingTimeInterval(2 * 24 * 3_600)
         )
         // At this rate, estimate is close to reset — could go either way
         // The key test is that it doesn't crash and returns a reasonable value or nil
@@ -533,7 +532,7 @@ struct RateLimitUsageTests {
         // Utilization at exactly 0.20 — threshold is > 0.20, so should return nil
         let usage = makeUsage(
             fiveHourUtil: 0.20,
-            fiveHourReset: Date().addingTimeInterval(2 * 3600)
+            fiveHourReset: Date().addingTimeInterval(2 * 3_600)
         )
         #expect(usage.estimatedTimeToLimit(for: "five_hour") == nil)
     }
@@ -543,12 +542,12 @@ struct RateLimitUsageTests {
         // 5h window = 18000s, reset in 17950s → only 50s elapsed
         let usage = makeUsage(
             fiveHourUtil: 0.60,
-            fiveHourReset: Date().addingTimeInterval(5 * 3600 - 50)
+            fiveHourReset: Date().addingTimeInterval(5 * 3_600 - 50)
         )
         #expect(usage.estimatedTimeToLimit(for: "five_hour") == nil)
     }
 
-    @Test func estimatedTimeToLimit_justAboveThreshold_returnsEstimate() {
+    @Test func estimatedTimeToLimit_justAboveThreshold_returnsEstimate() throws {
         // 25% utilization — above the 20% threshold, should not be blocked by the guard.
         // 5h window, reset in 4.5h → elapsed = 0.5h = 1800s
         // rate = 0.25/1800 ≈ 1.39e-4/s
@@ -557,11 +556,11 @@ struct RateLimitUsageTests {
         // This proves projections work in the 20-50% utilization range
         let usage = makeUsage(
             fiveHourUtil: 0.25,
-            fiveHourReset: Date().addingTimeInterval(4.5 * 3600)
+            fiveHourReset: Date().addingTimeInterval(4.5 * 3_600)
         )
         let estimate = usage.estimatedTimeToLimit(for: "five_hour")
         #expect(estimate != nil)
-        #expect(estimate! > 0)
+        #expect(try #require(estimate) > 0)
     }
 
     @Test func requestsPercentUsed_unknownClaim_defaultsToFiveHour() {
@@ -571,8 +570,8 @@ struct RateLimitUsageTests {
     }
 
     @Test func bindingReset_unknownClaim_defaultsToFiveHour() {
-        let fiveDate = Date(timeIntervalSince1970: 1700000000)
-        let sevenDate = Date(timeIntervalSince1970: 1700500000)
+        let fiveDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sevenDate = Date(timeIntervalSince1970: 1_700_500_000)
         let usage = makeUsage(claim: "unknown", fiveHourReset: fiveDate, sevenDayReset: sevenDate)
         #expect(usage.bindingReset == fiveDate)
     }
@@ -585,7 +584,7 @@ struct RateLimitUsageTests {
 
     @Test func countdownText_hoursAndMinutes() {
         let now = Date()
-        let future = now.addingTimeInterval(2 * 3600 + 30 * 60) // 2h 30m
+        let future = now.addingTimeInterval(2 * 3_600 + 30 * 60) // 2h 30m
         #expect(RateLimitUsage.countdownText(to: future, from: now) == "2h 30m")
     }
 
@@ -603,7 +602,7 @@ struct RateLimitUsageTests {
 
     @Test func countdownText_multiDay() {
         let now = Date()
-        let future = now.addingTimeInterval(3 * 24 * 3600 + 2 * 3600) // 3d 2h
+        let future = now.addingTimeInterval(3 * 24 * 3_600 + 2 * 3_600) // 3d 2h
         #expect(RateLimitUsage.countdownText(to: future, from: now) == "3d 2h")
     }
 
@@ -615,7 +614,7 @@ struct RateLimitUsageTests {
 
     @Test func countdownText_exactlyOneHour() {
         let now = Date()
-        let future = now.addingTimeInterval(3600) // exactly 1h
+        let future = now.addingTimeInterval(3_600) // exactly 1h
         #expect(RateLimitUsage.countdownText(to: future, from: now) == "1h 0m")
     }
 

--- a/Tests/AIBatteryCoreTests/Models/SessionEntryTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/SessionEntryTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("SessionEntry")
 struct SessionEntryTests {
-
     // MARK: - Codable decode
 
     @Test func decode_fullEntry() throws {
@@ -37,7 +36,7 @@ struct SessionEntryTests {
         #expect(entry.gitBranch == "main")
         #expect(entry.message?.role == "assistant")
         #expect(entry.message?.model == "claude-opus-4-6")
-        #expect(entry.message?.usage?.inputTokens == 1000)
+        #expect(entry.message?.usage?.inputTokens == 1_000)
         #expect(entry.message?.usage?.outputTokens == 500)
         #expect(entry.message?.usage?.cacheCreationInputTokens == 200)
         #expect(entry.message?.usage?.cacheReadInputTokens == 100)

--- a/Tests/AIBatteryCoreTests/Models/StandardRateLimitsTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/StandardRateLimitsTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("StandardRateLimits")
 struct StandardRateLimitsTests {
-
     @Test func parse_validHeaders_returnsLimits() {
         let headers: [AnyHashable: Any] = [
             "anthropic-ratelimit-requests-limit": "50",
@@ -18,8 +17,8 @@ struct StandardRateLimitsTests {
         #expect(result != nil)
         #expect(result?.requestsLimit == 50)
         #expect(result?.requestsRemaining == 45)
-        #expect(result?.tokensLimit == 80000)
-        #expect(result?.tokensRemaining == 75000)
+        #expect(result?.tokensLimit == 80_000)
+        #expect(result?.tokensRemaining == 75_000)
         #expect(result?.requestsReset != nil)
     }
 
@@ -31,8 +30,8 @@ struct StandardRateLimitsTests {
         let result = StandardRateLimits.parse(headers: headers)
         #expect(result != nil)
         #expect(result?.requestsLimit == 0)
-        #expect(result?.tokensLimit == 80000)
-        #expect(result?.tokensRemaining == 75000)
+        #expect(result?.tokensLimit == 80_000)
+        #expect(result?.tokensRemaining == 75_000)
     }
 
     @Test func parse_caseInsensitive_works() {
@@ -51,8 +50,8 @@ struct StandardRateLimitsTests {
             requestsLimit: 50,
             requestsRemaining: 30,
             requestsReset: nil,
-            tokensLimit: 80000,
-            tokensRemaining: 60000,
+            tokensLimit: 80_000,
+            tokensRemaining: 60_000,
             tokensReset: nil
         )
         #expect(limits.requestsPercent == 40.0) // 20/50 = 40%
@@ -77,7 +76,7 @@ struct StandardRateLimitsTests {
             requestsLimit: 50,
             requestsRemaining: 0,
             requestsReset: nil,
-            tokensLimit: 80000,
+            tokensLimit: 80_000,
             tokensRemaining: 0,
             tokensReset: nil
         )
@@ -90,8 +89,8 @@ struct StandardRateLimitsTests {
             requestsLimit: 50,
             requestsRemaining: 25,
             requestsReset: nil,
-            tokensLimit: 80000,
-            tokensRemaining: 40000,
+            tokensLimit: 80_000,
+            tokensRemaining: 40_000,
             tokensReset: nil
         )
         #expect(!limits.isRequestsExhausted)
@@ -114,10 +113,10 @@ struct StandardRateLimitsTests {
         ]
         let result = StandardRateLimits.parse(headers: headers)
         #expect(result != nil)
-        #expect(result?.requestsLimit == 100000)
-        #expect(result?.requestsRemaining == 85000)
-        #expect(result?.tokensLimit == 50000)
-        #expect(result?.tokensRemaining == 48000)
+        #expect(result?.requestsLimit == 100_000)
+        #expect(result?.requestsRemaining == 85_000)
+        #expect(result?.tokensLimit == 50_000)
+        #expect(result?.tokensRemaining == 48_000)
     }
 
     @Test func parse_unixTimestamp_parsesDate() {

--- a/Tests/AIBatteryCoreTests/Models/StatsCacheTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/StatsCacheTests.swift
@@ -4,15 +4,14 @@ import Foundation
 
 @Suite("StatsCache")
 struct StatsCacheTests {
-
     // MARK: - DailyActivity
 
-    @Test func dailyActivity_parsedDate_valid() {
+    @Test func dailyActivity_parsedDate_valid() throws {
         let activity = DailyActivity(date: "2025-06-15", messageCount: 10, sessionCount: 2, toolCallCount: 5)
         #expect(activity.parsedDate != nil)
         let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: activity.parsedDate!)
-        #expect(components.year == 2025)
+        let components = try calendar.dateComponents([.year, .month, .day], from: #require(activity.parsedDate))
+        #expect(components.year == 2_025)
         #expect(components.month == 6)
         #expect(components.day == 15)
     }

--- a/Tests/AIBatteryCoreTests/Models/TokenHealthConfigTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/TokenHealthConfigTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("TokenHealthConfig")
 struct TokenHealthConfigTests {
-
     // MARK: - Context window lookup
 
     @Test func contextWindow_exactMatch() {

--- a/Tests/AIBatteryCoreTests/Models/TokenHealthStatusTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/TokenHealthStatusTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("TokenHealthStatus")
 struct TokenHealthStatusTests {
-
     // MARK: - HealthBand raw values
 
     @Test func healthBand_rawValues() {
@@ -21,16 +20,16 @@ struct TokenHealthStatusTests {
         #expect(status.suggestedAction == nil)
     }
 
-    @Test func suggestedAction_orange() {
+    @Test func suggestedAction_orange() throws {
         let status = makeStatus(band: .orange)
         #expect(status.suggestedAction != nil)
-        #expect(status.suggestedAction!.contains("trimming"))
+        #expect(try #require(status.suggestedAction?.contains("trimming")))
     }
 
-    @Test func suggestedAction_red() {
+    @Test func suggestedAction_red() throws {
         let status = makeStatus(band: .red)
         #expect(status.suggestedAction != nil)
-        #expect(status.suggestedAction!.contains("new conversation"))
+        #expect(try #require(status.suggestedAction?.contains("new conversation")))
     }
 
     @Test func suggestedAction_unknown() {

--- a/Tests/AIBatteryCoreTests/Models/UsageSnapshotTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/UsageSnapshotTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("UsageSnapshot")
 struct UsageSnapshotTests {
-
     private func makeSnapshot(
         modelTokens: [ModelTokenSummary] = [],
         rateLimits: RateLimitUsage? = nil,
@@ -297,7 +296,7 @@ struct UsageSnapshotTests {
             fiveHourReset: nil,
             fiveHourStatus: "allowed",
             sevenDayUtilization: 1.0,
-            sevenDayReset: Date().addingTimeInterval(3600),
+            sevenDayReset: Date().addingTimeInterval(3_600),
             sevenDayStatus: "throttled",
             overallStatus: "throttled"
         )
@@ -322,7 +321,6 @@ struct UsageSnapshotTests {
         let snapshot = makeSnapshot(rateLimits: limits, topSessionHealths: [session])
         #expect(snapshot.autoResolvedMode == .fiveHour)
     }
-
 
     @Test func autoResolvedMode_throttled_overridesEvenFullContext() {
         let limits = RateLimitUsage(
@@ -357,7 +355,6 @@ struct UsageSnapshotTests {
         #expect(snapshot.autoResolvedMode == .sevenDay)
     }
 
-
     // MARK: - autoResolvedMode edge cases
 
     @Test func autoResolvedMode_exactly80_triggersRateLimitEscalation() {
@@ -383,7 +380,6 @@ struct UsageSnapshotTests {
         let snapshot = makeSnapshot(topSessionHealths: [session])
         #expect(snapshot.autoResolvedMode == .fiveHour)
     }
-
 
     // MARK: - autoResolvedMode escalation ladder
 
@@ -548,7 +544,7 @@ struct UsageSnapshotTests {
             overallStatus: "allowed"
         )
         let snapshot = makeSnapshot(rateLimits: limits)
-        let candidate = snapshot.autoResolvedMode  // Tier 4 binding = .sevenDay
+        let candidate = snapshot.autoResolvedMode // Tier 4 binding = .sevenDay
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .fiveHour,
@@ -587,7 +583,7 @@ struct UsageSnapshotTests {
         let active = makeHealth(id: "s1", usagePercentage: 58.0)
         let snapshot = makeSnapshot(rateLimits: limits, topSessionHealths: [active])
         // At 58% context (below 60%), autoResolvedMode returns Tier 4 binding
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (binding)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (binding)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .contextHealth,
@@ -606,7 +602,7 @@ struct UsageSnapshotTests {
         )
         let active = makeHealth(id: "s1", usagePercentage: 49.0)
         let snapshot = makeSnapshot(rateLimits: limits, topSessionHealths: [active])
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (binding)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (binding)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .contextHealth,
@@ -643,7 +639,7 @@ struct UsageSnapshotTests {
             overallStatus: "allowed"
         )
         let snapshot = makeSnapshot(rateLimits: limits)
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (Tier 2, RL >=80%)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (Tier 2, RL >=80%)
         // previous is also .fiveHour but from Tier 4 — same mode, so no conflict
         // Test a case where candidate differs: previous was .sevenDay binding, now .fiveHour escalation
         let result = UsageSnapshot.applyHysteresis(
@@ -668,7 +664,7 @@ struct UsageSnapshotTests {
         )
         let active = makeHealth(id: "s1", usagePercentage: 55.0)
         let snapshot = makeSnapshot(rateLimits: limits, topSessionHealths: [active])
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (Tier 1 throttle)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (Tier 1 throttle)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .contextHealth,
@@ -706,7 +702,7 @@ struct UsageSnapshotTests {
         let stale = makeHealth(id: "s1", usagePercentage: 55.0, band: .orange,
                                lastActivity: Date().addingTimeInterval(-31 * 60))
         let snapshot = makeSnapshot(rateLimits: limits, topSessionHealths: [stale])
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (stale session -> Tier 4)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (stale session -> Tier 4)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .contextHealth,
@@ -725,7 +721,7 @@ struct UsageSnapshotTests {
             overallStatus: "allowed"
         )
         let snapshot = makeSnapshot(rateLimits: limits)
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (Tier 4 binding, RL<80%)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (Tier 4 binding, RL<80%)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .sevenDay,
@@ -743,7 +739,7 @@ struct UsageSnapshotTests {
             overallStatus: "allowed"
         )
         let snapshot = makeSnapshot(rateLimits: limits)
-        let candidate = snapshot.autoResolvedMode  // .fiveHour (binding)
+        let candidate = snapshot.autoResolvedMode // .fiveHour (binding)
         let result = UsageSnapshot.applyHysteresis(
             candidate: candidate,
             previous: .sevenDay,
@@ -782,8 +778,8 @@ struct UsageSnapshotTests {
     @Test func trendDirection_13days_insufficientForSymmetricComparison() {
         // 13 days is not enough for a full 7-vs-7 comparison
         let activity = makeDailyActivity(daysBack: 13, messages: [
-            10, 10, 10, 10, 10, 10,  // 6 days of "last week"
-            50, 50, 50, 50, 50, 50, 50,  // 7 days of "this week"
+            10, 10, 10, 10, 10, 10, // 6 days of "last week"
+            50, 50, 50, 50, 50, 50, 50, // 7 days of "this week"
         ])
         let snapshot = makeSnapshot(dailyActivity: activity)
         #expect(snapshot.trendDirection == .flat)
@@ -792,8 +788,8 @@ struct UsageSnapshotTests {
     @Test func trendDirection_upWhenThisWeekHigher() {
         // Last week: 10/day avg, This week: 50/day avg → clearly up
         let activity = makeDailyActivity(daysBack: 14, messages: [
-            10, 10, 10, 10, 10, 10, 10,  // last week
-            50, 50, 50, 50, 50, 50, 50,  // this week
+            10, 10, 10, 10, 10, 10, 10, // last week
+            50, 50, 50, 50, 50, 50, 50, // this week
         ])
         let snapshot = makeSnapshot(dailyActivity: activity)
         #expect(snapshot.trendDirection == .up)
@@ -801,8 +797,8 @@ struct UsageSnapshotTests {
 
     @Test func trendDirection_downWhenThisWeekLower() {
         let activity = makeDailyActivity(daysBack: 14, messages: [
-            50, 50, 50, 50, 50, 50, 50,  // last week
-            10, 10, 10, 10, 10, 10, 10,  // this week
+            50, 50, 50, 50, 50, 50, 50, // last week
+            10, 10, 10, 10, 10, 10, 10, // this week
         ])
         let snapshot = makeSnapshot(dailyActivity: activity)
         #expect(snapshot.trendDirection == .down)
@@ -824,12 +820,12 @@ struct UsageSnapshotTests {
         #expect(snapshot.busiestDayOfWeek == nil)
     }
 
-    @Test func busiestDayOfWeek_returnsDay() {
+    @Test func busiestDayOfWeek_returnsDay() throws {
         let activity = makeDailyActivity(daysBack: 7, messages: [10, 10, 10, 100, 10, 10, 10])
         let snapshot = makeSnapshot(dailyActivity: activity)
         let busiest = snapshot.busiestDayOfWeek
         #expect(busiest != nil)
-        #expect(busiest!.averageCount > 0)
+        #expect(try #require(busiest?.averageCount) > 0)
     }
 
     // MARK: - TrendDirection symbols
@@ -850,19 +846,19 @@ struct UsageSnapshotTests {
         #expect(stats.busiestDay == nil)
     }
 
-    @Test func activityStats_singleWeek() {
+    @Test func activityStats_singleWeek() throws {
         let activity = makeDailyActivity(daysBack: 7, messages: [10, 20, 30, 40, 50, 60, 70])
         let stats = UsageSnapshot.computeActivityStats(activity)
         #expect(stats.average == 40) // 280 / 7
         #expect(stats.trend == .flat) // < 14 days
         #expect(stats.busiestDay != nil)
-        #expect(stats.busiestDay!.averageCount > 0)
+        #expect(try #require(stats.busiestDay?.averageCount) > 0)
     }
 
     @Test func activityStats_multiWeek_trendUp() {
         let activity = makeDailyActivity(daysBack: 14, messages: [
-            10, 10, 10, 10, 10, 10, 10,  // last week
-            50, 50, 50, 50, 50, 50, 50,  // this week
+            10, 10, 10, 10, 10, 10, 10, // last week
+            50, 50, 50, 50, 50, 50, 50, // this week
         ])
         let stats = UsageSnapshot.computeActivityStats(activity)
         #expect(stats.average == 50) // last 7: all 50

--- a/Tests/AIBatteryCoreTests/Services/AccountStoreTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/AccountStoreTests.swift
@@ -5,7 +5,6 @@ import Testing
 @Suite("AccountStore")
 @MainActor
 struct AccountStoreTests {
-
     /// Clean UserDefaults before each test to avoid cross-contamination.
     private func makeCleanStore() -> AccountStore {
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.accounts)
@@ -165,7 +164,7 @@ struct AccountStoreTests {
 
     @Test func persistence_surviesReinit() {
         let store = makeCleanStore()
-        let r1 = AccountRecord(id: "org-1", displayName: "Kyle", billingType: "pro", addedAt: Date(timeIntervalSince1970: 1700000000))
+        let r1 = AccountRecord(id: "org-1", displayName: "Kyle", billingType: "pro", addedAt: Date(timeIntervalSince1970: 1_700_000_000))
         store.add(r1)
 
         let store2 = AccountStore()
@@ -269,8 +268,8 @@ struct AccountStoreTests {
 
     @Test func update_mergePreservesEarliestAddedAt() {
         let store = makeCleanStore()
-        let earlier = Date(timeIntervalSince1970: 1000)
-        let later = Date(timeIntervalSince1970: 2000)
+        let earlier = Date(timeIntervalSince1970: 1_000)
+        let later = Date(timeIntervalSince1970: 2_000)
         let r1 = AccountRecord(id: "org-real", displayName: nil, billingType: nil, addedAt: earlier)
         let r2 = AccountRecord(id: "pending-abc", displayName: nil, billingType: nil, addedAt: later)
         store.add(r1)
@@ -355,8 +354,8 @@ struct AccountStoreTests {
 
     @Test func persistence_twoAccountsSurviveReinit() {
         let store = makeCleanStore()
-        let r1 = AccountRecord(id: "org-1", displayName: "A", billingType: nil, addedAt: Date(timeIntervalSince1970: 1700000000))
-        let r2 = AccountRecord(id: "org-2", displayName: "B", billingType: nil, addedAt: Date(timeIntervalSince1970: 1700000000))
+        let r1 = AccountRecord(id: "org-1", displayName: "A", billingType: nil, addedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let r2 = AccountRecord(id: "org-2", displayName: "B", billingType: nil, addedAt: Date(timeIntervalSince1970: 1_700_000_000))
         store.add(r1)
         store.add(r2)
         store.setActive(id: "org-2")

--- a/Tests/AIBatteryCoreTests/Services/NotificationManagerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/NotificationManagerTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("NotificationManager")
 struct NotificationManagerTests {
-
     @Test func shouldAlert_aboveThreshold_notPreviouslyFired() {
         #expect(NotificationManager.shouldAlert(percent: 85, threshold: 80, previouslyFired: false))
     }

--- a/Tests/AIBatteryCoreTests/Services/OAuthManagerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/OAuthManagerTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("OAuthManager.AuthError")
 struct OAuthManagerAuthErrorTests {
-
     // MARK: - userMessage
 
     @Test func userMessage_noVerifier() {

--- a/Tests/AIBatteryCoreTests/Services/RateLimitFetcherTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/RateLimitFetcherTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("RateLimitFetcher")
 struct RateLimitFetcherTests {
-
     // MARK: - Fetch with no token returns empty
 
     @Test @MainActor func fetch_emptyToken_returnsEmptyResult() async {
@@ -31,20 +30,20 @@ struct RateLimitFetcherTests {
         let rlA = RateLimitUsage(
             representativeClaim: "five_hour",
             fiveHourUtilization: 0.3,
-            fiveHourReset: Date().addingTimeInterval(3600),
+            fiveHourReset: Date().addingTimeInterval(3_600),
             fiveHourStatus: "allowed",
             sevenDayUtilization: 0.1,
-            sevenDayReset: Date().addingTimeInterval(86400),
+            sevenDayReset: Date().addingTimeInterval(86_400),
             sevenDayStatus: "allowed",
             overallStatus: "allowed"
         )
         let rlB = RateLimitUsage(
             representativeClaim: "five_hour",
             fiveHourUtilization: 0.7,
-            fiveHourReset: Date().addingTimeInterval(3600),
+            fiveHourReset: Date().addingTimeInterval(3_600),
             fiveHourStatus: "allowed",
             sevenDayUtilization: 0.4,
-            sevenDayReset: Date().addingTimeInterval(86400),
+            sevenDayReset: Date().addingTimeInterval(86_400),
             sevenDayStatus: "allowed",
             overallStatus: "allowed"
         )
@@ -76,10 +75,10 @@ struct RateLimitFetcherTests {
         let rateLimits = RateLimitUsage(
             representativeClaim: "five_hour",
             fiveHourUtilization: 0.5,
-            fiveHourReset: Date().addingTimeInterval(3600),
+            fiveHourReset: Date().addingTimeInterval(3_600),
             fiveHourStatus: "allowed",
             sevenDayUtilization: 0.2,
-            sevenDayReset: Date().addingTimeInterval(86400),
+            sevenDayReset: Date().addingTimeInterval(86_400),
             sevenDayStatus: "allowed",
             overallStatus: "allowed"
         )
@@ -107,17 +106,17 @@ struct RateLimitFetcherTests {
         let rateLimits = RateLimitUsage(
             representativeClaim: "five_hour",
             fiveHourUtilization: 0.5,
-            fiveHourReset: Date().addingTimeInterval(3600),
+            fiveHourReset: Date().addingTimeInterval(3_600),
             fiveHourStatus: "allowed",
             sevenDayUtilization: 0.2,
-            sevenDayReset: Date().addingTimeInterval(86400),
+            sevenDayReset: Date().addingTimeInterval(86_400),
             sevenDayStatus: "allowed",
             overallStatus: "allowed"
         )
         let cached = APIFetchResult(
             rateLimits: rateLimits,
             profile: nil,
-            fetchedAt: Date(timeIntervalSinceNow: -7200)
+            fetchedAt: Date(timeIntervalSinceNow: -7_200)
         )
         fetcher.setCachedResult(cached, for: "test-account")
 
@@ -272,7 +271,7 @@ struct RateLimitFetcherTests {
         #expect(fetcher.observedModels == ["restored-model-a", "restored-model-b"])
     }
 
-    @Test @MainActor func setObservedModels_emptyList_fallsBackToUltimateFallback() async {
+    @Test @MainActor func setObservedModels_emptyList_fallsBackToUltimateFallback() {
         let fetcher = RateLimitFetcher()
         // No observed models set — fetch should still attempt the ultimate fallback
         // (We can't fully test network behavior, but we verify observedModels is empty)

--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderDiscoveryTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderDiscoveryTests.swift
@@ -5,7 +5,6 @@ import Foundation
 @Suite("SessionLogReader — TTL-based Discovery Fallback")
 @MainActor
 struct SessionLogReaderDiscoveryTests {
-
     // MARK: - Helpers
 
     private func makeProjectsDir() throws -> URL {

--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderIntegrationTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderIntegrationTests.swift
@@ -9,7 +9,6 @@ import Foundation
 /// exercising real FileManager I/O rather than mocked internals.
 @Suite("SessionLogReader Integration", .serialized)
 struct SessionLogReaderIntegrationTests {
-
     // MARK: - Helpers
 
     /// Creates a temp projects directory with the given project subdirectories.
@@ -61,7 +60,7 @@ struct SessionLogReaderIntegrationTests {
 
     /// Sets a file's modification date to yesterday.
     private func backdateFile(at url: URL) throws {
-        let yesterday = Date().addingTimeInterval(-86400)
+        let yesterday = Date().addingTimeInterval(-86_400)
         try FileManager.default.setAttributes([.modificationDate: yesterday], ofItemAtPath: url.path)
     }
 

--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderSymlinkTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderSymlinkTests.swift
@@ -5,7 +5,6 @@ import Foundation
 @Suite("SessionLogReader — Symlink Boundary Check")
 @MainActor
 struct SessionLogReaderSymlinkTests {
-
     /// Files that resolve inside the projects directory should be kept.
     @Test func discoverFiles_keepsFilesInsideProjectsDir() throws {
         let tmpDir = FileManager.default.temporaryDirectory

--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderTests.swift
@@ -4,12 +4,11 @@ import Foundation
 
 @Suite("SessionLogReader")
 struct SessionLogReaderTests {
-
     // MARK: - AssistantUsageEntry model
 
     @Test func assistantUsageEntry_fieldsCorrect() {
         let entry = AssistantUsageEntry(
-            timestamp: Date(timeIntervalSince1970: 1000),
+            timestamp: Date(timeIntervalSince1970: 1_000),
             model: "claude-sonnet-4-5-20250929",
             messageId: "msg-123",
             inputTokens: 100,
@@ -58,7 +57,7 @@ struct SessionLogReaderTests {
         #expect(entry.message?.model == "claude-sonnet-4-5-20250929")
         #expect(entry.message?.usage?.inputTokens == 500)
         #expect(entry.message?.usage?.outputTokens == 120)
-        #expect(entry.message?.usage?.cacheReadInputTokens == 1000)
+        #expect(entry.message?.usage?.cacheReadInputTokens == 1_000)
         #expect(entry.message?.usage?.cacheCreationInputTokens == 0)
     }
 
@@ -398,7 +397,7 @@ struct SessionLogReaderTests {
         // Overwrite the file with a different entry.
         // Sleep ensures mod date changes (APFS has 1-second resolution for some APIs).
         Thread.sleep(forTimeInterval: 1.0)
-        try writeJSONL([assistantLine(messageId: "msg-001", inputTokens: 9999)], to: projectsDir)
+        try writeJSONL([assistantLine(messageId: "msg-001", inputTokens: 9_999)], to: projectsDir)
 
         // invalidate() with no scan running must mark dirty so next read re-scans.
         reader.invalidate()
@@ -406,7 +405,7 @@ struct SessionLogReaderTests {
         // Next read should pick up the changed file rather than returning the stale cache.
         let second = reader.readAllUsageEntries()
         #expect(second.count == 1)
-        #expect(second[0].inputTokens == 9999)
+        #expect(second[0].inputTokens == 9_999)
     }
 
     @Test func invalidate_afterScan_nextReadReturnsFreshData() throws {
@@ -445,7 +444,7 @@ struct SessionLogReaderTests {
         // Write entries with deliberately out-of-order timestamps across two files.
         try writeJSONL(
             [
-                assistantLine(messageId: "msg-late",  timestamp: "2026-02-17T12:00:00.000Z"),
+                assistantLine(messageId: "msg-late", timestamp: "2026-02-17T12:00:00.000Z"),
                 assistantLine(messageId: "msg-early", timestamp: "2026-02-17T08:00:00.000Z"),
             ],
             to: projectsDir,
@@ -695,7 +694,7 @@ struct SessionLogReaderTests {
 
     /// Simulates an old session file by backdating its modification date to yesterday.
     private func backdateFile(at url: URL) throws {
-        let yesterday = Date().addingTimeInterval(-86400)
+        let yesterday = Date().addingTimeInterval(-86_400)
         try FileManager.default.setAttributes([.modificationDate: yesterday], ofItemAtPath: url.path)
     }
 

--- a/Tests/AIBatteryCoreTests/Services/SparkleUpdateServiceTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SparkleUpdateServiceTests.swift
@@ -6,7 +6,6 @@ import Sparkle
 
 @Suite("SparkleUpdateService")
 struct SparkleUpdateServiceTests {
-
     @Test @MainActor func automaticChecksDisabled() {
         let service = SparkleUpdateService.shared
         #expect(service.updater.automaticallyChecksForUpdates == false)
@@ -22,13 +21,13 @@ struct SparkleUpdateServiceTests {
         #expect(service.updater.updateCheckInterval == 0)
     }
 
-    @Test @MainActor func feedURLIsSetWhenBundleHasPlist() {
+    @Test @MainActor func feedURLIsSetWhenBundleHasPlist() throws {
         let service = SparkleUpdateService.shared
         // In the app bundle, SUFeedURL is set in Info.plist.
         // In test bundles it may be nil — verify it doesn't crash either way.
         let feedURL = service.updater.feedURL
         if feedURL != nil {
-            let expected = URL(string: "https://kylenesium.github.io/AIBattery/appcast.xml")!
+            let expected = try #require(URL(string: "https://kylenesium.github.io/AIBattery/appcast.xml"))
             #expect(feedURL == expected)
         }
         // No assertion failure if nil — test environment lacks Info.plist

--- a/Tests/AIBatteryCoreTests/Services/StatsCacheReaderTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/StatsCacheReaderTests.swift
@@ -5,7 +5,6 @@ import Foundation
 @Suite("StatsCacheReader")
 @MainActor
 struct StatsCacheReaderTests {
-
     private func tempURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("test-stats-cache-\(UUID().uuidString).json")
@@ -136,14 +135,14 @@ struct StatsCacheReaderTests {
 
         // Daily model tokens
         #expect(result?.dailyModelTokens.count == 1)
-        #expect(result?.dailyModelTokens[0].tokensByModel["claude-sonnet-4-5-20250929"] == 50000)
+        #expect(result?.dailyModelTokens[0].tokensByModel["claude-sonnet-4-5-20250929"] == 50_000)
 
         // Model usage
         #expect(result?.modelUsage.count == 1)
         let sonnet = result?.modelUsage["claude-sonnet-4-5-20250929"]
-        #expect(sonnet?.inputTokens == 10000)
-        #expect(sonnet?.outputTokens == 5000)
-        #expect(sonnet?.cacheReadInputTokens == 2000)
+        #expect(sonnet?.inputTokens == 10_000)
+        #expect(sonnet?.outputTokens == 5_000)
+        #expect(sonnet?.cacheReadInputTokens == 2_000)
         #expect(sonnet?.cacheCreationInputTokens == 500)
 
         // Longest session
@@ -168,7 +167,7 @@ struct StatsCacheReaderTests {
         let decoded = try JSONDecoder().decode(DailyModelTokens.self, from: Data(json.utf8))
         #expect(decoded.date == "2025-06-15")
         #expect(decoded.tokensByModel.count == 2)
-        #expect(decoded.tokensByModel["claude-opus-4-6"] == 100000)
+        #expect(decoded.tokensByModel["claude-opus-4-6"] == 100_000)
     }
 
     @Test func dailyModelTokens_emptyModels() throws {
@@ -186,13 +185,13 @@ struct StatsCacheReaderTests {
         {"inputTokens": 1000, "outputTokens": 500, "cacheReadInputTokens": 200, "cacheCreationInputTokens": 50, "webSearchRequests": 3, "contextWindow": 200000, "maxOutputTokens": 8192}
         """
         let decoded = try JSONDecoder().decode(ModelUsageEntry.self, from: Data(json.utf8))
-        #expect(decoded.inputTokens == 1000)
+        #expect(decoded.inputTokens == 1_000)
         #expect(decoded.outputTokens == 500)
         #expect(decoded.cacheReadInputTokens == 200)
         #expect(decoded.cacheCreationInputTokens == 50)
         #expect(decoded.webSearchRequests == 3)
-        #expect(decoded.contextWindow == 200000)
-        #expect(decoded.maxOutputTokens == 8192)
+        #expect(decoded.contextWindow == 200_000)
+        #expect(decoded.maxOutputTokens == 8_192)
     }
 
     @Test func modelUsageEntry_optionalFieldsMissing() throws {
@@ -207,7 +206,7 @@ struct StatsCacheReaderTests {
 
     // MARK: - File Size Guard
 
-    @Test func read_returnsNil_forOversizedFile() throws {
+    @Test func read_returnsNil_forOversizedFile() {
         #expect(StatsCacheReader.maxFileSize == 10_000_000)
     }
 

--- a/Tests/AIBatteryCoreTests/Services/StatusCheckerParsingTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/StatusCheckerParsingTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("StatusChecker — incident escalation")
 struct StatusCheckerParsingTests {
-
     // MARK: - Incident impact parsing
 
     /// "none" impact should map to operational via StatusIndicator.from().

--- a/Tests/AIBatteryCoreTests/Services/StatusIndicatorTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/StatusIndicatorTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("StatusIndicator")
 struct StatusIndicatorTests {
-
     // MARK: - from() parsing
 
     @Test func from_operational() {

--- a/Tests/AIBatteryCoreTests/Services/TokenHealthMonitorTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/TokenHealthMonitorTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("TokenHealthMonitor")
 struct TokenHealthMonitorTests {
-
     let monitor = TokenHealthMonitor()
 
     // MARK: - Band classification
@@ -54,69 +53,69 @@ struct TokenHealthMonitorTests {
 
     // MARK: - Overflow guards
 
-    @Test func assess_overflowCapsAtContextWindow() {
+    @Test func assess_overflowCapsAtContextWindow() throws {
         // Absurdly large input — should be capped
         let entries = [makeEntry(sessionId: "s1", input: 999_999_999, output: 999_999_999)]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        #expect(result!.totalUsed <= result!.contextWindow)
+        #expect(try #require(result?.totalUsed) <= result!.contextWindow)
     }
 
     // MARK: - Turn count warnings
 
-    @Test func assess_infoTurnWarning() {
+    @Test func assess_infoTurnWarning() throws {
         // 16 turns → info warning (> 15, ≤ 25) — informational, not actionable
         let entries = (0..<16).map { i in
-            makeEntry(sessionId: "s1", input: 1000 * (i + 1), output: 100, timestamp: Date().addingTimeInterval(Double(i) * 60))
+            makeEntry(sessionId: "s1", input: 1_000 * (i + 1), output: 100, timestamp: Date().addingTimeInterval(Double(i) * 60))
         }
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
         #expect(result?.turnCount == 16)
-        let turnWarnings = result!.warnings.filter { $0.message.contains("turns") }
+        let turnWarnings = try #require(result?.warnings.filter { $0.message.contains("turns") })
         #expect(turnWarnings.count == 1)
         #expect(turnWarnings.first?.severity == .info)
     }
 
-    @Test func assess_strongTurnWarning() {
+    @Test func assess_strongTurnWarning() throws {
         // 26 turns → strong warning (> 25)
         let entries = (0..<26).map { i in
             makeEntry(sessionId: "s1", input: 500 * (i + 1), output: 50, timestamp: Date().addingTimeInterval(Double(i) * 60))
         }
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let turnWarnings = result!.warnings.filter { $0.message.contains("turns") }
+        let turnWarnings = try #require(result?.warnings.filter { $0.message.contains("turns") })
         #expect(turnWarnings.count == 1)
         #expect(turnWarnings.first?.severity == .strong)
     }
 
-    @Test func assess_noTurnWarning() {
+    @Test func assess_noTurnWarning() throws {
         // 10 turns → no warning (≤ 15)
         let entries = (0..<10).map { i in
             makeEntry(sessionId: "s1", input: 500, output: 50, timestamp: Date().addingTimeInterval(Double(i) * 60))
         }
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let turnWarnings = result!.warnings.filter { $0.message.contains("turns") }
+        let turnWarnings = try #require(result?.warnings.filter { $0.message.contains("turns") })
         #expect(turnWarnings.isEmpty)
     }
 
     // MARK: - Input/output ratio warning
 
-    @Test func assess_highRatioWarning() {
+    @Test func assess_highRatioWarning() throws {
         // Input:output ratio > 20:1 → info severity (informational, not actionable)
         let entries = [makeEntry(sessionId: "s1", input: 50_000, output: 100)]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let ratioWarnings = result!.warnings.filter { $0.message.contains("ratio") }
+        let ratioWarnings = try #require(result?.warnings.filter { $0.message.contains("ratio") })
         #expect(ratioWarnings.count == 1)
         #expect(ratioWarnings.first?.severity == .info)
     }
 
-    @Test func assess_normalRatio_noWarning() {
+    @Test func assess_normalRatio_noWarning() throws {
         let entries = [makeEntry(sessionId: "s1", input: 5_000, output: 2_000)]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let ratioWarnings = result!.warnings.filter { $0.message.contains("ratio") }
+        let ratioWarnings = try #require(result?.warnings.filter { $0.message.contains("ratio") })
         #expect(ratioWarnings.isEmpty)
     }
 
@@ -124,9 +123,9 @@ struct TokenHealthMonitorTests {
 
     @Test func assessSessions_groupsBySessionId() {
         let entries = [
-            makeEntry(sessionId: "s1", input: 1000, output: 100),
-            makeEntry(sessionId: "s2", input: 2000, output: 200),
-            makeEntry(sessionId: "s1", input: 1500, output: 150),
+            makeEntry(sessionId: "s1", input: 1_000, output: 100),
+            makeEntry(sessionId: "s2", input: 2_000, output: 200),
+            makeEntry(sessionId: "s1", input: 1_500, output: 150),
         ]
         let results = monitor.assessSessions(entries: entries, topLimit: 10)
         #expect(results.top.count == 2)
@@ -142,7 +141,7 @@ struct TokenHealthMonitorTests {
 
     @Test func assessSessions_currentSessionAlwaysInTop() {
         // Current session is idle past cutoff but should still appear in top
-        let oldTime = Date().addingTimeInterval(-48 * 3600) // 48h ago
+        let oldTime = Date().addingTimeInterval(-48 * 3_600) // 48h ago
         let entries = [
             makeEntry(sessionId: "current", input: 50_000, output: 1_000, timestamp: oldTime),
         ]
@@ -154,12 +153,12 @@ struct TokenHealthMonitorTests {
 
     @Test func topSessions_excludesOldSessions() {
         let recentTime = Date()
-        let oldTime = Date().addingTimeInterval(-48 * 3600) // 48h ago
+        let oldTime = Date().addingTimeInterval(-48 * 3_600) // 48h ago
 
         // Entries sorted by timestamp ascending (as SessionLogReader delivers them)
         let entries = [
-            makeEntry(sessionId: "old", input: 2000, output: 200, timestamp: oldTime),
-            makeEntry(sessionId: "recent", input: 1000, output: 100, timestamp: recentTime),
+            makeEntry(sessionId: "old", input: 2_000, output: 200, timestamp: oldTime),
+            makeEntry(sessionId: "recent", input: 1_000, output: 100, timestamp: recentTime),
         ]
         let top = monitor.topSessions(entries: entries, limit: 5)
         // "recent" is current (entries.last) so always included; "old" excluded by 24h cutoff
@@ -171,9 +170,9 @@ struct TokenHealthMonitorTests {
         let now = Date()
         // s3 has highest input (most context consumed), then s2, then s1
         let entries = [
-            makeEntry(sessionId: "s1", input: 1000, output: 100, timestamp: now.addingTimeInterval(-3600)),
-            makeEntry(sessionId: "s2", input: 2000, output: 200, timestamp: now),
-            makeEntry(sessionId: "s3", input: 3000, output: 300, timestamp: now.addingTimeInterval(-7200)),
+            makeEntry(sessionId: "s1", input: 1_000, output: 100, timestamp: now.addingTimeInterval(-3_600)),
+            makeEntry(sessionId: "s2", input: 2_000, output: 200, timestamp: now),
+            makeEntry(sessionId: "s3", input: 3_000, output: 300, timestamp: now.addingTimeInterval(-7_200)),
         ]
         let top = monitor.topSessions(entries: entries, limit: 5)
         #expect(top.count == 3)
@@ -186,7 +185,7 @@ struct TokenHealthMonitorTests {
     @Test func topSessions_respectsLimit() {
         let now = Date()
         let entries = (0..<10).map { i in
-            makeEntry(sessionId: "s\(i)", input: 1000, output: 100, timestamp: now.addingTimeInterval(Double(-i) * 60))
+            makeEntry(sessionId: "s\(i)", input: 1_000, output: 100, timestamp: now.addingTimeInterval(Double(-i) * 60))
         }
         let top = monitor.topSessions(entries: entries, limit: 3)
         #expect(top.count == 3)
@@ -195,20 +194,20 @@ struct TokenHealthMonitorTests {
     // MARK: - Metadata extraction
 
     @Test func assess_extractsProjectName() {
-        let entries = [makeEntry(sessionId: "s1", input: 1000, output: 100, cwd: "/Users/test/MyProject")]
+        let entries = [makeEntry(sessionId: "s1", input: 1_000, output: 100, cwd: "/Users/test/MyProject")]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result?.projectName == "MyProject")
     }
 
     @Test func assess_extractsGitBranch() {
-        let entries = [makeEntry(sessionId: "s1", input: 1000, output: 100, cwd: "/Users/test/MyProject", gitBranch: "feat/tests")]
+        let entries = [makeEntry(sessionId: "s1", input: 1_000, output: 100, cwd: "/Users/test/MyProject", gitBranch: "feat/tests")]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result?.gitBranch == "feat/tests")
     }
 
     // MARK: - Velocity calculation
 
-    @Test func assess_velocityCalculated() {
+    @Test func assess_velocityCalculated() throws {
         let start = Date()
         let entries = [
             makeEntry(sessionId: "s1", input: 5_000, output: 500, timestamp: start),
@@ -217,7 +216,7 @@ struct TokenHealthMonitorTests {
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result?.tokensPerMinute != nil)
         // totalUsed = 10K + 500 latestOutput = 10.5K, duration = 2 min → ~5250/min
-        #expect(result!.tokensPerMinute! > 0)
+        #expect(try #require(result?.tokensPerMinute) > 0)
     }
 
     @Test func assess_noVelocity_singleEntry() {
@@ -239,29 +238,29 @@ struct TokenHealthMonitorTests {
 
     // MARK: - Anomaly detection
 
-    @Test func assess_zeroOutput_manyTurns() {
+    @Test func assess_zeroOutput_manyTurns() throws {
         // 5 turns with zero output → warning
         let entries = (0..<5).map { i in
-            makeEntry(sessionId: "s1", input: 1000 * (i + 1), output: 0, timestamp: Date().addingTimeInterval(Double(i) * 120))
+            makeEntry(sessionId: "s1", input: 1_000 * (i + 1), output: 0, timestamp: Date().addingTimeInterval(Double(i) * 120))
         }
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let zeroOutputWarnings = result!.warnings.filter { $0.message.contains("No output") }
+        let zeroOutputWarnings = try #require(result?.warnings.filter { $0.message.contains("No output") })
         #expect(zeroOutputWarnings.count == 1)
         #expect(zeroOutputWarnings.first?.severity == .strong)
     }
 
-    @Test func assess_zeroOutput_fewTurns_noWarning() {
+    @Test func assess_zeroOutput_fewTurns_noWarning() throws {
         // 2 turns with zero output → below threshold, no warning
         let entries = (0..<2).map { i in
-            makeEntry(sessionId: "s1", input: 1000 * (i + 1), output: 0, timestamp: Date().addingTimeInterval(Double(i) * 120))
+            makeEntry(sessionId: "s1", input: 1_000 * (i + 1), output: 0, timestamp: Date().addingTimeInterval(Double(i) * 120))
         }
         let result = monitor.assessCurrentSession(entries: entries)
-        let zeroOutputWarnings = result!.warnings.filter { $0.message.contains("No output") }
+        let zeroOutputWarnings = try #require(result?.warnings.filter { $0.message.contains("No output") })
         #expect(zeroOutputWarnings.isEmpty)
     }
 
-    @Test func assess_staleSession_nonGreenBand() {
+    @Test func assess_staleSession_nonGreenBand() throws {
         // Session with last activity 45 min ago and orange band → stale warning
         // Need totalUsed > 60% of 1M = 600K for orange band
         let staleTime = Date().addingTimeInterval(-45 * 60)
@@ -271,11 +270,11 @@ struct TokenHealthMonitorTests {
         ]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let staleWarnings = result!.warnings.filter { $0.message.contains("idle") }
+        let staleWarnings = try #require(result?.warnings.filter { $0.message.contains("idle") })
         #expect(staleWarnings.count == 1)
     }
 
-    @Test func assess_staleSession_greenBand_noWarning() {
+    @Test func assess_staleSession_greenBand_noWarning() throws {
         // Green band session idle 45 min → no stale warning (green is fine)
         let staleTime = Date().addingTimeInterval(-45 * 60)
         let entries = [
@@ -283,7 +282,7 @@ struct TokenHealthMonitorTests {
             makeEntry(sessionId: "s1", input: 1_000, output: 100, timestamp: staleTime),
         ]
         let result = monitor.assessCurrentSession(entries: entries)
-        let staleWarnings = result!.warnings.filter { $0.message.contains("idle") }
+        let staleWarnings = try #require(result?.warnings.filter { $0.message.contains("idle") })
         #expect(staleWarnings.isEmpty)
     }
 
@@ -310,7 +309,7 @@ struct TokenHealthMonitorTests {
 
     // MARK: - Rapid consumption
 
-    @Test func assess_rapidConsumption_triggered() {
+    @Test func assess_rapidConsumption_triggered() throws {
         // 2 entries within 30 seconds, high token usage → warning
         let start = Date()
         let entries = [
@@ -319,11 +318,11 @@ struct TokenHealthMonitorTests {
         ]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let rapidWarnings = result!.warnings.filter { $0.message.contains("Rapid") }
+        let rapidWarnings = try #require(result?.warnings.filter { $0.message.contains("Rapid") })
         #expect(rapidWarnings.count == 1)
     }
 
-    @Test func assess_rapidConsumption_notTriggered_longSession() {
+    @Test func assess_rapidConsumption_notTriggered_longSession() throws {
         // 2 entries over 2 minutes — not rapid
         let start = Date()
         let entries = [
@@ -332,11 +331,11 @@ struct TokenHealthMonitorTests {
         ]
         let result = monitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let rapidWarnings = result!.warnings.filter { $0.message.contains("Rapid") }
+        let rapidWarnings = try #require(result?.warnings.filter { $0.message.contains("Rapid") })
         #expect(rapidWarnings.isEmpty)
     }
 
-    @Test func assess_rapidConsumption_customConfig() {
+    @Test func assess_rapidConsumption_customConfig() throws {
         var config = TokenHealthConfig()
         config.rapidConsumptionSeconds = 120
         config.rapidConsumptionTokens = 10_000
@@ -349,7 +348,7 @@ struct TokenHealthMonitorTests {
         ]
         let result = customMonitor.assessCurrentSession(entries: entries)
         #expect(result != nil)
-        let rapidWarnings = result!.warnings.filter { $0.message.contains("Rapid") }
+        let rapidWarnings = try #require(result?.warnings.filter { $0.message.contains("Rapid") })
         #expect(rapidWarnings.count == 1)
     }
 

--- a/Tests/AIBatteryCoreTests/Services/TokenLedgerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/TokenLedgerTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("TokenLedger")
 struct TokenLedgerTests {
-
     private func makeTempURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("TokenLedgerTests-\(UUID().uuidString).json")
@@ -48,12 +47,12 @@ struct TokenLedgerTests {
         let ledger = TokenLedger(fileURL: url)
 
         // First merge — stores 1000 input
-        _ = ledger.merge([makeToken(input: 1000, output: 500)], accountId: "acc1")
+        _ = ledger.merge([makeToken(input: 1_000, output: 500)], accountId: "acc1")
 
         // Second merge with lower values (stats-cache rebuilt)
         let result = ledger.merge([makeToken(input: 200, output: 100)], accountId: "acc1")
 
-        #expect(result[0].inputTokens == 1000)
+        #expect(result[0].inputTokens == 1_000)
         #expect(result[0].outputTokens == 500)
     }
 
@@ -75,14 +74,14 @@ struct TokenLedgerTests {
 
         // Store both models
         let tokens = [
-            makeToken(id: "claude-opus-4-6", displayName: "Opus 4.6", input: 1000),
+            makeToken(id: "claude-opus-4-6", displayName: "Opus 4.6", input: 1_000),
             makeToken(id: "claude-sonnet-4-6", displayName: "Sonnet 4.6", input: 500),
         ]
         _ = ledger.merge(tokens, accountId: "acc1")
 
         // New data only has Opus (Sonnet lost from stats-cache)
         let result = ledger.merge(
-            [makeToken(id: "claude-opus-4-6", displayName: "Opus 4.6", input: 1000)],
+            [makeToken(id: "claude-opus-4-6", displayName: "Opus 4.6", input: 1_000)],
             accountId: "acc1"
         )
 
@@ -98,7 +97,7 @@ struct TokenLedgerTests {
         let url = makeTempURL()
         let ledger = TokenLedger(fileURL: url)
 
-        _ = ledger.merge([makeToken(input: 1000)], accountId: "acc1")
+        _ = ledger.merge([makeToken(input: 1_000)], accountId: "acc1")
         let result = ledger.merge([makeToken(input: 100)], accountId: "acc2")
 
         // acc2 should not see acc1's values
@@ -111,13 +110,13 @@ struct TokenLedgerTests {
         let url = makeTempURL()
 
         let ledger1 = TokenLedger(fileURL: url)
-        _ = ledger1.merge([makeToken(input: 1000)], accountId: "acc1")
+        _ = ledger1.merge([makeToken(input: 1_000)], accountId: "acc1")
         ledger1.flushForTesting()
 
         let ledger2 = TokenLedger(fileURL: url)
         let result = ledger2.merge([makeToken(input: 200)], accountId: "acc1")
 
-        #expect(result[0].inputTokens == 1000)
+        #expect(result[0].inputTokens == 1_000)
     }
 
     // MARK: - Sort order
@@ -183,15 +182,15 @@ struct TokenLedgerTests {
         #expect(modBefore == modAfter)
     }
 
-    @Test @MainActor func merge_singleCallWritesOnce() throws {
+    @Test @MainActor func merge_singleCallWritesOnce() {
         let url = makeTempURL()
         let ledger1 = TokenLedger(fileURL: url)
 
         // Merge 3 different models in one call
         let tokens = [
-            makeToken(id: "claude-a", displayName: "A", input: 1000, output: 500),
-            makeToken(id: "claude-b", displayName: "B", input: 2000, output: 1000),
-            makeToken(id: "claude-c", displayName: "C", input: 3000, output: 1500),
+            makeToken(id: "claude-a", displayName: "A", input: 1_000, output: 500),
+            makeToken(id: "claude-b", displayName: "B", input: 2_000, output: 1_000),
+            makeToken(id: "claude-c", displayName: "C", input: 3_000, output: 1_500),
         ]
         _ = ledger1.merge(tokens, accountId: "acc1")
         ledger1.flushForTesting()
@@ -211,9 +210,9 @@ struct TokenLedgerTests {
         let a = result.first(where: { $0.id == "claude-a" })
         let b = result.first(where: { $0.id == "claude-b" })
         let c = result.first(where: { $0.id == "claude-c" })
-        #expect(a?.inputTokens == 1000)
-        #expect(b?.inputTokens == 2000)
-        #expect(c?.inputTokens == 3000)
+        #expect(a?.inputTokens == 1_000)
+        #expect(b?.inputTokens == 2_000)
+        #expect(c?.inputTokens == 3_000)
     }
 
     @Test @MainActor func merge_mixedChanges_writesOnlyOnce() throws {
@@ -286,7 +285,7 @@ struct TokenLedgerTests {
         defer { try? FileManager.default.removeItem(at: badParent) }
 
         let ledger = TokenLedger(fileURL: url)
-        _ = ledger.merge([makeToken(input: 1000, output: 500)], accountId: "acc1")
+        _ = ledger.merge([makeToken(input: 1_000, output: 500)], accountId: "acc1")
         ledger.flushForTesting() // first write fails silently — parent dir missing
 
         // File must not exist yet — write failed.
@@ -305,7 +304,7 @@ struct TokenLedgerTests {
         // not just that an empty file was created.
         let fresh = TokenLedger(fileURL: url)
         let result = fresh.merge([makeToken(input: 0, output: 0)], accountId: "acc1")
-        #expect(result.first?.inputTokens == 1000)
+        #expect(result.first?.inputTokens == 1_000)
         #expect(result.first?.outputTokens == 500)
     }
 }

--- a/Tests/AIBatteryCoreTests/Services/UsageAggregatorIntegrationTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/UsageAggregatorIntegrationTests.swift
@@ -9,7 +9,6 @@ import Foundation
 /// pointed at a non-existent file (JSONL-only aggregation, no stats-cache).
 @Suite("UsageAggregator Integration", .serialized)
 struct UsageAggregatorIntegrationTests {
-
     // MARK: - Helpers
 
     private func tempDir(id: String = UUID().uuidString) -> URL {
@@ -60,7 +59,7 @@ struct UsageAggregatorIntegrationTests {
 
     /// Sets a file's modification date to yesterday.
     private func backdateFile(at url: URL) throws {
-        let yesterday = Date().addingTimeInterval(-86400)
+        let yesterday = Date().addingTimeInterval(-86_400)
         try FileManager.default.setAttributes([.modificationDate: yesterday], ofItemAtPath: url.path)
     }
 
@@ -134,7 +133,7 @@ struct UsageAggregatorIntegrationTests {
                     output: 120,
                     sessionId: "old-sess",
                     messageId: "msg-old-1",
-                    timestamp: Date().addingTimeInterval(-86400), // yesterday's timestamp
+                    timestamp: Date().addingTimeInterval(-86_400), // yesterday's timestamp
                     cwd: "/proj/old"
                 ),
                 makeAssistantLine(
@@ -142,7 +141,7 @@ struct UsageAggregatorIntegrationTests {
                     output: 160,
                     sessionId: "old-sess",
                     messageId: "msg-old-2",
-                    timestamp: Date().addingTimeInterval(-86400),
+                    timestamp: Date().addingTimeInterval(-86_400),
                     cwd: "/proj/old"
                 ),
             ],
@@ -219,6 +218,6 @@ struct UsageAggregatorIntegrationTests {
         let (snapshot2, _) = aggregator.aggregate(rateLimits: nil)
         #expect(snapshot2.todayMessages == 5, "Second aggregate: 2 + 3 = 5 total messages")
         let total2 = snapshot2.todayModelTokens.reduce(0) { $0 + $1.inputTokens }
-        #expect(total2 == 1100, "Second aggregate: 100+100+200+300+400 = 1100 input tokens")
+        #expect(total2 == 1_100, "Second aggregate: 100+100+200+300+400 = 1100 input tokens")
     }
 }

--- a/Tests/AIBatteryCoreTests/Services/UsageAggregatorTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/UsageAggregatorTests.swift
@@ -5,7 +5,6 @@ import Foundation
 @Suite("UsageAggregator", .serialized)
 @MainActor
 struct UsageAggregatorTests {
-
     // MARK: - Helpers
 
     private func tempDir() -> URL {
@@ -165,10 +164,10 @@ struct UsageAggregatorTests {
         let rateLimits = RateLimitUsage(
             representativeClaim: "five_hour",
             fiveHourUtilization: 0.425,
-            fiveHourReset: Date().addingTimeInterval(3600),
+            fiveHourReset: Date().addingTimeInterval(3_600),
             fiveHourStatus: "allowed",
             sevenDayUtilization: 0.15,
-            sevenDayReset: Date().addingTimeInterval(86400),
+            sevenDayReset: Date().addingTimeInterval(86_400),
             sevenDayStatus: "allowed",
             overallStatus: "allowed"
         )
@@ -285,7 +284,7 @@ struct UsageAggregatorTests {
         #expect(!snapshot.modelTokens.isEmpty)
         if let sonnet = snapshot.modelTokens.first(where: { $0.id == "claude-sonnet-4-5-20250929" }) {
             // Stats cache has 10000 input + 5000 output + 2000 cache read + 500 cache write = 17500
-            #expect(sonnet.totalTokens == 17500)
+            #expect(sonnet.totalTokens == 17_500)
         }
     }
 
@@ -421,8 +420,8 @@ struct UsageAggregatorTests {
 
         let calendar = Calendar.current
         let now = Date()
-        let hour10 = calendar.date(bySettingHour: 10, minute: 30, second: 0, of: now)!
-        let hour11 = calendar.date(bySettingHour: 11, minute: 15, second: 0, of: now)!
+        let hour10 = try #require(calendar.date(bySettingHour: 10, minute: 30, second: 0, of: now))
+        let hour11 = try #require(calendar.date(bySettingHour: 11, minute: 15, second: 0, of: now))
 
         let lines = [
             makeAssistantLine(input: 100, output: 50, messageId: "hour-msg-1", timestamp: hour10),
@@ -455,7 +454,7 @@ struct UsageAggregatorTests {
 
         let calendar = Calendar.current
         let now = Date()
-        let hour9 = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: now)!
+        let hour9 = try #require(calendar.date(bySettingHour: 9, minute: 0, second: 0, of: now))
 
         // Add 30 messages at hour 9 to surpass the cache peak of 25
         var lines: [String] = []
@@ -606,8 +605,8 @@ struct UsageAggregatorTests {
         // Model should appear even without recent activity
         let opus = snapshot.modelTokens.first(where: { $0.id == "claude-opus-4-20250514" })
         #expect(opus != nil)
-        #expect(opus?.totalTokens == 95000)
-        #expect(snapshot.totalTokens == 95000)
+        #expect(opus?.totalTokens == 95_000)
+        #expect(snapshot.totalTokens == 95_000)
     }
 
     // MARK: - All-dates daily merge
@@ -619,8 +618,8 @@ struct UsageAggregatorTests {
         let formatter = DateFormatters.dateKey
         let cal = Calendar.current
         let now = Date()
-        let yesterday = cal.date(byAdding: .day, value: -1, to: now)!
-        let twoDaysAgo = cal.date(byAdding: .day, value: -2, to: now)!
+        let yesterday = try #require(cal.date(byAdding: .day, value: -1, to: now))
+        let twoDaysAgo = try #require(cal.date(byAdding: .day, value: -2, to: now))
         let yesterdayStr = formatter.string(from: yesterday)
         let twoDaysAgoStr = formatter.string(from: twoDaysAgo)
 
@@ -677,7 +676,7 @@ struct UsageAggregatorTests {
 
         let calendar = Calendar.current
         let now = Date()
-        let hour10 = calendar.date(bySettingHour: 10, minute: 0, second: 0, of: now)!
+        let hour10 = try #require(calendar.date(bySettingHour: 10, minute: 0, second: 0, of: now))
         let lines = [
             makeAssistantLine(input: 10, output: 5, messageId: "today-h10-1", timestamp: hour10),
             makeAssistantLine(input: 10, output: 5, messageId: "today-h10-2", timestamp: hour10),
@@ -775,7 +774,7 @@ struct UsageAggregatorTests {
         let myapp = snapshot.projectTokens.first(where: { $0.projectName == "myapp" })
         #expect(myapp != nil)
         // Sonnet input: $3/M * 1M = $3, Opus input: $15/M * 1M = $15 → total $18
-        #expect(myapp!.estimatedCost == 18.0)
+        #expect(myapp?.estimatedCost == 18.0)
     }
 
     @Test func projectTokens_emptyWhenNoEntries() {
@@ -903,9 +902,9 @@ struct UsageAggregatorTests {
         let now = Date()
         // Project A: two different models
         let projALines = [
-            makeAssistantLine(model: "claude-sonnet-4-5-20250929", input: 1000, output: 500,
+            makeAssistantLine(model: "claude-sonnet-4-5-20250929", input: 1_000, output: 500,
                               messageId: "map-a1", timestamp: now, cwd: "/workspace/project-alpha"),
-            makeAssistantLine(model: "claude-opus-4-20250514", input: 2000, output: 1000,
+            makeAssistantLine(model: "claude-opus-4-20250514", input: 2_000, output: 1_000,
                               messageId: "map-a2", timestamp: now, cwd: "/workspace/project-alpha"),
         ]
         // Project B: two different models
@@ -936,15 +935,15 @@ struct UsageAggregatorTests {
         // totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens
         // alpha: input=3000, output=1500, cacheRead=0, cacheWrite=0 → total=4500
         #expect(alpha != nil)
-        #expect(alpha?.inputTokens == 3000)
-        #expect(alpha?.outputTokens == 1500)
-        #expect(alpha?.totalTokens == 4500)
+        #expect(alpha?.inputTokens == 3_000)
+        #expect(alpha?.outputTokens == 1_500)
+        #expect(alpha?.totalTokens == 4_500)
 
         // Beta: input=1300, output=650, total=1950
         #expect(beta != nil)
-        #expect(beta?.inputTokens == 1300)
+        #expect(beta?.inputTokens == 1_300)
         #expect(beta?.outputTokens == 650)
-        #expect(beta?.totalTokens == 1950)
+        #expect(beta?.totalTokens == 1_950)
     }
 
     // MARK: - Observed models
@@ -957,7 +956,7 @@ struct UsageAggregatorTests {
         let projectsDir = dir.appendingPathComponent("projects")
 
         let now = Date()
-        let earlier = now.addingTimeInterval(-3600)
+        let earlier = now.addingTimeInterval(-3_600)
 
         // Two different models — newer model is sonnet-4-6, older is sonnet-4-5
         let lines = [
@@ -989,8 +988,8 @@ struct UsageAggregatorTests {
         let projectsDir = dir.appendingPathComponent("projects")
 
         let now = Date()
-        let earlier = now.addingTimeInterval(-7200)
-        let oldest = now.addingTimeInterval(-14400)
+        let earlier = now.addingTimeInterval(-7_200)
+        let oldest = now.addingTimeInterval(-14_400)
 
         // Three entries with distinct models in ascending time order
         let lines = [

--- a/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/VersionCheckerTests.swift
@@ -5,7 +5,6 @@ import Testing
 
 @Suite("VersionChecker")
 struct VersionCheckerTests {
-
     // MARK: - Semver comparison
 
     @Test func isNewer_majorBump() {
@@ -111,8 +110,8 @@ struct VersionCheckerTests {
 
     // MARK: - Cache behavior
 
-    @Test @MainActor func checkForUpdate_returnsCachedWithinInterval() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!, checkInterval: 86400)
+    @Test @MainActor func checkForUpdate_returnsCachedWithinInterval() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://example.com")), checkInterval: 86_400)
         let fakeUpdate = VersionChecker.UpdateInfo(version: "9.9.9", url: "https://example.com/release")
         checker.lastCheck = Date()
         checker.cachedUpdate = fakeUpdate
@@ -123,8 +122,8 @@ struct VersionCheckerTests {
         #expect(result?.url == "https://example.com/release")
     }
 
-    @Test @MainActor func checkForUpdate_returnsNilCachedWithinInterval() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!, checkInterval: 86400)
+    @Test @MainActor func checkForUpdate_returnsNilCachedWithinInterval() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://example.com")), checkInterval: 86_400)
         checker.lastCheck = Date()
         checker.cachedUpdate = nil
 
@@ -133,8 +132,8 @@ struct VersionCheckerTests {
         #expect(result == nil)
     }
 
-    @Test @MainActor func checkForUpdate_expiredCache_doesNotReturnStale() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://invalid.localhost.test")!, checkInterval: 1)
+    @Test @MainActor func checkForUpdate_expiredCache_doesNotReturnStale() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://invalid.localhost.test")), checkInterval: 1)
         let oldUpdate = VersionChecker.UpdateInfo(version: "1.0.0", url: "https://example.com")
         checker.lastCheck = Date(timeIntervalSinceNow: -10)
         checker.cachedUpdate = oldUpdate
@@ -146,8 +145,8 @@ struct VersionCheckerTests {
 
     // MARK: - forceCheckForUpdate
 
-    @Test @MainActor func forceCheckForUpdate_clearsLastCheck() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://invalid.localhost.test")!, checkInterval: 86400)
+    @Test @MainActor func forceCheckForUpdate_clearsLastCheck() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://invalid.localhost.test")), checkInterval: 86_400)
         checker.lastCheck = Date()
         checker.cachedUpdate = VersionChecker.UpdateInfo(version: "1.0.0", url: "https://example.com")
 
@@ -159,8 +158,8 @@ struct VersionCheckerTests {
         #expect(checker.cachedUpdate == nil)
     }
 
-    @Test @MainActor func forceCheckForUpdate_bypassesCache() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://invalid.localhost.test")!, checkInterval: 86400)
+    @Test @MainActor func forceCheckForUpdate_bypassesCache() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://invalid.localhost.test")), checkInterval: 86_400)
         let fakeUpdate = VersionChecker.UpdateInfo(version: "9.9.9", url: "https://example.com")
         checker.lastCheck = Date()
         checker.cachedUpdate = fakeUpdate
@@ -172,8 +171,8 @@ struct VersionCheckerTests {
         #expect(result == nil)
     }
 
-    @Test @MainActor func forceCheckForUpdate_setsLastCheckAfterAttempt() async {
-        let checker = VersionChecker(releaseURL: URL(string: "https://invalid.localhost.test")!, checkInterval: 86400)
+    @Test @MainActor func forceCheckForUpdate_setsLastCheckAfterAttempt() async throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://invalid.localhost.test")), checkInterval: 86_400)
         checker.lastCheck = nil
 
         _ = await checker.forceCheckForUpdate()
@@ -184,13 +183,13 @@ struct VersionCheckerTests {
 
     // MARK: - checkInterval
 
-    @Test @MainActor func checkInterval_defaultIs24Hours() {
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!)
-        #expect(checker.checkInterval == 86400)
+    @Test @MainActor func checkInterval_defaultIs24Hours() throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://example.com")))
+        #expect(checker.checkInterval == 86_400)
     }
 
-    @Test @MainActor func checkInterval_customValue() {
-        let checker = VersionChecker(releaseURL: URL(string: "https://example.com")!, checkInterval: 60)
+    @Test @MainActor func checkInterval_customValue() throws {
+        let checker = try VersionChecker(releaseURL: #require(URL(string: "https://example.com")), checkInterval: 60)
         #expect(checker.checkInterval == 60)
     }
 

--- a/Tests/AIBatteryCoreTests/Utilities/AdaptivePollingStateTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/AdaptivePollingStateTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("AdaptivePollingState")
 struct AdaptivePollingStateTests {
-
     @Test func belowThreshold_returnsBaseInterval() {
         var state = AdaptivePollingState()
         // 2 unchanged cycles (below threshold of 3) — should return base

--- a/Tests/AIBatteryCoreTests/Utilities/ClaudePathsTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ClaudePathsTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("ClaudePaths")
 struct ClaudePathsTests {
-
     @Test func statsCache_endsWithExpectedSuffix() {
         #expect(ClaudePaths.statsCache.path.hasSuffix(".claude/stats-cache.json"))
     }

--- a/Tests/AIBatteryCoreTests/Utilities/DateFormattersTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/DateFormattersTests.swift
@@ -4,19 +4,18 @@ import Foundation
 
 @Suite("DateFormatters")
 struct DateFormattersTests {
-
     // MARK: - dateKey
 
     @Test func dateKey_format() {
-        let date = makeDate(year: 2025, month: 3, day: 15)
+        let date = makeDate(year: 2_025, month: 3, day: 15)
         #expect(DateFormatters.dateKey.string(from: date) == "2025-03-15")
     }
 
-    @Test func dateKey_roundTrip() {
+    @Test func dateKey_roundTrip() throws {
         let original = "2025-12-31"
         let date = DateFormatters.dateKey.date(from: original)
         #expect(date != nil)
-        #expect(DateFormatters.dateKey.string(from: date!) == original)
+        #expect(try DateFormatters.dateKey.string(from: #require(date)) == original)
     }
 
     // MARK: - iso8601
@@ -27,11 +26,11 @@ struct DateFormattersTests {
         #expect(date != nil)
     }
 
-    @Test func iso8601_roundTrip() {
+    @Test func iso8601_roundTrip() throws {
         let str = "2025-06-15T10:30:45.000Z"
         let date = DateFormatters.iso8601.date(from: str)
         #expect(date != nil)
-        let output = DateFormatters.iso8601.string(from: date!)
+        let output = try DateFormatters.iso8601.string(from: #require(date))
         #expect(output == str)
     }
 
@@ -39,29 +38,29 @@ struct DateFormattersTests {
 
     @Test func shortDay_producesThreeLetterDay() {
         // 2025-03-17 is a Monday
-        let date = makeDate(year: 2025, month: 3, day: 17)
+        let date = makeDate(year: 2_025, month: 3, day: 17)
         #expect(DateFormatters.shortDay.string(from: date) == "Mon")
     }
 
     // MARK: - shortMonth
 
     @Test func shortMonth_producesThreeLetterMonth() {
-        let date = makeDate(year: 2025, month: 1, day: 1)
+        let date = makeDate(year: 2_025, month: 1, day: 1)
         #expect(DateFormatters.shortMonth.string(from: date) == "Jan")
     }
 
     // MARK: - formatDateRange
 
     @Test func formatDateRange_sameYear_omitsStartYear() {
-        let start = makeDate(year: 2026, month: 1, day: 5)
-        let end = makeDate(year: 2026, month: 3, day: 10)
+        let start = makeDate(year: 2_026, month: 1, day: 5)
+        let end = makeDate(year: 2_026, month: 3, day: 10)
         let result = DateFormatters.formatDateRange(from: start, to: end)
         #expect(result == "Jan 5 – Mar 10, 2026")
     }
 
     @Test func formatDateRange_crossYear_includesBothYears() {
-        let start = makeDate(year: 2025, month: 12, day: 15)
-        let end = makeDate(year: 2026, month: 3, day: 10)
+        let start = makeDate(year: 2_025, month: 12, day: 15)
+        let end = makeDate(year: 2_026, month: 3, day: 10)
         let result = DateFormatters.formatDateRange(from: start, to: end)
         #expect(result == "Dec 15, 2025 – Mar 10, 2026")
     }

--- a/Tests/AIBatteryCoreTests/Utilities/DurationFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/DurationFormatterTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("DurationFormatter")
 struct DurationFormatterTests {
-
     @Test func compact_zeroSeconds() {
         #expect(DurationFormatter.compact(0) == "0s")
     }
@@ -33,31 +32,31 @@ struct DurationFormatterTests {
     }
 
     @Test func compact_hoursAndMinutes() {
-        #expect(DurationFormatter.compact(7500) == "2h 5m")
+        #expect(DurationFormatter.compact(7_500) == "2h 5m")
     }
 
     @Test func compact_exactHours() {
-        #expect(DurationFormatter.compact(3600) == "1h 0m")
+        #expect(DurationFormatter.compact(3_600) == "1h 0m")
     }
 
     @Test func compact_overOneDay() {
         // 25 hours = 1d 1h
-        #expect(DurationFormatter.compact(90000) == "1d 1h")
+        #expect(DurationFormatter.compact(90_000) == "1d 1h")
     }
 
     @Test func compact_multipleDays() {
         // 50 hours = 2d 2h
-        #expect(DurationFormatter.compact(180000) == "2d 2h")
+        #expect(DurationFormatter.compact(180_000) == "2d 2h")
     }
 
     @Test func compact_exactly24Hours() {
         // 86400 seconds = 1d 0h (not "24h 0m")
-        #expect(DurationFormatter.compact(86400) == "1d 0h")
+        #expect(DurationFormatter.compact(86_400) == "1d 0h")
     }
 
     @Test func compact_justUnder24Hours() {
         // 23h 59m
-        #expect(DurationFormatter.compact(86340) == "23h 59m")
+        #expect(DurationFormatter.compact(86_340) == "23h 59m")
     }
 
     @Test func compact_exactlyOneMinute() {

--- a/Tests/AIBatteryCoreTests/Utilities/IdleSuspendPolicyTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/IdleSuspendPolicyTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("IdleSuspendPolicy")
 struct IdleSuspendPolicyTests {
-
     @Test("shouldSuspend false just under threshold")
     func justUnderThreshold() {
         #expect(!IdleSuspendPolicy.shouldSuspend(secondsIdle: 299, threshold: 300))

--- a/Tests/AIBatteryCoreTests/Utilities/MenuBarIconTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/MenuBarIconTests.swift
@@ -4,7 +4,6 @@ import AppKit
 
 @Suite("MenuBarIcon")
 struct MenuBarIconTests {
-
     private let testColor: NSColor = .systemGreen
 
     // MARK: - Breath parameters
@@ -170,6 +169,7 @@ struct MenuBarIconTests {
     }
 
     // MARK: - Context health color
+
     // Note: test for `ThemeColors.contextHealthNSColor` with specific color assertions
     // lives in ThemeColorsTests — that suite is `.serialized` and controls the global
     // `isColorblind` flag deterministically. Asserting here races with the parallel

--- a/Tests/AIBatteryCoreTests/Utilities/ModelNameMapperTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ModelNameMapperTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("ModelNameMapper")
 struct ModelNameMapperTests {
-
     // MARK: - Standard model families
 
     @Test func displayName_opus() {

--- a/Tests/AIBatteryCoreTests/Utilities/SecureNetworkingTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/SecureNetworkingTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("SecureNetworking")
 struct SecureNetworkingTests {
-
     @Test func session_usesEphemeralConfiguration() {
         let config = SecureNetworking.session.configuration
         // Ephemeral sessions have no persistent disk cache

--- a/Tests/AIBatteryCoreTests/Utilities/SpacingTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/SpacingTests.swift
@@ -4,23 +4,60 @@ import SwiftUI
 
 @Suite("Spacing")
 struct SpacingTests {
-    @Test func tight_is2() { #expect(Spacing.tight == 2) }
-    @Test func small_is4() { #expect(Spacing.small == 4) }
-    @Test func gap_is6() { #expect(Spacing.gap == 6) }
-    @Test func section_is8() { #expect(Spacing.section == 8) }
-    @Test func sectionHorizontal_is16() { #expect(Spacing.sectionHorizontal == 16) }
-    @Test func overlay_is24() { #expect(Spacing.overlay == 24) }
+    @Test func tight_is2() {
+        #expect(Spacing.tight == 2)
+    }
+
+    @Test func small_is4() {
+        #expect(Spacing.small == 4)
+    }
+
+    @Test func gap_is6() {
+        #expect(Spacing.gap == 6)
+    }
+
+    @Test func section_is8() {
+        #expect(Spacing.section == 8)
+    }
+
+    @Test func sectionHorizontal_is16() {
+        #expect(Spacing.sectionHorizontal == 16)
+    }
+
+    @Test func overlay_is24() {
+        #expect(Spacing.overlay == 24)
+    }
 }
 
 @Suite("Layout")
 struct LayoutTests {
-    @Test func popoverWidth_is275() { #expect(Layout.popoverWidth == 275) }
-    @Test func chartHeight_is50() { #expect(Layout.chartHeight == 50) }
-    @Test func barHeight_is8() { #expect(Layout.barHeight == 8) }
-    @Test func barCornerRadius_is3() { #expect(Layout.barCornerRadius == 3) }
-    @Test func chevronFrame_is22() { #expect(Layout.chevronFrame == 22) }
-    @Test func dotSize_is8() { #expect(Layout.dotSize == 8) }
-    @Test func dotSizeSmall_is6() { #expect(Layout.dotSizeSmall == 6) }
+    @Test func popoverWidth_is275() {
+        #expect(Layout.popoverWidth == 275)
+    }
+
+    @Test func chartHeight_is50() {
+        #expect(Layout.chartHeight == 50)
+    }
+
+    @Test func barHeight_is8() {
+        #expect(Layout.barHeight == 8)
+    }
+
+    @Test func barCornerRadius_is3() {
+        #expect(Layout.barCornerRadius == 3)
+    }
+
+    @Test func chevronFrame_is22() {
+        #expect(Layout.chevronFrame == 22)
+    }
+
+    @Test func dotSize_is8() {
+        #expect(Layout.dotSize == 8)
+    }
+
+    @Test func dotSizeSmall_is6() {
+        #expect(Layout.dotSizeSmall == 6)
+    }
 }
 
 @Suite("MotionConstants")

--- a/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 @Suite("ThemeColors", .serialized)
 struct ThemeColorsTests {
-
     private func setColorblind(_ value: Bool) {
         UserDefaults.standard.set(value, forKey: UserDefaultsKeys.colorblindMode)
         ThemeColors.refreshColorblindFlag()

--- a/Tests/AIBatteryCoreTests/Utilities/ThrottleTrackerTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ThrottleTrackerTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("ThrottleTracker")
 struct ThrottleTrackerTests {
-
     // MARK: - evaluate
 
     @Test func evaluate_nilRateLimits_noRecord() {
@@ -164,8 +163,8 @@ struct ThrottleTrackerTests {
 
     @Test func appendAndPrune_prunesOlderThan30Days() {
         let now = Date().timeIntervalSince1970
-        let old = now - 31 * 86400 // 31 days ago
-        let recent = now - 5 * 86400 // 5 days ago
+        let old = now - 31 * 86_400 // 31 days ago
+        let recent = now - 5 * 86_400 // 5 days ago
         let result = ThrottleTracker.appendAndPrune(timestamps: [old, recent], newTimestamp: now)
         #expect(result.count == 2) // recent + now (old pruned)
         #expect(!result.contains(old))
@@ -177,7 +176,7 @@ struct ThrottleTrackerTests {
 
     @Test func count_filtersOldEvents() {
         let now = Date().timeIntervalSince1970
-        let old = now - 8 * 86400 // 8 days ago
+        let old = now - 8 * 86_400 // 8 days ago
         let timestamps = [old, now]
         #expect(ThrottleTracker.count(timestamps: timestamps, days: 7) == 1)
         #expect(ThrottleTracker.count(timestamps: timestamps, days: 30) == 2)

--- a/Tests/AIBatteryCoreTests/Utilities/TokenFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/TokenFormatterTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("TokenFormatter")
 struct TokenFormatterTests {
-
     // MARK: - Sub-1K (raw number)
 
     @Test func format_zero() {

--- a/Tests/AIBatteryCoreTests/Utilities/TypographyTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/TypographyTests.swift
@@ -7,45 +7,59 @@ struct TypographyTests {
     @Test func sectionHeader_isSubheadlineBold() {
         #expect(Typography.sectionHeader == Font.subheadline.bold())
     }
+
     @Test func chevronIcon_isSize9Bold() {
         #expect(Typography.chevronIcon == Font.system(size: 9, weight: .bold))
     }
+
     @Test func heroTitle_isSize14() {
         #expect(Typography.heroTitle == Font.system(size: 14))
     }
+
     @Test func heroValue_isSize12Bold() {
         #expect(Typography.heroValue == Font.system(size: 12, weight: .bold))
     }
+
     @Test func bodyLabel_isSize11Medium() {
         #expect(Typography.bodyLabel == Font.system(size: 11, weight: .medium))
     }
+
     @Test func caption_isCaption() {
         #expect(Typography.caption == Font.caption)
     }
+
     @Test func tinyLabel_isCaption2() {
         #expect(Typography.tinyLabel == Font.caption2)
     }
+
     @Test func monoValue_isHeadlineMonoSemibold() {
         #expect(Typography.monoValue == Font.system(.headline, design: .monospaced, weight: .semibold))
     }
+
     @Test func monoValueMedium_isSubheadlineMonoSemibold() {
         #expect(Typography.monoValueMedium == Font.system(.subheadline, design: .monospaced, weight: .semibold))
     }
+
     @Test func monoCaption_isCaptionMono() {
         #expect(Typography.monoCaption == Font.system(.caption, design: .monospaced))
     }
+
     @Test func monoCaptionSmall_isCaption2Mono() {
         #expect(Typography.monoCaptionSmall == Font.system(.caption2, design: .monospaced))
     }
+
     @Test func monoTiny_isSize10Mono() {
         #expect(Typography.monoTiny == Font.system(size: 10, design: .monospaced))
     }
+
     @Test func badgeLabel_isSize10MediumMono() {
         #expect(Typography.badgeLabel == Font.system(size: 10, weight: .medium, design: .monospaced))
     }
+
     @Test func buttonLabel_isSubheadlineMedium() {
         #expect(Typography.buttonLabel == Font.subheadline.weight(.medium))
     }
+
     @Test func decorativeIcon_meetsMinimumSize() {
         // UI-05: minimum 9pt floor — decorativeIcon aliases iconSmall
         #expect(Typography.decorativeIcon == Font.system(size: 9))

--- a/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/UserDefaultsKeysTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("UserDefaultsKeys")
 struct UserDefaultsKeysTests {
-
     /// All keys must use the "aibattery_" prefix for namespacing.
     @Test func allKeys_havePrefix() {
         let keys = allKeys

--- a/Tests/AIBatteryCoreTests/ViewModels/UsageViewModelIdleTests.swift
+++ b/Tests/AIBatteryCoreTests/ViewModels/UsageViewModelIdleTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("UsageViewModel Idle")
 struct UsageViewModelIdleTests {
-
     @Test("idle threshold is 5 minutes")
     func idleThresholdIsFiveMinutes() {
         #expect(IdleSuspendPolicy.defaultThreshold == 300)

--- a/Tests/AIBatteryCoreTests/ViewModels/UsageViewModelTests.swift
+++ b/Tests/AIBatteryCoreTests/ViewModels/UsageViewModelTests.swift
@@ -5,7 +5,6 @@ import Foundation
 @Suite("UsageViewModel")
 @MainActor
 struct UsageViewModelTests {
-
     // MARK: - clampedRefreshInterval
 
     @Test func clampedRefreshInterval_zero_returnsDefault() {
@@ -51,9 +50,9 @@ struct UsageViewModelTests {
 
     @Test func refreshErrorMessage_authError_returnsReconnectMessage() {
         let msg = UsageViewModel.refreshErrorMessage(
-            hasRateLimits: true,           // even with all data present,
-            hasStandardLimits: true,       // an authError must take precedence —
-            hasProfile: true,              // the data is stale and the user needs
+            hasRateLimits: true, // even with all data present,
+            hasStandardLimits: true, // an authError must take precedence —
+            hasProfile: true, // the data is stale and the user needs
             hasStandardRateLimitHeaders: true,
             totalMessages: 100,
             authError: true
@@ -303,7 +302,7 @@ struct UsageViewModelTests {
         let key = UserDefaultsKeys.throttleTimestamps
         let now = Date().timeIntervalSince1970
         // Simulate legacy string-typed timestamps (the actual bug that caused 0 counts)
-        UserDefaults.standard.set([String(now), String(now - 86400)], forKey: key)
+        UserDefaults.standard.set([String(now), String(now - 86_400)], forKey: key)
         #expect(UsageViewModel.throttleCount(days: 7) == 2)
         UserDefaults.standard.removeObject(forKey: key)
     }
@@ -311,7 +310,7 @@ struct UsageViewModelTests {
     @Test func throttleCount_filtersOldEvents() {
         let key = UserDefaultsKeys.throttleTimestamps
         let now = Date().timeIntervalSince1970
-        let old = now - 8 * 86400 // 8 days ago
+        let old = now - 8 * 86_400 // 8 days ago
         UserDefaults.standard.set([old, now], forKey: key)
         #expect(UsageViewModel.throttleCount(days: 7) == 1)
         #expect(UsageViewModel.throttleCount(days: 30) == 2)

--- a/Tests/AIBatteryCoreTests/Views/ActivityChartDataTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/ActivityChartDataTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("ActivityChartData")
 struct ActivityChartDataTests {
-
     // MARK: - Seven day data
 
     @Test func sevenDayData_returns7Days() {
@@ -15,12 +14,12 @@ struct ActivityChartDataTests {
     @Test func sevenDayData_fillsGapsWithZero() {
         let now = Date()
         let todayKey = DateFormatters.dateKey.string(from: now)
-        let tokens: [String: Int] = [todayKey: 5000]
+        let tokens: [String: Int] = [todayKey: 5_000]
         let data = ActivityChartData.sevenDayData(from: tokens, now: now)
 
         // Today should have 5000, all others should be 0
         let todayPoint = data.first(where: { $0.key == todayKey })
-        #expect(todayPoint?.count == 5000)
+        #expect(todayPoint?.count == 5_000)
 
         let zeroDays = data.filter { $0.key != todayKey }
         #expect(zeroDays.allSatisfy { $0.count == 0 })
@@ -40,19 +39,19 @@ struct ActivityChartDataTests {
         #expect(data.count == 20)
     }
 
-    @Test func fiveHourData_looksUpCorrectBuckets() {
-        let buckets: [Int: Int] = [0: 1000, 19: 5000]
+    @Test func fiveHourData_looksUpCorrectBuckets() throws {
+        let buckets: [Int: Int] = [0: 1_000, 19: 5_000]
         let data = ActivityChartData.fiveHourData(from: buckets)
 
         // Bucket 0 (oldest) should be the first point
-        let firstPoint = data.first!
+        let firstPoint = try #require(data.first)
         #expect(firstPoint.id == 0)
-        #expect(firstPoint.count == 1000)
+        #expect(firstPoint.count == 1_000)
 
         // Bucket 19 (most recent) should be the last point
-        let lastPoint = data.last!
+        let lastPoint = try #require(data.last)
         #expect(lastPoint.id == 19)
-        #expect(lastPoint.count == 5000)
+        #expect(lastPoint.count == 5_000)
     }
 
     @Test func fiveHourData_zeroForMissingBuckets() {
@@ -64,13 +63,13 @@ struct ActivityChartDataTests {
 
     @Test func monthTokenTotals_aggregatesCorrectly() {
         let daily: [String: Int] = [
-            "2026-03-01": 10000,
-            "2026-03-15": 20000,
-            "2026-02-10": 5000,
+            "2026-03-01": 10_000,
+            "2026-03-15": 20_000,
+            "2026-02-10": 5_000,
         ]
         let totals = ActivityChartData.monthTokenTotals(from: daily)
-        #expect(totals["2026-03"] == 30000)
-        #expect(totals["2026-02"] == 5000)
+        #expect(totals["2026-03"] == 30_000)
+        #expect(totals["2026-02"] == 5_000)
     }
 
     @Test func monthTokenTotals_emptyInput() {
@@ -80,12 +79,12 @@ struct ActivityChartDataTests {
 
     @Test func monthTokenTotals_skipsInvalidDates() {
         let daily: [String: Int] = [
-            "not-a-date": 10000,
-            "2026-01-05": 7000,
+            "not-a-date": 10_000,
+            "2026-01-05": 7_000,
         ]
         let totals = ActivityChartData.monthTokenTotals(from: daily)
         #expect(totals.count == 1)
-        #expect(totals["2026-01"] == 7000)
+        #expect(totals["2026-01"] == 7_000)
     }
 
     // MARK: - Monthly data
@@ -102,44 +101,44 @@ struct ActivityChartDataTests {
         }
     }
 
-    @Test func monthlyData_projectsCurrentMonth() {
+    @Test func monthlyData_projectsCurrentMonth() throws {
         let cal = Calendar.current
         // Fix to March 10, 2026 — so dayOfMonth=10, daysInMonth=31
-        let fixedDate = cal.date(from: DateComponents(year: 2026, month: 3, day: 10))!
+        let fixedDate = try #require(cal.date(from: DateComponents(year: 2_026, month: 3, day: 10)))
         // monthlyData expects pre-aggregated month keys (from monthTokenTotals)
         let monthTotals: [String: Int] = [
-            "2026-03": 30000,
+            "2026-03": 30_000,
         ]
         let data = ActivityChartData.monthlyData(from: monthTotals, now: fixedDate)
-        let march = data.first(where: { $0.key == "2026-03" })!
+        let march = try #require(data.first(where: { $0.key == "2026-03" }))
 
         // Total is 30000, projected = 30000 * 31 / 10 = 93000
-        #expect(march.count == 93000)
+        #expect(march.count == 93_000)
     }
 
-    @Test func monthlyData_noProjectionFirstThreeDays() {
+    @Test func monthlyData_noProjectionFirstThreeDays() throws {
         let cal = Calendar.current
-        let fixedDate = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let fixedDate = try #require(cal.date(from: DateComponents(year: 2_026, month: 3, day: 2)))
         let monthTotals: [String: Int] = [
-            "2026-03": 10000,
+            "2026-03": 10_000,
         ]
         let data = ActivityChartData.monthlyData(from: monthTotals, now: fixedDate)
-        let march = data.first(where: { $0.key == "2026-03" })!
+        let march = try #require(data.first(where: { $0.key == "2026-03" }))
 
         // Day 2 < 4, so no projection — raw total
-        #expect(march.count == 10000)
+        #expect(march.count == 10_000)
     }
 
-    @Test func monthlyData_pastMonthsNotProjected() {
+    @Test func monthlyData_pastMonthsNotProjected() throws {
         let cal = Calendar.current
-        let fixedDate = cal.date(from: DateComponents(year: 2026, month: 3, day: 15))!
+        let fixedDate = try #require(cal.date(from: DateComponents(year: 2_026, month: 3, day: 15)))
         let monthTotals: [String: Int] = [
-            "2026-02": 50000,
+            "2026-02": 50_000,
         ]
         let data = ActivityChartData.monthlyData(from: monthTotals, now: fixedDate)
-        let feb = data.first(where: { $0.key == "2026-02" })!
+        let feb = try #require(data.first(where: { $0.key == "2026-02" }))
 
         // Past month — no projection
-        #expect(feb.count == 50000)
+        #expect(feb.count == 50_000)
     }
 }

--- a/Tests/AIBatteryCoreTests/Views/ActivityChartIsEmptyTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/ActivityChartIsEmptyTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("ActivityChartIsEmpty")
 struct ActivityChartIsEmptyTests {
-
     // The old InsightsView.isHourlyEmpty() static method was removed.
     // Emptiness is now determined by snapshot token fields directly.
     // These tests verify the underlying data signals used by ActivityChartView.isEmpty.
@@ -17,7 +16,7 @@ struct ActivityChartIsEmptyTests {
 
     // DATA-01: has five-hour tokens → fiveHour mode is not empty
     @Test func fiveHourNotEmpty_whenFiveHourTokensNonZero() {
-        let snapshot = makeSnapshot(fiveHourTokens: 1000)
+        let snapshot = makeSnapshot(fiveHourTokens: 1_000)
         #expect(snapshot.fiveHourTokens > 0)
     }
 
@@ -29,7 +28,7 @@ struct ActivityChartIsEmptyTests {
 
     // DATA-01: has seven-day tokens → sevenDay mode is not empty
     @Test func sevenDayNotEmpty_whenSevenDayTokensNonZero() {
-        let snapshot = makeSnapshot(sevenDayTokens: 5000)
+        let snapshot = makeSnapshot(sevenDayTokens: 5_000)
         #expect(snapshot.sevenDayTokens > 0)
     }
 
@@ -41,7 +40,7 @@ struct ActivityChartIsEmptyTests {
 
     // DATA-01: has dailyTokenTotals → monthly mode is not empty
     @Test func monthlyNotEmpty_whenDailyTokenTotalsNonZero() {
-        let snapshot = makeSnapshot(dailyTokenTotals: ["2026-03-01": 12000])
+        let snapshot = makeSnapshot(dailyTokenTotals: ["2026-03-01": 12_000])
         #expect(snapshot.dailyTokenTotals.values.reduce(0, +) > 0)
     }
 

--- a/Tests/AIBatteryCoreTests/Views/ActivityTrendTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/ActivityTrendTests.swift
@@ -5,37 +5,36 @@ import Foundation
 @Suite("ActivityTrendComputation")
 @MainActor
 struct ActivityTrendTests {
-
     // MARK: - changeVsYesterday
 
-    @Test func changeVsYesterday_positive() {
+    @Test func changeVsYesterday_positive() throws {
         let cal = Calendar.current
         let now = Date()
         let todayStr = DateFormatters.dateKey.string(from: now)
-        let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 15000, yesterdayStr: 10000])
+        let yesterdayStr = try DateFormatters.dateKey.string(from: #require(cal.date(byAdding: .day, value: -1, to: now)))
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 15_000, yesterdayStr: 10_000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "↑")
         #expect(change?.label == "+50% vs yesterday")
     }
 
-    @Test func changeVsYesterday_negative() {
+    @Test func changeVsYesterday_negative() throws {
         let cal = Calendar.current
         let now = Date()
         let todayStr = DateFormatters.dateKey.string(from: now)
-        let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 5000, yesterdayStr: 10000])
+        let yesterdayStr = try DateFormatters.dateKey.string(from: #require(cal.date(byAdding: .day, value: -1, to: now)))
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 5_000, yesterdayStr: 10_000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "↓")
         #expect(change?.label == "-50% vs yesterday")
     }
 
-    @Test func changeVsYesterday_same() {
+    @Test func changeVsYesterday_same() throws {
         let cal = Calendar.current
         let now = Date()
         let todayStr = DateFormatters.dateKey.string(from: now)
-        let yesterdayStr = DateFormatters.dateKey.string(from: cal.date(byAdding: .day, value: -1, to: now)!)
-        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 10000, yesterdayStr: 10000])
+        let yesterdayStr = try DateFormatters.dateKey.string(from: #require(cal.date(byAdding: .day, value: -1, to: now)))
+        let snapshot = makeSnapshot(dailyTokenTotals: [todayStr: 10_000, yesterdayStr: 10_000])
         let change = ActivityTrendComputation.changeVsYesterday(snapshot, cal: cal, now: now)
         #expect(change?.symbol == "→")
     }
@@ -48,10 +47,10 @@ struct ActivityTrendTests {
 
     // MARK: - monthChangeInfo
 
-    @Test func monthChange_positiveProjection() {
+    @Test func monthChange_positiveProjection() throws {
         let cal = Calendar.current
         // March 15, 2026 — dayOfMonth=15, daysInMonth=31
-        let now = cal.date(from: DateComponents(year: 2026, month: 3, day: 15))!
+        let now = try #require(cal.date(from: DateComponents(year: 2_026, month: 3, day: 15)))
         // thisMonth=100, projected=100*31/15=206, lastMonth=100 → +106% → ↑
         let change = ActivityTrendComputation.monthChangeInfo(thisMonth: 100, lastMonth: 100, cal: cal, now: now)
         #expect(change?.symbol == "↑")
@@ -62,9 +61,9 @@ struct ActivityTrendTests {
         #expect(change == nil)
     }
 
-    @Test func monthChange_nilWhenTooEarlyInMonth() {
+    @Test func monthChange_nilWhenTooEarlyInMonth() throws {
         let cal = Calendar.current
-        let now = cal.date(from: DateComponents(year: 2026, month: 3, day: 2))!
+        let now = try #require(cal.date(from: DateComponents(year: 2_026, month: 3, day: 2)))
         let change = ActivityTrendComputation.monthChangeInfo(thisMonth: 50, lastMonth: 100, cal: cal, now: now)
         #expect(change == nil) // dayOfMonth < 4
     }

--- a/Tests/AIBatteryCoreTests/Views/DeferredRenderingTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/DeferredRenderingTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("DeferredRenderState")
 struct DeferredRenderingTests {
-
     // MARK: - Initial state
 
     @Test func initialState_hasAppearedIsFalse() {

--- a/Tests/AIBatteryCoreTests/Views/GaugeBarTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/GaugeBarTests.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 @Suite("GaugeBar")
 struct GaugeBarTests {
-
     // MARK: - Clamping logic
 
     @Test func clampPercent_belowZero_returnsZero() {

--- a/Tests/AIBatteryCoreTests/Views/InsightsViewFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/InsightsViewFormatterTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("InsightsViewFormatter")
 struct InsightsViewFormatterTests {
-
     // MARK: - CHART-02: formatHourLabelFull
 
     @Test func formatHourLabelFull_midnight_returns_00colon00() {
@@ -42,8 +41,12 @@ struct InsightsViewFormatterTests {
         for offset in stride(from: -11, through: 0, by: 1) {
             var m = endingMonth + offset
             var y = endingYear
-            while m <= 0 { m += 12; y -= 1 }
-            while m > 12 { m -= 12; y += 1 }
+            while m <= 0 {
+                m += 12; y -= 1
+            }
+            while m > 12 {
+                m -= 12; y += 1
+            }
             components.year = y
             components.month = m
             dates.append(cal.date(from: components)!)
@@ -54,12 +57,12 @@ struct InsightsViewFormatterTests {
     // March 2026: window is Apr 2025 – Mar 2026
     // Quarterly in window: Apr(4), Jul(7), Oct(10), Jan(1) → 4 quarterly
     // Current = Mar(3), not quarterly → 5 labels total
-    @Test func quarterlyLabelDates_march2026_returns5Labels() {
+    @Test func quarterlyLabelDates_march2026_returns5Labels() throws {
         var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
-        let comps = DateComponents(year: 2026, month: 3, day: 15)
-        let march2026 = cal.date(from: comps)!
-        let dates = make12MonthDates(endingYear: 2026, endingMonth: 3)
+        cal.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let comps = DateComponents(year: 2_026, month: 3, day: 15)
+        let march2026 = try #require(cal.date(from: comps))
+        let dates = make12MonthDates(endingYear: 2_026, endingMonth: 3)
         let labels = InsightsView.quarterlyLabelDates(from: dates, now: march2026)
         #expect(labels.count == 5)
     }
@@ -67,26 +70,26 @@ struct InsightsViewFormatterTests {
     // April 2026: window is May 2025 – Apr 2026
     // Quarterly in window: Jul(7), Oct(10), Jan(1), Apr(4) → 4 quarterly
     // Current = Apr(4), IS quarterly → 4 labels total (no duplicate)
-    @Test func quarterlyLabelDates_april2026_returns4Labels() {
+    @Test func quarterlyLabelDates_april2026_returns4Labels() throws {
         var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
-        let comps = DateComponents(year: 2026, month: 4, day: 15)
-        let april2026 = cal.date(from: comps)!
-        let dates = make12MonthDates(endingYear: 2026, endingMonth: 4)
+        cal.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let comps = DateComponents(year: 2_026, month: 4, day: 15)
+        let april2026 = try #require(cal.date(from: comps))
+        let dates = make12MonthDates(endingYear: 2_026, endingMonth: 4)
         let labels = InsightsView.quarterlyLabelDates(from: dates, now: april2026)
         #expect(labels.count == 4)
     }
 
     // Current month must always appear in the label set
-    @Test func quarterlyLabelDates_currentMonthAlwaysIncluded() {
+    @Test func quarterlyLabelDates_currentMonthAlwaysIncluded() throws {
         var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
-        let comps = DateComponents(year: 2026, month: 3, day: 15)
-        let march2026 = cal.date(from: comps)!
-        let dates = make12MonthDates(endingYear: 2026, endingMonth: 3)
+        cal.timeZone = try #require(TimeZone(identifier: "UTC"))
+        let comps = DateComponents(year: 2_026, month: 3, day: 15)
+        let march2026 = try #require(cal.date(from: comps))
+        let dates = make12MonthDates(endingYear: 2_026, endingMonth: 3)
         let labels = InsightsView.quarterlyLabelDates(from: dates, now: march2026)
         // The last date in the array is the current month (Mar 2026)
-        let currentMonthDate = dates.last!
+        let currentMonthDate = try #require(dates.last)
         #expect(labels.contains(currentMonthDate))
     }
 }

--- a/Tests/AIBatteryCoreTests/Views/MenuBarMultiAccountTextTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/MenuBarMultiAccountTextTests.swift
@@ -240,6 +240,7 @@ struct MenuBarMultiAccountTextTests {
     // bar into countdown mode.
 
     // MARK: - resolveDisplay end-to-end
+
     //
     // These tests exercise the full menu-bar decision (gate + builder + countdown
     // composition + single-account fallback) as one pure function. They are the
@@ -286,8 +287,8 @@ struct MenuBarMultiAccountTextTests {
         let active = Self.usage(fiveHourUtilization: 0.42)
         let result = MenuBarMultiAccountText.resolveDisplay(
             toggleOn: true,
-            perAccount: [:],  // fan-out hasn't completed yet
-            order: ["a", "b"],  // 2 authenticated accounts
+            perAccount: [:], // fan-out hasn't completed yet
+            order: ["a", "b"], // 2 authenticated accounts
             activeRateLimits: active,
             activePercent: 42,
             metricMode: .fiveHour,
@@ -308,7 +309,7 @@ struct MenuBarMultiAccountTextTests {
         let active = Self.usage(fiveHourUtilization: 0.42)
         let result = MenuBarMultiAccountText.resolveDisplay(
             toggleOn: true,
-            perAccount: ["a": active],  // only 1 fetched
+            perAccount: ["a": active], // only 1 fetched
             order: ["a", "b"],
             activeRateLimits: active,
             activePercent: 42,
@@ -336,7 +337,7 @@ struct MenuBarMultiAccountTextTests {
         )
         #expect(result.usedMultiAccount == true)
         #expect(result.text == "42%\u{00A0}|\u{00A0}87%")
-        #expect(result.percent == 87)  // worst across accounts
+        #expect(result.percent == 87) // worst across accounts
         #expect(result.isExhausted == false)
     }
 
@@ -364,8 +365,8 @@ struct MenuBarMultiAccountTextTests {
     func resolveDisplay_healthyAccounts_noCountdown() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         // Healthy: low utilization, future reset, not throttled.
-        let a = Self.usage(fiveHourUtilization: 0.42, fiveHourReset: now.addingTimeInterval(3600))
-        let b = Self.usage(fiveHourUtilization: 0.23, fiveHourReset: now.addingTimeInterval(3600))
+        let a = Self.usage(fiveHourUtilization: 0.42, fiveHourReset: now.addingTimeInterval(3_600))
+        let b = Self.usage(fiveHourUtilization: 0.23, fiveHourReset: now.addingTimeInterval(3_600))
         let result = MenuBarMultiAccountText.resolveDisplay(
             toggleOn: true,
             perAccount: ["a": a, "b": b],
@@ -385,7 +386,7 @@ struct MenuBarMultiAccountTextTests {
     @Test("Multi-account: one account throttled → countdown mode kicks in")
     func resolveDisplay_oneThrottled_countdown() {
         let now = Date(timeIntervalSince1970: 1_000_000)
-        let reset = now.addingTimeInterval(300)  // 5 min away
+        let reset = now.addingTimeInterval(300) // 5 min away
         let a = Self.usage(fiveHourUtilization: 0.42)
         let throttled = Self.usage(
             fiveHourUtilization: 1.0,
@@ -451,7 +452,7 @@ struct MenuBarMultiAccountTextTests {
             countdownResetDate: Self.countdownReset
         )
         #expect(result.usedMultiAccount == true)
-        #expect(result.percent == 85)  // floor at active, not the multi.worstPercent of 85
+        #expect(result.percent == 85) // floor at active, not the multi.worstPercent of 85
     }
 
     @Test("Toggle on, 1 authenticated account: shouldRender false, single-account fallback")

--- a/Tests/AIBatteryCoreTests/Views/SessionInfoFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/SessionInfoFormatterTests.swift
@@ -4,7 +4,6 @@ import Foundation
 
 @Suite("SessionInfoFormatter")
 struct SessionInfoFormatterTests {
-
     // MARK: - Label parts
 
     @Test func labelParts_projectAndBranch() {
@@ -58,9 +57,9 @@ struct SessionInfoFormatterTests {
 
     @Test func bottomParts_includesDurationAndVelocity() {
         let health = makeHealth(
-            sessionDuration: 3600,
+            sessionDuration: 3_600,
             lastActivity: Date(),
-            tokensPerMinute: 1500
+            tokensPerMinute: 1_500
         )
         let parts = SessionInfoFormatter.bottomParts(for: health)
         #expect(parts.count == 3)
@@ -87,7 +86,7 @@ struct SessionInfoFormatterTests {
     // MARK: - Stale idle minutes
 
     @Test func staleIdleMinutes_nilForGreenBand() {
-        let health = makeHealth(band: .green, lastActivity: Date().addingTimeInterval(-3600))
+        let health = makeHealth(band: .green, lastActivity: Date().addingTimeInterval(-3_600))
         #expect(SessionInfoFormatter.staleIdleMinutes(for: health) == nil)
     }
 
@@ -97,7 +96,7 @@ struct SessionInfoFormatterTests {
     }
 
     @Test func staleIdleMinutes_returnsMinutesWhenStale() {
-        let health = makeHealth(band: .orange, lastActivity: Date().addingTimeInterval(-3600))
+        let health = makeHealth(band: .orange, lastActivity: Date().addingTimeInterval(-3_600))
         let minutes = SessionInfoFormatter.staleIdleMinutes(for: health)
         #expect(minutes == 60)
     }
@@ -117,7 +116,7 @@ struct SessionInfoFormatterTests {
     }
 
     @Test func detailTooltip_includesContext() {
-        let health = makeHealth(totalUsed: 50000, usableWindow: 160000)
+        let health = makeHealth(totalUsed: 50_000, usableWindow: 160_000)
         let tooltip = SessionInfoFormatter.detailTooltip(for: health)
         #expect(tooltip.contains("Context:"))
     }
@@ -135,7 +134,7 @@ struct SessionInfoFormatterTests {
     }
 
     @Test func formatSessionTime_todayShowsTime() {
-        let result = SessionInfoFormatter.formatSessionTime(Date().addingTimeInterval(-7200))
+        let result = SessionInfoFormatter.formatSessionTime(Date().addingTimeInterval(-7_200))
         #expect(result.hasPrefix("Today"))
     }
 
@@ -168,7 +167,7 @@ struct SessionInfoFormatterTests {
     }
 
     @Test func copyableDetails_includesExactTokenCounts() {
-        let health = makeHealth(totalUsed: 50000, usableWindow: 160000)
+        let health = makeHealth(totalUsed: 50_000, usableWindow: 160_000)
         let text = SessionInfoFormatter.copyableDetails(for: health)
         #expect(text.contains("Context:  50000/160000"))
     }
@@ -195,14 +194,14 @@ struct SessionInfoFormatterTests {
         lastActivity: Date? = nil,
         tokensPerMinute: Double? = nil,
         totalUsed: Int = 0,
-        usableWindow: Int = 160000
+        usableWindow: Int = 160_000
     ) -> TokenHealthStatus {
         TokenHealthStatus(
             id: id,
             band: band,
             usagePercentage: 0,
             totalUsed: totalUsed,
-            contextWindow: 200000,
+            contextWindow: 200_000,
             usableWindow: usableWindow,
             remainingTokens: usableWindow - totalUsed,
             inputTokens: 0,

--- a/Tests/AIBatteryCoreTests/Views/StatusBarCountdownResetDateTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/StatusBarCountdownResetDateTests.swift
@@ -8,7 +8,6 @@ import Foundation
 /// still-valid 7-day countdown was dropped in favour of a stuck `"100%"`.
 @Suite("StatusBarManager.countdownResetDate")
 struct StatusBarCountdownResetDateTests {
-
     private let now = Date(timeIntervalSince1970: 1_700_000_000)
 
     private func makeRateLimits(
@@ -37,7 +36,7 @@ struct StatusBarCountdownResetDateTests {
 
     @Test func neitherExhausted_returnsNil() {
         let rl = makeRateLimits(
-            fiveHourUtilization: 0.5, fiveHourReset: now.addingTimeInterval(3600),
+            fiveHourUtilization: 0.5, fiveHourReset: now.addingTimeInterval(3_600),
             sevenDayUtilization: 0.2, sevenDayReset: now.addingTimeInterval(86_400)
         )
         #expect(StatusBarManager.countdownResetDate(for: rl, now: now) == nil)
@@ -46,7 +45,7 @@ struct StatusBarCountdownResetDateTests {
     // MARK: - Single-window exhaustion
 
     @Test func fiveHourExhausted_returnsFiveHourReset() {
-        let reset = now.addingTimeInterval(1800)
+        let reset = now.addingTimeInterval(1_800)
         let rl = makeRateLimits(
             fiveHourUtilization: 1.0, fiveHourReset: reset,
             sevenDayUtilization: 0.2, sevenDayReset: now.addingTimeInterval(86_400)
@@ -57,7 +56,7 @@ struct StatusBarCountdownResetDateTests {
     @Test func sevenDayExhausted_returnsSevenDayReset() {
         let reset = now.addingTimeInterval(86_400)
         let rl = makeRateLimits(
-            fiveHourUtilization: 0.5, fiveHourReset: now.addingTimeInterval(1800),
+            fiveHourUtilization: 0.5, fiveHourReset: now.addingTimeInterval(1_800),
             sevenDayUtilization: 1.0, sevenDayReset: reset
         )
         #expect(StatusBarManager.countdownResetDate(for: rl, now: now) == reset)
@@ -86,7 +85,7 @@ struct StatusBarCountdownResetDateTests {
     }
 
     @Test func bothExhausted_bothFuture_returnsEarlierReset() {
-        let five = now.addingTimeInterval(1800)
+        let five = now.addingTimeInterval(1_800)
         let seven = now.addingTimeInterval(86_400)
         let rl = makeRateLimits(
             fiveHourUtilization: 1.0, fiveHourReset: five,
@@ -114,7 +113,7 @@ struct StatusBarCountdownResetDateTests {
     // MARK: - Throttled
 
     @Test func throttled_futureBindingReset_returnsBindingReset() {
-        let reset = now.addingTimeInterval(1800)
+        let reset = now.addingTimeInterval(1_800)
         let rl = makeRateLimits(
             fiveHourUtilization: 1.0, fiveHourReset: reset, fiveHourStatus: "throttled",
             sevenDayUtilization: 0.5, sevenDayReset: now.addingTimeInterval(86_400),

--- a/Tests/AIBatteryCoreTests/Views/StatusBarToggleTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/StatusBarToggleTests.swift
@@ -5,17 +5,16 @@ import Testing
 /// Covers RESP-03: toggle desync prevention.
 @Suite("PanelToggleState")
 struct StatusBarToggleTests {
-
     // Test 1: Initial state is not showing
     @Test("starts with isShowing = false")
-    func testInitialStateIsFalse() {
+    func initialStateIsFalse() {
         let state = PanelToggleState()
         #expect(state.isShowing == false)
     }
 
     // Test 2: show() sets isShowing to true
     @Test("show() sets isShowing to true")
-    func testShowSetsIsShowingTrue() {
+    func showSetsIsShowingTrue() {
         var state = PanelToggleState()
         state.show()
         #expect(state.isShowing == true)
@@ -23,7 +22,7 @@ struct StatusBarToggleTests {
 
     // Test 3: dismiss() sets isShowing to false
     @Test("dismiss() sets isShowing to false")
-    func testDismissSetsIsShowingFalse() {
+    func dismissSetsIsShowingFalse() {
         var state = PanelToggleState()
         state.show()
         state.dismiss()
@@ -32,7 +31,7 @@ struct StatusBarToggleTests {
 
     // Test 4: dismiss() when already false remains false (idempotent)
     @Test("dismiss() when already false stays false")
-    func testDismissIsIdempotentWhenFalse() {
+    func dismissIsIdempotentWhenFalse() {
         var state = PanelToggleState()
         state.dismiss()
         #expect(state.isShowing == false)
@@ -40,7 +39,7 @@ struct StatusBarToggleTests {
 
     // Test 5: show → dismiss → show results in isShowing = true (no stuck state)
     @Test("show → dismiss → show results in isShowing = true")
-    func testShowDismissShowSequence() {
+    func showDismissShowSequence() {
         var state = PanelToggleState()
         state.show()
         state.dismiss()
@@ -50,7 +49,7 @@ struct StatusBarToggleTests {
 
     // Test 6: Two consecutive dismiss() calls do not crash or produce incorrect state
     @Test("two consecutive dismiss() calls remain correct")
-    func testConsecutiveDismissCallsAreStable() {
+    func consecutiveDismissCallsAreStable() {
         var state = PanelToggleState()
         state.show()
         state.dismiss()
@@ -60,7 +59,7 @@ struct StatusBarToggleTests {
 
     // Test 7: toggle() from false returns .show and sets isShowing = true
     @Test("toggle() from false returns .show")
-    func testToggleFromFalseReturnsShow() {
+    func toggleFromFalseReturnsShow() {
         var state = PanelToggleState()
         let action = state.toggle()
         #expect(action == .show)
@@ -69,7 +68,7 @@ struct StatusBarToggleTests {
 
     // Test 8: toggle() from true returns .hide and sets isShowing = false
     @Test("toggle() from true returns .hide")
-    func testToggleFromTrueReturnsHide() {
+    func toggleFromTrueReturnsHide() {
         var state = PanelToggleState()
         state.show()
         let action = state.toggle()


### PR DESCRIPTION
## Summary

Phase 1 of the v2.3 tech debt sprint ([plan](https://github.com/KyleNesium/AIBattery/blob/main/.planning/v2.3-tech-debt.md)). Pure tooling — zero behaviour change, all 922 tests pass unchanged.

- Adds `.swiftformat` (conservative house-style config, swift 5.9, 4-space indent)
- Adds `.swiftlint.yml` (opt-in rules only; custom rule bans `Timer.publish` to prevent the v1.9.4 freeze class)
- Adds `.github/workflows/lint.yml` (runs both tools on every PR, fails only on format diffs / swiftlint errors; warnings advisory)
- Removes 3 redundant `@available(macOS 13.0, *)` annotations from `LaunchAtLoginManager.swift` (deployment floor is already macOS 13)
- Applies `swiftformat` baseline normalization across 107 files

The format-normalization commit is intentionally separated from the config commit so reviewers can read the config decisions without 800 lines of mechanical noise.

## Why split format from config?

Subsequent v2.3 phases (RetryPolicy extraction, MainActor refactors, large-file splits) will produce focused diffs. Absorbing the format normalization now means those review surfaces aren't polluted by `redundantReturn` / `wrapArguments` style changes mixed in with the logic changes.

## Lint baseline state

- `swiftformat --lint AIBattery/ AIBatteryApp/ Tests/` → 0 diffs across 148 files
- `swiftlint --quiet` → 0 errors, 12 advisory warnings (all `force_unwrapping`: literal HTTPS URLs in service files + test helpers — known-safe)

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` — all 922 tests pass
- [x] `swiftformat --lint` clean
- [x] `swiftlint --quiet` reports 0 errors
- [ ] CI `lint.yml` job passes (will verify after push)
- [ ] CI `build-and-test` still green

## Follow-ups

- Phase 2: extract `RetryPolicy` utility (#TBD)
- Phase 3a–c: move 3 services' network I/O off `@MainActor` (#TBD)
- Phase 4: split 5 files >500 lines (#TBD)