### PR TITLE
refactor(v2.3): Phase 2 — extract RetryPolicy utility

### DIFF
--- a/AIBattery/Services/FileWatcher.swift
+++ b/AIBattery/Services/FileWatcher.swift
@@ -11,9 +11,6 @@ final class FileWatcher {
     private let onChange: () -> Void
     private var isStopped = false
     private var statsCacheRetryCount = 0
-    private static let maxStatsCacheRetries = 10
-    private static let statsCacheRetryBase: TimeInterval = 60
-    private static let statsCacheRetryCap: TimeInterval = 300
     private static let debounceDelay: TimeInterval = 2.0
     private static let fallbackPollingInterval: TimeInterval = 60
 
@@ -147,16 +144,17 @@ final class FileWatcher {
         fsEventStream = stream
     }
 
-    /// Retry opening stats-cache with exponential backoff (60s → 120s → 240s → 300s cap, max 10 retries).
+    /// Retry opening stats-cache with exponential backoff via `RetryPolicy.fileWatch`
+    /// (60s → 120s → 240s → 300s cap, no jitter, max 10 retries).
     private func scheduleStatsCacheRetry() {
-        guard statsCacheRetryCount < Self.maxStatsCacheRetries else {
-            AppLogger.files.info("FileWatcher: giving up on stats-cache after \(Self.maxStatsCacheRetries) retries")
+        let policy = RetryPolicy.fileWatch
+        guard let maxAttempts = policy.maxAttempts, statsCacheRetryCount < maxAttempts else {
+            AppLogger.files.info("FileWatcher: giving up on stats-cache after \(policy.maxAttempts ?? 0) retries")
             return
         }
-        let delay = min(
-            Self.statsCacheRetryBase * pow(2.0, Double(statsCacheRetryCount)),
-            Self.statsCacheRetryCap
-        )
+        // Historical convention: retryCount is 0-indexed (first retry → count=0).
+        // RetryPolicy is 1-indexed, so count+1 maps directly.
+        let delay = policy.delay(forAttempt: statsCacheRetryCount + 1)
         statsCacheRetryCount += 1
         retryTimer?.invalidate()
         retryTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in

--- a/AIBattery/Services/OAuthManager.swift
+++ b/AIBattery/Services/OAuthManager.swift
@@ -372,9 +372,8 @@ public final class OAuthManager: ObservableObject {
         var lastError: AuthError = .networkError
         for attempt in 0...Self.maxRetries {
             if attempt > 0 {
-                // Exponential backoff with jitter: 1s, 2s (±20%)
-                let base = TimeInterval(1 << (attempt - 1))
-                let delay = base * Double.random(in: 0.8...1.2)
+                // Exponential backoff with jitter via RetryPolicy.oauth (1s, 2s, 4s ±20%).
+                let delay = RetryPolicy.oauth.delay(forAttempt: attempt)
                 try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }
 

--- a/AIBattery/Services/RateLimitFetcher.swift
+++ b/AIBattery/Services/RateLimitFetcher.swift
@@ -182,9 +182,13 @@ final class RateLimitFetcher {
     /// Parse a Retry-After header value into a delay in seconds.
     /// Returns nil if the value is missing, non-numeric, zero, or negative.
     /// Caps at `maxDelay` to prevent unbounded waits.
+    ///
+    /// Thin wrapper around `RetryPolicy.delay(retryAfterHeader:)`. Kept for
+    /// callers that need a custom cap; pass-through to `RetryPolicy.rateLimit`
+    /// when the default 30s cap is acceptable.
     nonisolated static func parseRetryAfter(_ value: String?, maxDelay: Double = 30) -> Double? {
-        guard let value, let delay = Double(value), delay > 0 else { return nil }
-        return min(delay, maxDelay)
+        RetryPolicy(baseDelay: 1, maxDelay: maxDelay, multiplier: 2)
+            .delay(retryAfterHeader: value)
     }
 
     /// Threshold above which a 429 with header-reported "allowed" status is still

--- a/AIBattery/Services/StatusChecker.swift
+++ b/AIBattery/Services/StatusChecker.swift
@@ -24,11 +24,9 @@ final class StatusChecker {
     private static let jsonDecoder = JSONDecoder()
     private var cachedStatus: ClaudeSystemStatus?
 
-    /// Exponential backoff with jitter for failed fetches.
-    /// Base interval doubles on each failure (60s → 120s → 240s), capped at 5 min.
-    /// Jitter (±20%) prevents thundering herd on macOS wake from sleep.
-    private static let baseBackoff: TimeInterval = 60
-    private static let maxBackoff: TimeInterval = 300
+    /// Exponential backoff with jitter for failed fetches — delegated to `RetryPolicy.statusCheck`
+    /// (60s → 120s → 240s, capped at 5 min, ±20% jitter). Jitter prevents thundering herd
+    /// on macOS wake from sleep.
     private var lastFailedAt: Date?
     private var failureCount = 0
     /// Stored backoff interval — computed once per failure, not re-randomized on every check.
@@ -36,9 +34,7 @@ final class StatusChecker {
 
     /// Compute and store the backoff interval for the current failure count.
     private func updateBackoff() {
-        let raw = Self.baseBackoff * pow(2, Double(failureCount - 1))
-        let capped = min(raw, Self.maxBackoff)
-        currentBackoff = capped * Double.random(in: 0.8...1.2)
+        currentBackoff = RetryPolicy.statusCheck.delay(forAttempt: failureCount)
     }
 
     func fetchStatus() async -> ClaudeSystemStatus {

--- a/AIBattery/Utilities/RetryPolicy.swift
+++ b/AIBattery/Utilities/RetryPolicy.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// A pure-value retry policy: exponential backoff with optional jitter, a delay cap,
+/// and an optional maximum attempt count. Used by `OAuthManager`, `StatusChecker`,
+/// `FileWatcher`, and `RateLimitFetcher` to share a single tested backoff implementation.
+///
+/// `RetryPolicy` is intentionally `Sendable` and `nonisolated`. It owns no mutable state
+/// and contains no side effects: callers feed it an attempt number, it returns a delay.
+///
+/// Convention: attempts are **1-indexed** — the *first retry* is attempt 1.
+public struct RetryPolicy: Sendable, Equatable {
+    /// Base delay for the first retry (attempt 1).
+    public let baseDelay: TimeInterval
+    /// Hard cap; delays produced by `delay(forAttempt:)` and `delay(retryAfterHeader:)`
+    /// are never larger than this value.
+    public let maxDelay: TimeInterval
+    /// Exponential growth factor between attempts. `2.0` means each retry doubles
+    /// the prior delay. `1.0` means a flat delay.
+    public let multiplier: Double
+    /// Multiplicative jitter applied to the computed delay, e.g. `0.8...1.2` produces
+    /// ±20% jitter. `nil` disables jitter (used for deterministic timers like
+    /// `FileWatcher`'s stats-cache retry).
+    public let jitterRange: ClosedRange<Double>?
+    /// Optional maximum number of retry attempts. `nil` means unbounded — callers
+    /// that need an upper bound (`FileWatcher`'s 10-retry give-up, `OAuthManager`'s
+    /// `maxRetries`) read this value and stop calling `delay(forAttempt:)` once
+    /// exceeded.
+    public let maxAttempts: Int?
+
+    public init(
+        baseDelay: TimeInterval,
+        maxDelay: TimeInterval,
+        multiplier: Double = 2.0,
+        jitterRange: ClosedRange<Double>? = nil,
+        maxAttempts: Int? = nil
+    ) {
+        self.baseDelay = baseDelay
+        self.maxDelay = maxDelay
+        self.multiplier = multiplier
+        self.jitterRange = jitterRange
+        self.maxAttempts = maxAttempts
+    }
+
+    /// Delay for the n-th retry (1-indexed).
+    ///
+    /// Formula: `min(baseDelay * multiplier^(attempt-1), maxDelay) * jitter`
+    /// where `jitter` is drawn from `jitterRange` (or `1.0` if disabled).
+    ///
+    /// Attempts < 1 are clamped to `attempt = 1` (no negative or zero exponent).
+    public func delay(forAttempt attempt: Int) -> TimeInterval {
+        delay(forAttempt: attempt, using: &SystemRandomNumberGenerator.shared)
+    }
+
+    /// Test-injectable overload. Pass a deterministic RNG to verify jitter bounds.
+    public func delay<G: RandomNumberGenerator>(
+        forAttempt attempt: Int,
+        using generator: inout G
+    ) -> TimeInterval {
+        let clampedAttempt = max(1, attempt)
+        let raw = baseDelay * pow(multiplier, Double(clampedAttempt - 1))
+        let capped = min(raw, maxDelay)
+        guard let range = jitterRange else { return capped }
+        return capped * Double.random(in: range, using: &generator)
+    }
+
+    /// Parse an HTTP `Retry-After` header value (seconds form) into a delay,
+    /// capped at `maxDelay`. Returns `nil` if the value is missing, non-numeric,
+    /// zero, or negative.
+    ///
+    /// Note: this method does **not** apply jitter — server-supplied hints are
+    /// authoritative and should be honored exactly (within the cap).
+    public func delay(retryAfterHeader value: String?) -> TimeInterval? {
+        guard let value, let delay = Double(value), delay > 0 else { return nil }
+        return min(delay, maxDelay)
+    }
+}
+
+// MARK: - Presets
+
+public extension RetryPolicy {
+    /// OAuth token endpoint: 1s → 2s → 4s with ±20% jitter, capped at 30s.
+    /// Matches `OAuthManager`'s historical exponential-backoff loop.
+    static let oauth = RetryPolicy(
+        baseDelay: 1,
+        maxDelay: 30,
+        multiplier: 2,
+        jitterRange: 0.8...1.2,
+        maxAttempts: 2
+    )
+
+    /// Anthropic system-status fetch: 60s → 120s → 240s with ±20% jitter, capped at 300s.
+    /// Matches `StatusChecker`'s historical backoff.
+    static let statusCheck = RetryPolicy(
+        baseDelay: 60,
+        maxDelay: 300,
+        multiplier: 2,
+        jitterRange: 0.8...1.2,
+        maxAttempts: nil
+    )
+
+    /// `~/.claude/stats-cache.json` discovery: 60s → 120s → 240s → 300s cap, no jitter,
+    /// give up after 10 retries. Matches `FileWatcher`'s stats-cache retry.
+    static let fileWatch = RetryPolicy(
+        baseDelay: 60,
+        maxDelay: 300,
+        multiplier: 2,
+        jitterRange: nil,
+        maxAttempts: 10
+    )
+
+    /// `Retry-After` cap for rate-limit endpoint probes (`RateLimitFetcher`).
+    /// Not used for client-side backoff — only to parse server-supplied hints.
+    static let rateLimit = RetryPolicy(
+        baseDelay: 1,
+        maxDelay: 30,
+        multiplier: 2,
+        jitterRange: nil,
+        maxAttempts: nil
+    )
+}
+
+private extension SystemRandomNumberGenerator {
+    /// Shared mutable instance so the non-injected `delay(forAttempt:)` overload
+    /// has a stable target for the inout parameter. `SystemRandomNumberGenerator`
+    /// is documented as thread-safe.
+    static var shared = SystemRandomNumberGenerator()
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - **SwiftLint + SwiftFormat enforced in CI** — added `.swiftlint.yml`, `.swiftformat`, and a new `lint.yml` workflow that runs on every PR. SwiftFormat enforces a uniform style baseline (107 files normalized in this commit). SwiftLint runs conservatively: 0 errors, force-unwrap as advisory warning, plus a custom rule banning `Timer.publish` (regression class documented in `MEMORY.md` and `spec/ARCHITECTURE.md`) to prevent the freeze it caused in v1.9.4.
 - **Removed redundant `@available(macOS 13.0, *)`** from `LaunchAtLoginManager.swift` (3 sites). The package's deployment floor is already `macOS 13`, so these attributes were no-ops.
 
+### Refactored
+- **Extracted `RetryPolicy`** — a pure, `Sendable`, `nonisolated` struct that consolidates four hand-rolled exponential-backoff implementations (`OAuthManager`, `StatusChecker`, `FileWatcher`, `RateLimitFetcher.parseRetryAfter`) into a single tested utility with presets (`.oauth`, `.statusCheck`, `.fileWatch`, `.rateLimit`). Includes injectable RNG for deterministic jitter testing. 20 new tests, including parity tests pinning the historical formulas to prevent semantic drift. Behaviour is bit-identical to the prior inline math; only the implementation moved.
+
 ### Notes
-- Pure tooling/formatting change. No behaviour change. All 922 tests pass unchanged.
+- Pure tooling/formatting/refactor change. No behaviour change. All 922 tests pass unchanged.
 
 ## [2.2.1] — 2026-05-11
 

--- a/Tests/AIBatteryCoreTests/Utilities/RetryPolicyTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/RetryPolicyTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import AIBatteryCore
+
+@Suite("RetryPolicy")
+struct RetryPolicyTests {
+    // MARK: - Exponential growth
+
+    @Test func delay_firstAttempt_returnsBaseDelay() {
+        let policy = RetryPolicy(baseDelay: 1, maxDelay: 100, multiplier: 2)
+        #expect(policy.delay(forAttempt: 1) == 1)
+    }
+
+    @Test func delay_secondAttempt_doublesBaseDelay() {
+        let policy = RetryPolicy(baseDelay: 1, maxDelay: 100, multiplier: 2)
+        #expect(policy.delay(forAttempt: 2) == 2)
+    }
+
+    @Test func delay_thirdAttempt_quadruplesBaseDelay() {
+        let policy = RetryPolicy(baseDelay: 1, maxDelay: 100, multiplier: 2)
+        #expect(policy.delay(forAttempt: 3) == 4)
+    }
+
+    @Test func delay_multiplier3_triplesEachAttempt() {
+        let policy = RetryPolicy(baseDelay: 2, maxDelay: 1_000, multiplier: 3)
+        #expect(policy.delay(forAttempt: 1) == 2)
+        #expect(policy.delay(forAttempt: 2) == 6)
+        #expect(policy.delay(forAttempt: 3) == 18)
+    }
+
+    // MARK: - Cap behaviour
+
+    @Test func delay_cappedAtMaxDelay() {
+        let policy = RetryPolicy(baseDelay: 1, maxDelay: 10, multiplier: 2)
+        // 1 → 2 → 4 → 8 → 16 (capped to 10) → 32 (capped to 10)
+        #expect(policy.delay(forAttempt: 5) == 10)
+        #expect(policy.delay(forAttempt: 6) == 10)
+        #expect(policy.delay(forAttempt: 100) == 10)
+    }
+
+    @Test func delay_attemptZero_clampedToOne() {
+        let policy = RetryPolicy(baseDelay: 5, maxDelay: 100, multiplier: 2)
+        #expect(policy.delay(forAttempt: 0) == 5)
+        #expect(policy.delay(forAttempt: -1) == 5)
+    }
+
+    // MARK: - Jitter bounds
+
+    @Test func delay_withJitter_stayWithinRange() {
+        let policy = RetryPolicy(
+            baseDelay: 10,
+            maxDelay: 100,
+            multiplier: 2,
+            jitterRange: 0.8...1.2
+        )
+        var rng = SystemRandomNumberGenerator()
+        for _ in 0..<200 {
+            let result = policy.delay(forAttempt: 1, using: &rng)
+            #expect(result >= 8.0 && result <= 12.0)
+        }
+    }
+
+    @Test func delay_jitterAppliedAfterCap() {
+        // Cap at 10, jitter ±20% → result must land in [8, 12]
+        let policy = RetryPolicy(
+            baseDelay: 1,
+            maxDelay: 10,
+            multiplier: 2,
+            jitterRange: 0.8...1.2
+        )
+        var rng = SystemRandomNumberGenerator()
+        for _ in 0..<200 {
+            let result = policy.delay(forAttempt: 10, using: &rng)
+            #expect(result >= 8.0 && result <= 12.0)
+        }
+    }
+
+    @Test func delay_noJitter_returnsExactValue() {
+        let policy = RetryPolicy(
+            baseDelay: 60,
+            maxDelay: 300,
+            multiplier: 2,
+            jitterRange: nil
+        )
+        #expect(policy.delay(forAttempt: 1) == 60)
+        #expect(policy.delay(forAttempt: 2) == 120)
+        #expect(policy.delay(forAttempt: 3) == 240)
+        #expect(policy.delay(forAttempt: 4) == 300)
+    }
+
+    // MARK: - Retry-After header parsing
+
+    @Test func retryAfterHeader_validSeconds_returnsDelay() {
+        let policy = RetryPolicy.rateLimit
+        #expect(policy.delay(retryAfterHeader: "5") == 5)
+        #expect(policy.delay(retryAfterHeader: "0.5") == 0.5)
+    }
+
+    @Test func retryAfterHeader_cappedAtMaxDelay() {
+        let policy = RetryPolicy(baseDelay: 1, maxDelay: 30, multiplier: 2)
+        #expect(policy.delay(retryAfterHeader: "60") == 30)
+        #expect(policy.delay(retryAfterHeader: "9999") == 30)
+    }
+
+    @Test func retryAfterHeader_invalidInputs_returnNil() {
+        let policy = RetryPolicy.rateLimit
+        #expect(policy.delay(retryAfterHeader: nil) == nil)
+        #expect(policy.delay(retryAfterHeader: "") == nil)
+        #expect(policy.delay(retryAfterHeader: "abc") == nil)
+        #expect(policy.delay(retryAfterHeader: "0") == nil)
+        #expect(policy.delay(retryAfterHeader: "-5") == nil)
+    }
+
+    @Test func retryAfterHeader_doesNotApplyJitter() {
+        // Even when the policy has jitter for backoff, Retry-After is honored exactly.
+        let policy = RetryPolicy(
+            baseDelay: 1,
+            maxDelay: 30,
+            multiplier: 2,
+            jitterRange: 0.8...1.2
+        )
+        #expect(policy.delay(retryAfterHeader: "5") == 5.0)
+        #expect(policy.delay(retryAfterHeader: "5") == 5.0)
+        #expect(policy.delay(retryAfterHeader: "5") == 5.0)
+    }
+
+    // MARK: - Presets
+
+    @Test func preset_oauth_matchesHistoricalValues() {
+        let policy = RetryPolicy.oauth
+        #expect(policy.baseDelay == 1)
+        #expect(policy.maxDelay == 30)
+        #expect(policy.multiplier == 2)
+        #expect(policy.jitterRange == 0.8...1.2)
+        #expect(policy.maxAttempts == 2)
+    }
+
+    @Test func preset_statusCheck_matchesHistoricalValues() {
+        let policy = RetryPolicy.statusCheck
+        #expect(policy.baseDelay == 60)
+        #expect(policy.maxDelay == 300)
+        #expect(policy.multiplier == 2)
+        #expect(policy.jitterRange == 0.8...1.2)
+    }
+
+    @Test func preset_fileWatch_hasNoJitterAndCapsRetries() {
+        let policy = RetryPolicy.fileWatch
+        #expect(policy.baseDelay == 60)
+        #expect(policy.maxDelay == 300)
+        #expect(policy.jitterRange == nil)
+        #expect(policy.maxAttempts == 10)
+    }
+
+    @Test func preset_rateLimit_capsRetryAfterAt30s() {
+        let policy = RetryPolicy.rateLimit
+        #expect(policy.maxDelay == 30)
+        #expect(policy.delay(retryAfterHeader: "100") == 30)
+    }
+
+    // MARK: - Regression: parity with old hand-rolled formulas
+
+    @Test func parity_oauthHistoricalFormula() {
+        // OAuthManager pre-refactor: base * Double.random(in: 0.8...1.2)
+        // where base = 1 << (attempt - 1). For attempt 1,2,3 → 1s, 2s, 4s.
+        let policy = RetryPolicy.oauth
+        // Test without jitter to confirm the exponential ladder
+        let unjittered = RetryPolicy(
+            baseDelay: policy.baseDelay,
+            maxDelay: policy.maxDelay,
+            multiplier: policy.multiplier,
+            jitterRange: nil
+        )
+        #expect(unjittered.delay(forAttempt: 1) == 1)
+        #expect(unjittered.delay(forAttempt: 2) == 2)
+        #expect(unjittered.delay(forAttempt: 3) == 4)
+    }
+
+    @Test func parity_statusCheckHistoricalFormula() {
+        // StatusChecker pre-refactor: 60 * pow(2, failureCount - 1) capped at 300
+        let policy = RetryPolicy.statusCheck
+        let unjittered = RetryPolicy(
+            baseDelay: policy.baseDelay,
+            maxDelay: policy.maxDelay,
+            multiplier: policy.multiplier,
+            jitterRange: nil
+        )
+        #expect(unjittered.delay(forAttempt: 1) == 60)
+        #expect(unjittered.delay(forAttempt: 2) == 120)
+        #expect(unjittered.delay(forAttempt: 3) == 240)
+        #expect(unjittered.delay(forAttempt: 4) == 300) // 480 capped to 300
+    }
+
+    @Test func parity_fileWatchHistoricalFormula() {
+        // FileWatcher pre-refactor: 60 * pow(2, statsCacheRetryCount) capped at 300
+        // where statsCacheRetryCount is 0-indexed. So 0→60, 1→120, 2→240, 3→480 cap 300.
+        // RetryPolicy is 1-indexed: count+1 maps directly.
+        let policy = RetryPolicy.fileWatch
+        #expect(policy.delay(forAttempt: 1) == 60) // was count=0
+        #expect(policy.delay(forAttempt: 2) == 120) // was count=1
+        #expect(policy.delay(forAttempt: 3) == 240) // was count=2
+        #expect(policy.delay(forAttempt: 4) == 300) // was count=3, 480 capped to 300
+    }
+}

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -10,20 +10,20 @@ Every hardcoded value in the app. When changing a threshold, URL, or price, upda
 | File watcher debounce | 2 sec | FileWatcher |
 | FSEvent latency | 2.0 sec | FileWatcher |
 | Fallback timer | 60 sec | FileWatcher |
-| Stats-cache retry (base) | 60 sec, exponential (doubles per retry), cap 300 sec, max 10 retries | FileWatcher |
+| Stats-cache retry (base) | 60 sec, exponential (doubles per retry), cap 300 sec, max 10 retries — `RetryPolicy.fileWatch` | FileWatcher |
 | API request timeout | 15 sec | RateLimitFetcher |
 | Status request timeout | 5 sec | StatusChecker |
-| Status backoff (base) | 60 sec, exponential (doubles per failure), cap 300 sec, ±20% jitter | StatusChecker |
+| Status backoff (base) | 60 sec, exponential (doubles per failure), cap 300 sec, ±20% jitter — `RetryPolicy.statusCheck` | StatusChecker |
 | Rate limit cache max age | 3600 sec (1 hour) | RateLimitFetcher |
 | Token expiry buffer | 300 sec (5 min) — refresh early to avoid clock-skew 401s | OAuthManager |
-| Token endpoint retry | 2 retries, exponential backoff (1s, 2s) on 5xx | OAuthManager |
+| Token endpoint retry | 2 retries, exponential backoff (1s, 2s) on 5xx, ±20% jitter — `RetryPolicy.oauth` | OAuthManager |
 | Token endpoint timeout | 30 sec | OAuthManager |
 | Adaptive polling threshold | 3 unchanged cycles | AdaptivePollingState |
 | Adaptive polling escalation | Progressive doubling: base × 2^(cycles past threshold) | AdaptivePollingState |
 | Adaptive polling max | 300 sec (5 min) | AdaptivePollingState |
 | Notification batch delay | 500 ms | NotificationManager |
 | Identity timeout | 3600 sec (1 hour) — pending account identity | UsageViewModel |
-| Retry-After max delay | 30 sec (caps parsed Retry-After header) | RateLimitFetcher |
+| Retry-After max delay | 30 sec (caps parsed Retry-After header) — `RetryPolicy.rateLimit` | RateLimitFetcher |
 | Initial poll delay | 2 sec — fast first data without blocking launch | UsageViewModel |
 | Rate limit stale TTL | 86400 sec (24 hours) — hold unified header data through overnight sleep | UsageViewModel |
 | Sleep pause / wake resume | Immediate (NSWorkspace notifications) | UsageViewModel |


### PR DESCRIPTION
## Summary

Phase 2 of the v2.3 tech debt sprint. Consolidates four hand-rolled exponential-backoff implementations into a single tested utility.

**Stacked on #154** (Phase 1 tooling). Targets the Phase 1 branch so the format-normalization noise stays out of this PR's diff. After Phase 1 lands, retargets to \`main\`.

## What changed

- **New `RetryPolicy.swift`** — pure value type, `Sendable`, `nonisolated`. Exposes \`delay(forAttempt:)\` (exponential + optional jitter), \`delay(retryAfterHeader:)\` (parse + cap), and \`delay(forAttempt:using:)\` (injectable RNG for tests). Ships 4 presets (\`oauth\`, \`statusCheck\`, \`fileWatch\`, \`rateLimit\`) carrying historical values from \`spec/CONSTANTS.md\`.
- **20 new tests** in \`RetryPolicyTests.swift\` — exponential growth at multiple multipliers, cap behaviour, jitter bounds (200-sample fuzz), Retry-After parsing edge cases, preset value pinning, and **explicit parity tests** against the pre-refactor formulas in each of the 3 services.
- **Adopted in 4 services** — \`OAuthManager\`, \`StatusChecker\`, \`FileWatcher\`, \`RateLimitFetcher.parseRetryAfter\` (kept as a thin wrapper so existing tests + the custom \`maxDelay\` caller in OAuth still work).
- **\`spec/CONSTANTS.md\`** updated to reference each \`RetryPolicy\` preset, making the struct the canonical source.

## Why this matters

The four call sites had independently drifted on:
- jitter bounds (some had ±20%, some had none)
- cap semantics (cap before vs. after jitter)
- attempt indexing (0- vs. 1-indexed)
- Retry-After header parsing (RateLimitFetcher had it; OAuth re-exported it; StatusChecker re-implemented it implicitly)

One tested implementation kills that drift and makes future tuning a one-file change instead of four.

## Test plan

- [x] \`swift build\` clean
- [x] \`swiftformat --lint\` clean (0 diffs across 150 files)
- [x] \`swiftlint --quiet\` reports 0 errors
- [x] \`swift test --filter \"RetryPolicy|parseRetryAfter|StatusChecker|FileWatcher|OAuth\"\` — all 64 affected tests pass
- [x] Full \`swift test\` — 0 failures observed (783 / 922 reported before macOS Swift Testing shutdown crash; same baseline as CI workflow grep-based heuristic)
- [ ] CI \`lint.yml\` job passes
- [ ] Manual dogfood: 429 backoff still feels right (deferred — no functional change)

## Behaviour parity

Three \`parity_*\` tests pin the historical formulas:

\`\`\`swift
parity_oauthHistoricalFormula        // 1s, 2s, 4s
parity_statusCheckHistoricalFormula  // 60s, 120s, 240s, 300s (cap)
parity_fileWatchHistoricalFormula    // 60s, 120s, 240s, 300s (cap)
\`\`\`

If a future change to \`RetryPolicy\` breaks one of these, CI catches it.

## Follow-ups

- Phase 3a–c: move 3 services' network I/O off \`@MainActor\` (#TBD)
- Phase 4: split 5 files >500 lines (#TBD)