### PR TITLE
v2.3.1 — popover polish, design tokens, a11y

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,12 @@ jobs:
     name: Build, Test & Verify
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft != true
     runs-on: macos-15
-    timeout-minutes: 10
+    # Bumped from 10 → 22: the test step has 3 × 6-minute retry attempts for
+    # macos-15 swiftpm-testing-helper hangs. At 10 minutes the job timeout
+    # cancelled before the retry logic could try a second attempt — observed
+    # twice on v2.3.1 PR runs. 22 = 3 × 6 retry budget + 4 min for build/cache
+    # /cleanup overhead.
+    timeout-minutes: 22
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 

--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>CFBundleIconFile</key>

--- a/AIBattery/Utilities/Spacing.swift
+++ b/AIBattery/Utilities/Spacing.swift
@@ -196,9 +196,16 @@ enum MotionConstants {
     /// Full-rotation spin (refresh button): 0.5s easeInOut.
     static let spin: Animation = .easeInOut(duration: 0.5)
 
-    /// Section expand/collapse transition — fade + slide from top.
+    /// Section expand/collapse transition.
+    ///
+    /// Plain opacity — never .move(edge:) inside the popover. The panel is
+    /// an NSPanel that re-anchors its top to the menu bar and grows/shrinks
+    /// to fit SwiftUI's content height. A .move transition translates the
+    /// inserting/removing view while the panel is simultaneously resizing,
+    /// which reads as a "jump" rather than a smooth expand. Cross-fade
+    /// hides the resize boundary cleanly.
     static var expandTransition: AnyTransition {
-        .opacity.combined(with: .move(edge: .top))
+        .opacity
     }
 
     // MARK: - State timing (non-animation durations)

--- a/AIBattery/Utilities/Spacing.swift
+++ b/AIBattery/Utilities/Spacing.swift
@@ -196,6 +196,31 @@ enum MotionConstants {
     /// Full-rotation spin (refresh button): 0.5s easeInOut.
     static let spin: Animation = .easeInOut(duration: 0.5)
 
+    // MARK: - Marquee (footer incident ticker)
+
+    /// Pause at each end of a marquee scroll, and the initial geometry-settle
+    /// delay before the first scroll. Short so the leading text isn't mistaken
+    /// for a static, truncated message on first reveal.
+    static let marqueePauseSeconds: Double = 0.5
+
+    /// Hold duration for a non-scrolling text before cycling to the next.
+    static let marqueeHoldSeconds: Double = 3.0
+
+    /// Restart delay after the `texts` array changes — lets new geometry settle.
+    static let marqueeRestartSeconds: Double = 0.1
+
+    /// Wait between fade-in completing and the next scroll cycle starting,
+    /// so geometry has time to remeasure under the new text.
+    static let marqueeFadeSettleSeconds: Double = 0.6
+
+    /// Points per second a marquee scrolls horizontally.
+    static let marqueeScrollSpeed: Double = 30.0
+
+    /// Linear animation for a marquee scroll of `travel` points at `marqueeScrollSpeed`.
+    static func marqueeScroll(travelPoints: Double) -> Animation {
+        .linear(duration: max(0.0, travelPoints / marqueeScrollSpeed))
+    }
+
     /// Section expand/collapse transition.
     ///
     /// Plain opacity — never .move(edge:) inside the popover. The panel is

--- a/AIBattery/Utilities/ThemeColors.swift
+++ b/AIBattery/Utilities/ThemeColors.swift
@@ -167,6 +167,15 @@ enum ThemeColors {
         dark: NSColor(white: 1.0, alpha: 0.35)
     )
 
+    /// Inactive stroke — the project's canonical "subtle secondary outline" used
+    /// for unselected segmented-control borders, inactive auto-mode ring, etc.
+    /// Centralizes the prior `Color.secondary.opacity(…)` pattern.
+    static let inactiveStroke: Color = .secondary
+
+    /// Shadow color for elevated controls (selected tab fill, hovered cards).
+    /// Wraps the raw black-with-opacity pattern that was scattered across views.
+    static let shadowColor: Color = .black
+
     // MARK: - Interactive state colors
 
     /// Hover highlight for interactive elements (buttons, chevrons, headers).

--- a/AIBattery/Views/AuthView.swift
+++ b/AIBattery/Views/AuthView.swift
@@ -61,7 +61,7 @@ public struct AuthView: View {
                         .padding(.vertical, Spacing.gap)
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(.accentColor)
+                    .tint(ThemeColors.action)
                     .accessibilityLabel("Sign in with Claude")
                     .accessibilityHint("Opens browser to sign in with your Anthropic account")
                     .help("Opens browser to sign in with your Anthropic account")
@@ -130,7 +130,7 @@ public struct AuthView: View {
                             }
                         }
                         .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
+                        .tint(ThemeColors.action)
                         .disabled(authCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isExchanging)
                         .accessibilityLabel(isExchanging ? "Connecting" : "Connect")
                         .accessibilityHint("Submit authorization code")

--- a/AIBattery/Views/AuthView.swift
+++ b/AIBattery/Views/AuthView.swift
@@ -116,6 +116,7 @@ public struct AuthView: View {
                         .font(Typography.caption)
                         .foregroundStyle(ThemeColors.secondaryLabel)
                         .accessibilityLabel("Cancel authentication")
+                        .accessibilityHint("Returns to the sign-in screen")
                         .help("Go back to sign-in")
 
                         Spacer()
@@ -160,6 +161,7 @@ public struct AuthView: View {
                         .font(Typography.tinyLabel)
                         .foregroundStyle(ThemeColors.secondaryLabel)
                         .accessibilityLabel("Cancel adding account")
+                        .accessibilityHint("Returns to the main popover")
                 } else {
                     Button("Quit") { NSApplication.shared.terminate(nil) }
                         .buttonStyle(.plain)

--- a/AIBattery/Views/CollapsibleSectionHeader.swift
+++ b/AIBattery/Views/CollapsibleSectionHeader.swift
@@ -31,7 +31,7 @@ struct CollapsibleSectionHeader: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Spacing.xsmall)
-                    .stroke(isFocused ? Color.accentColor.opacity(ThemeColors.focusRingOpacity) : Color.clear, lineWidth: Layout.borderWidth)
+                    .stroke(isFocused ? ThemeColors.action.opacity(ThemeColors.focusRingOpacity) : Color.clear, lineWidth: Layout.borderWidth)
             )
             .contentShape(Rectangle())
         }

--- a/AIBattery/Views/Components/GaugeRow.swift
+++ b/AIBattery/Views/Components/GaugeRow.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Shared shell for the "labelled gauge" row used by every rate-limit section
+/// in the popover: a header HStack, a `GaugeBar`, and a `TimelineView` footer.
+///
+/// The header content (label, badges, trailing value) and footer content (state
+/// text on the left, reset countdown on the right) vary between call sites, so
+/// they're supplied as ViewBuilder closures. The wrapper owns the VStack
+/// spacing, the gauge wiring, the accessibility plumbing, and the timeline
+/// schedule.
+struct GaugeRow<HeaderLeading: View, HeaderTrailing: View, Footer: View>: View {
+    let percent: Double
+    let barColor: Color
+    let accessibilityLabel: String
+    let accessibilityValue: String
+    var tickInterval: TimeInterval = 10
+    @ViewBuilder var headerLeading: () -> HeaderLeading
+    @ViewBuilder var headerTrailing: () -> HeaderTrailing
+    @ViewBuilder var footer: (Date) -> Footer
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.inner) {
+            HStack {
+                headerLeading()
+                Spacer()
+                headerTrailing()
+            }
+
+            GaugeBar(percent: percent, barColor: barColor)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityValue(accessibilityValue)
+
+            TimelineView(.periodic(from: .now, by: tickInterval)) { context in
+                footer(context.date)
+            }
+        }
+    }
+}

--- a/AIBattery/Views/Components/LinkActionButton.swift
+++ b/AIBattery/Views/Components/LinkActionButton.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// A plain text-styled button that reads as a link rather than a control —
+/// used for inline secondary actions like "Add Account", "Test", "Download",
+/// "Install Update". Standardizes color (`ThemeColors.action`), font scale,
+/// and icon-to-text spacing across what used to be four ad-hoc variants.
+///
+/// Use `.standard` for in-flow settings actions (e.g. Add Account) and
+/// `.compact` for in-banner actions (Test, Download, Install Update).
+struct LinkActionButton: View {
+    enum Size {
+        case standard
+        case compact
+    }
+
+    let label: String
+    var icon: String?
+    var size: Size = .standard
+    var help: String?
+    var accessibilityLabel: String?
+    var accessibilityHint: String = ""
+    let action: () -> Void
+
+    private var labelFont: Font {
+        size == .compact ? Typography.tinyLabel : Typography.caption
+    }
+
+    private var iconFont: Font {
+        size == .compact ? Typography.monoTiny : Typography.tinyLabel
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.xsmall) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(iconFont)
+                }
+                Text(label)
+                    .font(labelFont)
+            }
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(ThemeColors.action)
+        .modifier(OptionalHelp(text: help))
+        .accessibilityLabel(accessibilityLabel ?? label)
+        .accessibilityHint(accessibilityHint)
+    }
+}
+
+/// `.help(_)` always renders a tooltip — even with an empty string — and
+/// SwiftUI doesn't ship an "apply only if non-nil" overload. Wrap it.
+private struct OptionalHelp: ViewModifier {
+    let text: String?
+    func body(content: Content) -> some View {
+        if let text {
+            content.help(text)
+        } else {
+            content
+        }
+    }
+}

--- a/AIBattery/Views/Components/LinkActionButton.swift
+++ b/AIBattery/Views/Components/LinkActionButton.swift
@@ -21,11 +21,17 @@ struct LinkActionButton: View {
     var accessibilityHint: String = ""
     let action: () -> Void
 
-    private var labelFont: Font {
+    private var labelFont: Font { Self.labelFont(for: size) }
+    private var iconFont: Font { Self.iconFont(for: size) }
+
+    /// Label font for the given size variant. Exposed for unit tests so the
+    /// scaling contract is pinned outside of view-body introspection.
+    static func labelFont(for size: Size) -> Font {
         size == .compact ? Typography.tinyLabel : Typography.caption
     }
 
-    private var iconFont: Font {
+    /// Icon font for the given size variant.
+    static func iconFont(for size: Size) -> Font {
         size == .compact ? Typography.monoTiny : Typography.tinyLabel
     }
 

--- a/AIBattery/Views/FooterLink.swift
+++ b/AIBattery/Views/FooterLink.swift
@@ -1,12 +1,19 @@
 import SwiftUI
 
-/// Footer link button with hover underline effect and external link arrow.
+/// Footer link button with hover underline effect.
+///
+/// By default renders a trailing arrow.up.right suggesting "opens in browser".
+/// Set `showsExternalArrow: false` for inline actions like Logout / Quit.
+/// Set `foregroundOverride` when the action communicates state (e.g. destructive
+/// confirm) that the default .primary/.secondary palette can't express.
 struct FooterLink<Leading: View>: View {
     let icon: String?
     let label: String
     var tooltip: String = ""
     var accessibilityLabel: String?
     var accessibilityHint: String = "Opens in browser"
+    var showsExternalArrow: Bool = true
+    var foregroundOverride: Color?
     let action: () -> Void
     let leading: () -> Leading
 
@@ -19,6 +26,8 @@ struct FooterLink<Leading: View>: View {
         tooltip: String = "",
         accessibilityLabel: String? = nil,
         accessibilityHint: String = "Opens in browser",
+        showsExternalArrow: Bool = true,
+        foregroundOverride: Color? = nil,
         action: @escaping () -> Void,
         @ViewBuilder leading: @escaping () -> Leading = { EmptyView() }
     ) {
@@ -27,6 +36,8 @@ struct FooterLink<Leading: View>: View {
         self.tooltip = tooltip
         self.accessibilityLabel = accessibilityLabel
         self.accessibilityHint = accessibilityHint
+        self.showsExternalArrow = showsExternalArrow
+        self.foregroundOverride = foregroundOverride
         self.action = action
         self.leading = leading
     }
@@ -43,13 +54,15 @@ struct FooterLink<Leading: View>: View {
                 Text(label)
                     .font(Typography.tinyLabel)
                     .underline(isHovered || isFocused)
-                Image(systemName: "arrow.up.right")
-                    .font(Typography.decorativeIcon)
+                if showsExternalArrow {
+                    Image(systemName: "arrow.up.right")
+                        .font(Typography.decorativeIcon)
+                }
             }
             .fixedSize()
         }
         .buttonStyle(.plain)
-        .foregroundStyle(isHovered || isFocused ? .primary : .secondary)
+        .foregroundStyle(foregroundOverride ?? (isHovered || isFocused ? .primary : .secondary))
         .focused($isFocused)
         .onHover { isHovered = $0 }
         .help(tooltip)

--- a/AIBattery/Views/FooterLink.swift
+++ b/AIBattery/Views/FooterLink.swift
@@ -42,14 +42,14 @@ struct FooterLink<Leading: View>: View {
                 }
                 Text(label)
                     .font(Typography.tinyLabel)
-                    .underline(isHovered)
+                    .underline(isHovered || isFocused)
                 Image(systemName: "arrow.up.right")
                     .font(Typography.decorativeIcon)
             }
             .fixedSize()
         }
         .buttonStyle(.plain)
-        .foregroundStyle(isFocused ? .primary : .secondary)
+        .foregroundStyle(isHovered || isFocused ? .primary : .secondary)
         .focused($isFocused)
         .onHover { isHovered = $0 }
         .help(tooltip)

--- a/AIBattery/Views/InsightsTrendCostSection.swift
+++ b/AIBattery/Views/InsightsTrendCostSection.swift
@@ -42,6 +42,7 @@ extension InsightsView {
                 HStack(spacing: Spacing.xsmall) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(Typography.decorativeIcon)
+                        .accessibilityHidden(true)
                     Text("Throttled: \(throttleCount)×")
                         .font(Typography.monoCaption)
                 }
@@ -88,19 +89,22 @@ extension InsightsView {
         if !models.isEmpty {
             VStack(alignment: .leading, spacing: Spacing.inner) {
                 ForEach(models) { model in
+                    let active = isActive(model)
                     let modelTokensText = TokenFormatter.format(model.totalTokens)
                     let modelCost = "~\(ModelPricing.formatCompactCost(model.estimatedCost))"
-                    let copyText = "\(model.displayName) \u{00B7} \(modelCost) \u{00B7} \(modelTokensText)"
+                    let activeSuffix = active ? " \u{00B7} active" : ""
+                    let copyText = "\(model.displayName)\(activeSuffix) \u{00B7} \(modelCost) \u{00B7} \(modelTokensText)"
                     HStack(spacing: Spacing.gap) {
                         Text(model.displayName)
                             .font(Typography.tinyLabel)
                             .lineLimit(1)
 
-                        if isActive(model) {
+                        if active {
                             Text("▶")
                                 .font(Typography.decorativeIcon)
                                 .foregroundStyle(ThemeColors.success)
                                 .help("Active model in current session")
+                                .accessibilityLabel("Active model")
                         }
 
                         Spacer()
@@ -116,6 +120,8 @@ extension InsightsView {
                             .frame(width: tokenColumnWidth, alignment: .trailing)
                     }
                     .copyable(copyText)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(model.displayName)\(active ? ", active" : ""), \(modelCost), \(modelTokensText) tokens")
                 }
             }
         }

--- a/AIBattery/Views/LocalEstimateSection.swift
+++ b/AIBattery/Views/LocalEstimateSection.swift
@@ -56,6 +56,7 @@ struct LocalEstimateSection: View {
                     Text("\(Int(pct))%")
                         .font(Typography.monoValue)
                         .copyable("\(Int(pct))%")
+                        .accessibilityLabel("\(label) usage \(Int(pct)) percent")
                 }
                 tokenLabel(tokens: tokens, limit: limit)
             }

--- a/AIBattery/Views/MarqueeText.swift
+++ b/AIBattery/Views/MarqueeText.swift
@@ -5,8 +5,8 @@ import SwiftUI
 /// Single text bounces back and forth; if the text fits, it displays statically.
 struct MarqueeText: View {
     let texts: [String]
-    var font: Font = .caption2
-    var color: Color = .secondary
+    var font: Font = Typography.tinyLabel
+    var color: Color = ThemeColors.secondaryLabel
 
     @State private var currentIndex: Int = 0
     @State private var textWidth: CGFloat = 0
@@ -16,16 +16,6 @@ struct MarqueeText: View {
     @State private var textOpacity: Double = 1.0
     @State private var pendingWork: DispatchWorkItem?
 
-    /// Pause at each end before scrolling. Kept short so a glance at the
-    /// footer banner doesn't catch a long static-truncation pose before the
-    /// scroll starts (the leading text would otherwise look like the whole
-    /// message, mid-truncation, on first reveal).
-    private let pauseDuration: Double = 0.5
-    /// Points per second scroll speed.
-    private let scrollSpeed: Double = 30.0
-    /// How long a non-scrolling text stays before cycling to the next.
-    private let holdDuration: Double = 3.0
-
     private var currentText: String {
         texts.isEmpty ? "" : texts[currentIndex % texts.count]
     }
@@ -34,14 +24,14 @@ struct MarqueeText: View {
     private var hasMultiple: Bool { texts.count > 1 }
 
     /// Convenience init for a single text string.
-    init(text: String, font: Font = .caption2, color: Color = .secondary) {
+    init(text: String, font: Font = Typography.tinyLabel, color: Color = ThemeColors.secondaryLabel) {
         self.texts = [text]
         self.font = font
         self.color = color
     }
 
     /// Init for multiple cycling texts.
-    init(texts: [String], font: Font = .caption2, color: Color = .secondary) {
+    init(texts: [String], font: Font = Typography.tinyLabel, color: Color = ThemeColors.secondaryLabel) {
         self.texts = texts
         self.font = font
         self.color = color
@@ -118,7 +108,7 @@ struct MarqueeText: View {
         textOpacity = 1.0
 
         // Wait a beat for geometry to settle, then decide scroll vs hold
-        schedule(after: pauseDuration) {
+        schedule(after: MotionConstants.marqueePauseSeconds) {
             if needsScroll {
                 scrollLeft()
             } else if hasMultiple {
@@ -133,7 +123,7 @@ struct MarqueeText: View {
         textWidth = 0
         currentIndex = 0
         textOpacity = 1.0
-        schedule(after: 0.1) {
+        schedule(after: MotionConstants.marqueeRestartSeconds) {
             beginCycle()
         }
     }
@@ -143,13 +133,13 @@ struct MarqueeText: View {
     private func scrollLeft() {
         guard animating, needsScroll else { return }
         let travel = textWidth - containerWidth
-        let duration = travel / scrollSpeed
 
-        withAnimation(.linear(duration: duration)) {
+        withAnimation(MotionConstants.marqueeScroll(travelPoints: Double(travel))) {
             offset = -travel
         }
 
-        schedule(after: duration + pauseDuration) {
+        let duration = Double(travel) / MotionConstants.marqueeScrollSpeed
+        schedule(after: duration + MotionConstants.marqueePauseSeconds) {
             if hasMultiple {
                 fadeToNext()
             } else {
@@ -161,13 +151,13 @@ struct MarqueeText: View {
     private func scrollRight() {
         guard animating, needsScroll else { return }
         let travel = textWidth - containerWidth
-        let duration = travel / scrollSpeed
 
-        withAnimation(.linear(duration: duration)) {
+        withAnimation(MotionConstants.marqueeScroll(travelPoints: Double(travel))) {
             offset = 0
         }
 
-        schedule(after: duration + pauseDuration) {
+        let duration = Double(travel) / MotionConstants.marqueeScrollSpeed
+        schedule(after: duration + MotionConstants.marqueePauseSeconds) {
             scrollLeft()
         }
     }
@@ -176,7 +166,7 @@ struct MarqueeText: View {
 
     /// Hold the current (non-scrolling) text, then advance.
     private func holdThenAdvance() {
-        schedule(after: holdDuration) {
+        schedule(after: MotionConstants.marqueeHoldSeconds) {
             fadeToNext()
         }
     }
@@ -190,6 +180,7 @@ struct MarqueeText: View {
             textOpacity = 0
         }
 
+        // 0.35s lines up with fadeOut's 0.3s duration plus a brief settle.
         schedule(after: 0.35) {
             currentIndex = (currentIndex + 1) % texts.count
             offset = 0
@@ -201,7 +192,7 @@ struct MarqueeText: View {
             }
 
             // After fade-in + geometry settle, start new cycle for this text
-            schedule(after: 0.6) {
+            schedule(after: MotionConstants.marqueeFadeSettleSeconds) {
                 if needsScroll {
                     scrollLeft()
                 } else {

--- a/AIBattery/Views/MetricToggleView.swift
+++ b/AIBattery/Views/MetricToggleView.swift
@@ -60,7 +60,7 @@ struct MetricToggleView: View {
                 .background(
                     RoundedRectangle(cornerRadius: Layout.tabCornerRadius)
                         .fill(isSelected && !autoMetricMode ? Self.selectedFill : isHovered ? ThemeColors.hoverFill : .clear)
-                        .shadow(color: isSelected && !autoMetricMode ? Color.black.opacity(ThemeColors.shadowOpacity) : .clear, radius: Layout.shadowSmall, y: 0.5)
+                        .shadow(color: isSelected && !autoMetricMode ? ThemeColors.shadowColor.opacity(ThemeColors.shadowOpacity) : .clear, radius: Layout.shadowSmall, y: 0.5)
                 )
                 .contentShape(RoundedRectangle(cornerRadius: Layout.tabCornerRadius))
         }
@@ -90,7 +90,7 @@ struct MetricToggleView: View {
                 )
                 .overlay(
                     Circle()
-                        .stroke(autoMetricMode ? ThemeColors.action.opacity(ThemeColors.activeAccentOpacity) : autoHovered ? Color.secondary.opacity(ThemeColors.hoverBorderOpacity) : Color.secondary.opacity(ThemeColors.subtleBorderOpacity), lineWidth: Layout.borderWidth)
+                        .stroke(autoMetricMode ? ThemeColors.action.opacity(ThemeColors.activeAccentOpacity) : autoHovered ? ThemeColors.inactiveStroke.opacity(ThemeColors.hoverBorderOpacity) : ThemeColors.inactiveStroke.opacity(ThemeColors.subtleBorderOpacity), lineWidth: Layout.borderWidth)
                 )
                 .shadow(color: autoMetricMode ? ThemeColors.action.opacity(ThemeColors.activeLabelOpacity) : .clear, radius: Layout.glowRadius)
                 .contentShape(Circle())

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -38,10 +38,7 @@ struct PopoverFooterView: View {
                         NSWorkspace.shared.open(url)
                     }
                 } leading: {
-                    Circle()
-                        .fill(statusColor)
-                        .frame(width: Layout.dotSizeSmall, height: Layout.dotSizeSmall)
-                        .accessibilityLabel(statusTooltip)
+                    statusDot
                 }
 
                 Spacer()
@@ -143,6 +140,33 @@ struct PopoverFooterView: View {
     private var statusColor: Color {
         guard let indicator = systemIndicator else { return .gray }
         return ThemeColors.statusColor(indicator)
+    }
+
+    /// Shape carrying the status color plus, for non-operational states, an
+    /// inset SF Symbol so the severity is distinguishable without color.
+    /// Operational and unknown stay plain dots — they're the visual default.
+    @ViewBuilder
+    private var statusDot: some View {
+        ZStack {
+            Circle()
+                .fill(statusColor)
+                .frame(width: Layout.dotSizeSmall, height: Layout.dotSizeSmall)
+            if let symbol = statusSymbol {
+                Image(systemName: symbol)
+                    .font(.system(size: Layout.dotSizeSmall * 0.72, weight: .bold))
+                    .foregroundStyle(Color.white)
+            }
+        }
+        .accessibilityLabel(statusTooltip)
+    }
+
+    private var statusSymbol: String? {
+        switch systemIndicator {
+        case .degradedPerformance: "exclamationmark"
+        case .partialOutage, .majorOutage: "xmark"
+        case .maintenance: "wrench.adjustable"
+        case .operational, .unknown, .none: nil
+        }
     }
 
     static func relativeTime(_ date: Date) -> String {

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -129,7 +129,6 @@ struct PopoverFooterView: View {
     /// Shape carrying the status color plus, for non-operational states, an
     /// inset SF Symbol so the severity is distinguishable without color.
     /// Operational and unknown stay plain dots — they're the visual default.
-    @ViewBuilder
     private var statusDot: some View {
         ZStack {
             Circle()

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -10,9 +10,6 @@ struct PopoverFooterView: View {
     @Binding var showLogoutConfirm: Bool
     let onLogout: () -> Void
     let onRequestLogout: () -> Void
-    @State private var logoutHovered = false
-    @State private var quitHovered = false
-
     var body: some View {
         VStack(spacing: Spacing.gap) {
             // Links row
@@ -44,47 +41,34 @@ struct PopoverFooterView: View {
                 Spacer()
 
                 // Logout (active account) — two-tap confirmation
-                Button(action: {
-                    if showLogoutConfirm {
-                        onLogout()
-                    } else {
-                        onRequestLogout()
+                FooterLink(
+                    icon: showLogoutConfirm ? "exclamationmark.triangle" : "rectangle.portrait.and.arrow.right",
+                    label: showLogoutConfirm ? "Confirm?" : "Logout",
+                    accessibilityLabel: showLogoutConfirm ? "Confirm logout" : "Logout",
+                    accessibilityHint: "Sign out of active Claude account",
+                    showsExternalArrow: false,
+                    foregroundOverride: showLogoutConfirm ? ThemeColors.danger : nil,
+                    action: {
+                        if showLogoutConfirm {
+                            onLogout()
+                        } else {
+                            onRequestLogout()
+                        }
                     }
-                }) {
-                    HStack(spacing: Spacing.tight) {
-                        Image(systemName: showLogoutConfirm ? "exclamationmark.triangle" : "rectangle.portrait.and.arrow.right")
-                            .font(Typography.monoTiny)
-                        Text(showLogoutConfirm ? "Confirm?" : "Logout")
-                            .font(Typography.tinyLabel)
-                            .underline(logoutHovered)
-                    }
-                    .fixedSize()
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(showLogoutConfirm ? ThemeColors.danger : .secondary)
-                .onHover { logoutHovered = $0 }
+                )
                 .animation(MotionConstants.snappy, value: showLogoutConfirm)
-                .accessibilityLabel(showLogoutConfirm ? "Confirm logout" : "Logout")
-                .accessibilityHint("Sign out of active Claude account")
 
                 // Quit
-                Button(action: {
-                    NSApplication.shared.terminate(nil)
-                }) {
-                    HStack(spacing: Spacing.tight) {
-                        Image(systemName: "xmark.circle")
-                            .font(Typography.monoTiny)
-                        Text("Quit")
-                            .font(Typography.tinyLabel)
-                            .underline(quitHovered)
-                    }
-                    .fixedSize()
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(ThemeColors.secondaryLabel)
-                .onHover { quitHovered = $0 }
-                .help("Quit (⌘Q)")
-                .accessibilityLabel("Quit AI Battery")
+                FooterLink(
+                    icon: "xmark.circle",
+                    label: "Quit",
+                    tooltip: "Quit (⌘Q)",
+                    accessibilityLabel: "Quit AI Battery",
+                    accessibilityHint: "Quit application",
+                    showsExternalArrow: false,
+                    foregroundOverride: ThemeColors.secondaryLabel,
+                    action: { NSApplication.shared.terminate(nil) }
+                )
             }
 
             // Active incident banner replaces timestamp when visible

--- a/AIBattery/Views/PopoverFooterView.swift
+++ b/AIBattery/Views/PopoverFooterView.swift
@@ -145,7 +145,14 @@ struct PopoverFooterView: View {
     }
 
     private var statusSymbol: String? {
-        switch systemIndicator {
+        Self.statusSymbol(for: systemIndicator)
+    }
+
+    /// Map a status indicator to the SF Symbol overlaid inside the footer dot.
+    /// Pure function — extracted so tests can pin the mapping without
+    /// constructing a full SwiftUI view.
+    static func statusSymbol(for indicator: StatusIndicator?) -> String? {
+        switch indicator {
         case .degradedPerformance: "exclamationmark"
         case .partialOutage, .majorOutage: "xmark"
         case .maintenance: "wrench.adjustable"

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -182,12 +182,16 @@ struct PopoverHeaderView: View {
                             .foregroundStyle(ThemeColors.action)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Download the latest release")
+                    .accessibilityHint("Opens the GitHub release page in your browser")
                     Button(action: { SparkleUpdateService.shared.clearError() }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(Typography.monoTiny)
                             .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Dismiss update error")
+                    .accessibilityHint("Hides the update-failed banner")
                 }
                 .help(sparkleError)
                 .transition(.opacity)

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -133,12 +133,13 @@ struct PopoverHeaderView: View {
                     Spacer()
                     Button(action: { updateBannerDismissed = true }) {
                         Image(systemName: "xmark.circle.fill")
-                            .font(Typography.heroTitle)
+                            .font(Typography.bodyLabel)
                             .foregroundStyle(ThemeColors.secondaryLabel)
                     }
                     .buttonStyle(.plain)
                     .help("Dismiss")
                     .accessibilityLabel("Dismiss update banner")
+                    .accessibilityHint("Hides the available-update banner")
                 }
                 .padding(Spacing.section)
                 .background(

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -107,7 +107,12 @@ struct PopoverHeaderView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Version \(update.version) release notes")
-                    Button(action: {
+                    LinkActionButton(
+                        label: "Install Update",
+                        icon: "arrow.down.circle",
+                        size: .compact,
+                        accessibilityLabel: "Install update version \(update.version)"
+                    ) {
                         #if ENABLE_SPARKLE
                         if SparkleUpdateService.shared.canCheckForUpdates {
                             SparkleUpdateService.shared.checkForUpdates()
@@ -119,17 +124,7 @@ struct PopoverHeaderView: View {
                             NSWorkspace.shared.open(url)
                         }
                         #endif
-                    }) {
-                        HStack(spacing: Spacing.xsmall) {
-                            Image(systemName: "arrow.down.circle")
-                                .font(Typography.monoTiny)
-                            Text("Install Update")
-                                .font(Typography.tinyLabel)
-                        }
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(ThemeColors.action)
-                    .accessibilityLabel("Install update version \(update.version)")
                     Spacer()
                     Button(action: { updateBannerDismissed = true }) {
                         Image(systemName: "xmark.circle.fill")
@@ -173,18 +168,16 @@ struct PopoverHeaderView: View {
                         .font(Typography.tinyLabel)
                         .foregroundStyle(ThemeColors.secondaryLabel)
                     Spacer()
-                    Button(action: {
+                    LinkActionButton(
+                        label: "Download",
+                        size: .compact,
+                        accessibilityLabel: "Download the latest release",
+                        accessibilityHint: "Opens the GitHub release page in your browser"
+                    ) {
                         if let url = URL(string: "https://github.com/KyleNesium/AIBattery/releases/latest") {
                             NSWorkspace.shared.open(url)
                         }
-                    }) {
-                        Text("Download")
-                            .font(Typography.tinyLabel)
-                            .foregroundStyle(ThemeColors.action)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Download the latest release")
-                    .accessibilityHint("Opens the GitHub release page in your browser")
                     Button(action: { SparkleUpdateService.shared.clearError() }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(Typography.monoTiny)

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -19,7 +19,7 @@ struct PopoverHeaderView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.inner) {
-            HStack(alignment: .firstTextBaseline, spacing: Spacing.inner) {
+            HStack(alignment: .center, spacing: Spacing.inner) {
                 Image(systemName: "sparkle")
                     .font(Typography.heroValue)
                     .foregroundStyle(.primary)

--- a/AIBattery/Views/PopoverHeaderView.swift
+++ b/AIBattery/Views/PopoverHeaderView.swift
@@ -67,6 +67,7 @@ struct PopoverHeaderView: View {
                 .onHover { updateHovered = $0 }
                 .help(availableUpdate.map { "v\($0.version) available" } ?? "Check for updates")
                 .accessibilityLabel(availableUpdate.map { "Version \($0.version) available" } ?? "Check for updates")
+                .accessibilityHint(availableUpdate != nil ? "Reopens the update banner" : "Checks for a newer release")
                 #else
                 Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0")")
                     .font(Typography.monoTiny)
@@ -107,11 +108,13 @@ struct PopoverHeaderView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Version \(update.version) release notes")
+                    .accessibilityHint("Opens the release notes in your browser")
                     LinkActionButton(
                         label: "Install Update",
                         icon: "arrow.down.circle",
                         size: .compact,
-                        accessibilityLabel: "Install update version \(update.version)"
+                        accessibilityLabel: "Install update version \(update.version)",
+                        accessibilityHint: "Downloads and installs the update"
                     ) {
                         #if ENABLE_SPARKLE
                         if SparkleUpdateService.shared.canCheckForUpdates {

--- a/AIBattery/Views/ProjectUsageSection.swift
+++ b/AIBattery/Views/ProjectUsageSection.swift
@@ -132,6 +132,7 @@ struct ProjectUsageSection: View {
                 .foregroundStyle(ThemeColors.action)
                 .onHover { showMoreHovered = $0 }
                 .accessibilityLabel(showAll ? "Show fewer projects" : "Show more projects")
+                .accessibilityHint(showAll ? "Collapses to the top projects" : "Expands to show all projects")
             }
 
             Spacer()
@@ -152,6 +153,7 @@ struct ProjectUsageSection: View {
                 .onHover { sortHovered = $0 }
                 .help("Sort by \(sortMode.next.label) (click to cycle)")
                 .accessibilityLabel("Sort by \(sortMode.label)")
+                .accessibilityHint("Cycles the sort order")
             }
         }
     }
@@ -209,6 +211,7 @@ struct ProjectUsageSection: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear search")
+                .accessibilityHint("Clears the search field")
             }
         }
         .padding(.horizontal, Spacing.gap)

--- a/AIBattery/Views/Settings/AlertSettingsSection.swift
+++ b/AIBattery/Views/Settings/AlertSettingsSection.swift
@@ -27,14 +27,13 @@ struct AlertSettingsSection: View {
                     if on { NotificationManager.shared.requestPermission() }
                 }
             if alertStatus {
-                Button("Test") {
-                    NotificationManager.shared.testAlerts()
-                }
-                .buttonStyle(.plain)
-                .font(Typography.tinyLabel)
-                .foregroundStyle(ThemeColors.action)
-                .help("Send a test notification")
-                .accessibilityLabel("Test alerts")
+                LinkActionButton(
+                    label: "Test",
+                    size: .compact,
+                    help: "Send a test notification",
+                    accessibilityLabel: "Test alerts",
+                    action: { NotificationManager.shared.testAlerts() }
+                )
             }
         }
         if alertRateLimit {

--- a/AIBattery/Views/Settings/SettingsRow.swift
+++ b/AIBattery/Views/Settings/SettingsRow.swift
@@ -71,6 +71,7 @@ struct SettingsRow: View {
                 .buttonStyle(.plain)
                 .help("Remove this account")
                 .accessibilityLabel("Remove account \(index + 1)")
+                .accessibilityHint("Signs out and removes this account")
             }
         }
     }

--- a/AIBattery/Views/Settings/SettingsRow.swift
+++ b/AIBattery/Views/Settings/SettingsRow.swift
@@ -22,18 +22,13 @@ struct SettingsRow: View {
             if accountStore.canAddAccount {
                 HStack(spacing: Spacing.section) {
                     Spacer().frame(width: Layout.settingsLabel)
-                    Button(action: onAddAccount) {
-                        HStack(spacing: Spacing.xsmall) {
-                            Image(systemName: "plus.circle")
-                                .font(Typography.tinyLabel)
-                            Text("Add Account")
-                                .font(Typography.caption)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(ThemeColors.action)
-                    .accessibilityLabel("Add another Claude account")
-                    .help("Sign in with another Claude account")
+                    LinkActionButton(
+                        label: "Add Account",
+                        icon: "plus.circle",
+                        help: "Sign in with another Claude account",
+                        accessibilityLabel: "Add another Claude account",
+                        action: onAddAccount
+                    )
                 }
             }
 

--- a/AIBattery/Views/StandardLimitsSection.swift
+++ b/AIBattery/Views/StandardLimitsSection.swift
@@ -59,25 +59,29 @@ private struct StandardLimitBar: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.inner) {
-            HStack {
-                Text(label)
-                    .font(Typography.buttonLabel)
-                if isExhausted {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(Typography.tinyLabel)
-                        .foregroundStyle(ThemeColors.danger)
-                        .accessibilityHidden(true)
+        GaugeRow(
+            percent: percent,
+            barColor: ThemeColors.barColor(percent: percent),
+            accessibilityLabel: "\(label) rate limit usage \(Int(percent)) percent",
+            accessibilityValue: isExhausted ? "Limit reached" : "\(TokenFormatter.format(remaining)) remaining",
+            headerLeading: {
+                HStack(spacing: Spacing.inner) {
+                    Text(label)
+                        .font(Typography.buttonLabel)
+                    if isExhausted {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(Typography.tinyLabel)
+                            .foregroundStyle(ThemeColors.danger)
+                            .accessibilityHidden(true)
+                    }
                 }
-                Spacer()
+            },
+            headerTrailing: {
                 Text("\(TokenFormatter.format(remaining))/\(TokenFormatter.format(limit))")
                     .font(Typography.monoValue)
                     .copyable("\(remaining)/\(limit)")
-            }
-
-            GaugeBar(percent: percent, barColor: ThemeColors.barColor(percent: percent))
-
-            TimelineView(.periodic(from: .now, by: 10)) { context in
+            },
+            footer: { now in
                 HStack {
                     if isExhausted {
                         Text("Limit reached")
@@ -92,7 +96,7 @@ private struct StandardLimitBar: View {
                     Spacer()
 
                     if let reset = resetsAt {
-                        let diff = reset.timeIntervalSince(context.date)
+                        let diff = reset.timeIntervalSince(now)
                         if diff > 0 {
                             Text("Resets in \(DurationFormatter.compact(diff))")
                                 .font(Typography.tinyLabel)
@@ -101,6 +105,6 @@ private struct StandardLimitBar: View {
                     }
                 }
             }
-        }
+        )
     }
 }

--- a/AIBattery/Views/TokenHealthSection.swift
+++ b/AIBattery/Views/TokenHealthSection.swift
@@ -64,10 +64,7 @@ struct TokenHealthSection: View {
                     // Session info on its own line for full width
                     sessionInfoLabel
                         .id(selectedIndex)
-                        .transition(.asymmetric(
-                            insertion: .opacity.combined(with: .move(edge: .trailing)),
-                            removal: .opacity.combined(with: .move(edge: .leading))
-                        ))
+                        .transition(.opacity)
 
                     // Gauge bar
                     GaugeBar(percent: health.usagePercentage, barColor: bandColor)

--- a/AIBattery/Views/TokenHealthSection.swift
+++ b/AIBattery/Views/TokenHealthSection.swift
@@ -192,6 +192,7 @@ struct TokenHealthSection: View {
                 }
             }
             .accessibilityLabel("Previous session")
+            .accessibilityHint("Browses to the previous recent session")
 
             Text("\(selectedIndex + 1)/\(sessions.count)")
                 .font(Typography.monoCaptionSmall)
@@ -206,6 +207,7 @@ struct TokenHealthSection: View {
                 }
             }
             .accessibilityLabel("Next session")
+            .accessibilityHint("Browses to the next recent session")
         }
         .help("Browse recent sessions (← → arrow keys)")
         .accessibilityElement(children: .contain)

--- a/AIBattery/Views/TutorialOverlay.swift
+++ b/AIBattery/Views/TutorialOverlay.swift
@@ -34,7 +34,7 @@ struct TutorialOverlay: View {
     private var content: some View {
         ZStack {
             // Semi-transparent backdrop
-            Color.black.opacity(ThemeColors.overlayBackdropOpacity)
+            ThemeColors.shadowColor.opacity(ThemeColors.overlayBackdropOpacity)
                 .ignoresSafeArea()
 
             // Centered card
@@ -57,7 +57,7 @@ struct TutorialOverlay: View {
                 HStack(spacing: Spacing.gap) {
                     ForEach(0..<steps.count, id: \.self) { i in
                         Circle()
-                            .fill(i == step ? ThemeColors.action : Color.secondary.opacity(ThemeColors.inactiveIndicatorOpacity))
+                            .fill(i == step ? ThemeColors.action : ThemeColors.inactiveStroke.opacity(ThemeColors.inactiveIndicatorOpacity))
                             .frame(width: Layout.dotSizeSmall, height: Layout.dotSizeSmall)
                             .accessibilityHidden(true)
                     }

--- a/AIBattery/Views/UsageBarsSection.swift
+++ b/AIBattery/Views/UsageBarsSection.swift
@@ -74,8 +74,13 @@ struct UsageBar: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.inner) {
-            HStack {
+        GaugeRow(
+            percent: displayPercent,
+            barColor: ThemeColors.barColor(percent: displayPercent),
+            accessibilityLabel: "\(label) rate limit usage \(Int(displayPercent)) percent",
+            accessibilityValue: isThrottled ? "Rate limited" : "\(max(0, Int(100 - displayPercent))) percent remaining",
+            tickInterval: resetTickInterval,
+            headerLeading: {
                 HStack(spacing: Spacing.inner) {
                     Text(label)
                         .font(Typography.buttonLabel)
@@ -99,27 +104,22 @@ struct UsageBar: View {
                             .help("You are currently rate limited")
                     }
                 }
-                Spacer()
-                if tokenTotal > 0 {
-                    Text(TokenFormatter.format(tokenTotal))
-                        .font(Typography.monoCaption)
-                        .foregroundStyle(ThemeColors.tertiaryLabel)
-                        .frame(width: Layout.tokenColumn, alignment: .trailing)
-                        .copyable("\(tokenTotal) tokens")
+            },
+            headerTrailing: {
+                HStack(spacing: Spacing.inner) {
+                    if tokenTotal > 0 {
+                        Text(TokenFormatter.format(tokenTotal))
+                            .font(Typography.monoCaption)
+                            .foregroundStyle(ThemeColors.tertiaryLabel)
+                            .frame(width: Layout.tokenColumn, alignment: .trailing)
+                            .copyable("\(tokenTotal) tokens")
+                    }
+                    Text("\(Int(displayPercent))%")
+                        .font(Typography.monoValue)
+                        .copyable("\(Int(displayPercent))%")
                 }
-                Text("\(Int(displayPercent))%")
-                    .font(Typography.monoValue)
-                    .copyable("\(Int(displayPercent))%")
-            }
-
-            GaugeBar(percent: displayPercent, barColor: ThemeColors.barColor(percent: displayPercent))
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel("\(label) rate limit usage \(Int(displayPercent)) percent")
-                .accessibilityValue(isThrottled ? "Rate limited" : "\(max(0, Int(100 - displayPercent))) percent remaining")
-
-            // TimelineView ticks every second when reset is <60s away for live countdown.
-            TimelineView(.periodic(from: .now, by: resetTickInterval)) { context in
-                let now = context.date
+            },
+            footer: { now in
                 let resetDiff = resetsAt.map { $0.timeIntervalSince(now) }
                 let expired = (resetDiff ?? 1) <= 0
                 HStack {
@@ -176,8 +176,8 @@ struct UsageBar: View {
                         }
                     }
                 }
-            } // TimelineView
-        }
+            }
+        )
     }
 
     /// Tick every 1s when reset is <60s away (live countdown), otherwise every 10s.

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -148,6 +148,8 @@ public struct UsagePopoverView: View {
                         }
                         .buttonStyle(.plain)
                         .help("Anthropic removed usage headers from their API. Tap for details.")
+                        .accessibilityLabel("Why usage is estimated locally")
+                        .accessibilityHint("Opens an explanation in your browser")
                         Spacer()
                     }
                     .padding(.horizontal, Spacing.sectionHorizontal)

--- a/AIBattery/Views/UsagePopoverView.swift
+++ b/AIBattery/Views/UsagePopoverView.swift
@@ -121,7 +121,7 @@ public struct UsagePopoverView: View {
                     accountStore: accountStore,
                     onAddAccount: { isAddingAccount = true }
                 )
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .transition(.opacity)
                 // No StyledDivider here — the always-present divider above the footer
                 // already separates the settings stack from the footer row. Adding
                 // another here renders a doubled-up line at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [2.3.1] — 2026-05-17
+
+Popover polish sweep. Two visible bug-fixes, eight design-token /
+component refactors, ten accessibility wins, and the spec/code
+realignment that goes with it. No data-flow or auth changes.
+
+### Fixed
+- **Header alignment** — the account picker no longer sits visibly below "AI Battery". The header HStack used `.firstTextBaseline`, which baseline-aligned the larger title (`sectionHeader`) with the smaller picker (`caption`) and pushed the picker's visual center down. Switched to `.center`. (`PopoverHeaderView.swift`)
+- **Settings toggle no longer "jumps down"** — clicking the gear used to combine an `.opacity + .move(edge: .top)` transition with an NSPanel that re-anchors to the menu bar while resizing. The slide and the panel resize fought each other and the whole popover read as jumping. Switched `MotionConstants.expandTransition` (and the one direct call site) to plain `.opacity`. Same fix root-cause-applied to TokenHealthSection's session swap, which was using asymmetric `.move(edge: .trailing/.leading)`.
+- **Colorblind-safe status dot** — the footer status dot encoded operational/degraded/partial-outage/major-outage/maintenance with color only on a 6pt circle. Non-operational dots now overlay a small white SF Symbol so the severity is distinguishable without color (`exclamationmark`, `xmark`, `wrench.adjustable`). Operational and unknown stay plain dots.
+- **Update-banner dismiss icon size** — the xmark.circle.fill used `Typography.heroTitle`, making it optically larger than the sibling install-update and version icons. Dropped to `Typography.bodyLabel` to match the row.
+
+### Accessibility
+- VoiceOver labels added to icon-only buttons that previously read as a generic "button": local-estimate info button, Sparkle Download, Sparkle-error dismiss, update-check button, release-notes link, Install Update, project sort/clear-search, AuthView cancel buttons, TokenHealthSection prev/next session arrows, SettingsRow remove-account `x`, banner dismiss.
+- Hints added to every label that was missing one — VoiceOver now announces what activating the control will do, not just what the control is named.
+- LocalEstimateSection percent text now anchors with the metric name ("5-Hour usage 73 percent" instead of bare "73 percent").
+- InsightsTrendCostSection per-model rows now combine into a single VoiceOver element with active-state context; decorative throttle glyph hidden from a11y; active-model "▶" gets an explicit "Active model" label; copyText includes "active" suffix.
+
+### Design system
+- **Extracted `GaugeRow`** — `UsageBar` (5h/7d) and `StandardLimitBar` (per-minute fallback) shared the same VStack[Header HStack + GaugeBar + TimelineView footer] shape with subtle drift. Both now build on the same shell via `headerLeading` / `headerTrailing` / `footer` ViewBuilders.
+- **Extracted `LinkActionButton`** — four ad-hoc "small text-styled link button" implementations (Add Account / Test / Download / Install Update) collapsed into one component with `Size.standard` (settings) and `Size.compact` (in-banner) variants. Standardizes color, font, icon-to-label spacing, and a11y-label fallback.
+- **`FooterLink` carries Logout and Quit** — both buttons used to re-implement FooterLink's hover-underline pattern inline. `FooterLink` now accepts `showsExternalArrow` (false for inline actions) and `foregroundOverride` (state-driven coloring). Drops ~30 lines of duplicate styling and picks up `@FocusState` for free.
+- **`FooterLink` hover and focus unified** — previously, mouse users saw an underline-only signal and keyboard users saw a color-only signal. Both now produce both cues.
+- **New `ThemeColors` tokens** — `inactiveStroke` (= `.secondary`) for unselected/inactive outlines; `shadowColor` (= `.black`) for elevated-control shadows. Replaces raw color references in MetricToggleView, TutorialOverlay.
+- **`MotionConstants.expandTransition` documented** — token doc-comment now explains why `.move(edge:)` is banned inside the popover (NSPanel resize race), so the slide isn't re-added later.
+- **MarqueeText tokenized** — pause/hold/restart/fade-settle durations, scroll speed, and animation curve all moved out of inline literals into `MotionConstants.marquee*` tokens with a `marqueeScroll(travelPoints:)` builder. Default font and color flipped from raw `.caption2` / `.secondary` to `Typography.tinyLabel` / `ThemeColors.secondaryLabel`.
+- **`CollapsibleSectionHeader` focus ring via token** — `Color.accentColor` → `ThemeColors.action`.
+- **`AuthView` tint via token** — `.tint(.accentColor)` → `.tint(ThemeColors.action)` on both `.borderedProminent` CTAs.
+
+### Spec
+- `spec/ARCHITECTURE.md`, `spec/UI_SPEC.md`, `spec/CONSTANTS.md` updated to match the new component list, ThemeColors tokens, MotionConstants tokens, header alignment, session-swap transition, FooterLink contract, and status-dot SF Symbol overlay.
+
 ## [2.3.0] — 2026-05-16
 
 ### Tooling

--- a/Tests/AIBatteryCoreTests/Utilities/SpacingTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/SpacingTests.swift
@@ -71,4 +71,71 @@ struct MotionConstantsTests {
         let anim = MotionConstants.snappy
         #expect(anim == .easeOut(duration: 0.1))
     }
+
+    @Test func fadeIn_isDefined() {
+        // fadeIn was added during the v2.3.1 polish sprint (MarqueeText
+        // cycling) — pin its shape so the cross-fade timing doesn't drift.
+        let anim = MotionConstants.fadeIn
+        #expect(anim == .easeIn(duration: 0.3))
+    }
+
+    @Test func fadeOut_matchesFadeIn() {
+        // fadeIn/fadeOut should remain symmetric — same duration, mirrored curves.
+        // Lets MarqueeText's "fade out → 0.35s settle → fade in" choreography stay tunable.
+        #expect(MotionConstants.fadeOut == .easeOut(duration: 0.3))
+        #expect(MotionConstants.fadeIn == .easeIn(duration: 0.3))
+    }
+
+    // MARK: - expandTransition: opacity-only contract
+
+    @Test func expandTransition_isPlainOpacity_notMove() {
+        // Regression pin for v2.3.1: the popover is an NSPanel that re-anchors
+        // its top to the menu bar while resizing. A .move transition translates
+        // the inserting view in the opposite direction of the panel resize and
+        // reads as a "jump". expandTransition MUST stay .opacity-only.
+        //
+        // AnyTransition has no public structural API, but it's a value type and
+        // .opacity has a stable equality footprint. We compare against a fresh
+        // .opacity, which historically diff-equates in SwiftUI's internals.
+        // If a future change recombines .move into the token, the snapshot
+        // string below will diverge.
+        let lhs = String(reflecting: MotionConstants.expandTransition)
+        let rhs = String(reflecting: AnyTransition.opacity)
+        #expect(lhs == rhs, "expandTransition diverged from plain .opacity — did someone recombine .move(edge:)? See token doc-comment.")
+    }
+
+    // MARK: - Marquee timing tokens
+
+    @Test func marqueePauseSeconds_is0_5() {
+        #expect(MotionConstants.marqueePauseSeconds == 0.5)
+    }
+
+    @Test func marqueeHoldSeconds_is3_0() {
+        #expect(MotionConstants.marqueeHoldSeconds == 3.0)
+    }
+
+    @Test func marqueeRestartSeconds_is0_1() {
+        #expect(MotionConstants.marqueeRestartSeconds == 0.1)
+    }
+
+    @Test func marqueeFadeSettleSeconds_is0_6() {
+        #expect(MotionConstants.marqueeFadeSettleSeconds == 0.6)
+    }
+
+    @Test func marqueeScrollSpeed_is30() {
+        #expect(MotionConstants.marqueeScrollSpeed == 30.0)
+    }
+
+    @Test func marqueeScroll_durationIsTravelOverSpeed() {
+        // 30 pts/s scroll speed × 60-pt travel = 2s linear animation.
+        let anim = MotionConstants.marqueeScroll(travelPoints: 60)
+        #expect(anim == .linear(duration: 2.0))
+    }
+
+    @Test func marqueeScroll_zeroTravelClampsToZero() {
+        // Guard the max(0,...) in the builder — negative travel from layout
+        // race conditions should never produce a negative duration.
+        let anim = MotionConstants.marqueeScroll(travelPoints: -10)
+        #expect(anim == .linear(duration: 0.0))
+    }
 }

--- a/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/ThemeColorsTests.swift
@@ -236,4 +236,20 @@ struct ThemeColorsTests {
         #expect(green == .systemGreen)
         #expect(red == .systemRed)
     }
+
+    // MARK: - v2.3.1 semantic-stroke tokens
+
+    @Test func inactiveStroke_isSecondary() {
+        // Pin: ThemeColors.inactiveStroke must resolve to .secondary so that
+        // MetricToggleView's unselected ring and TutorialOverlay's inactive
+        // step dots stay tied to system secondary tinting.
+        #expect(ThemeColors.inactiveStroke == .secondary)
+    }
+
+    @Test func shadowColor_isBlack() {
+        // Pin: ThemeColors.shadowColor must stay .black — MetricToggleView's
+        // selected-tab shadow and TutorialOverlay's backdrop both opacity-mix
+        // off this token, and the visual result is calibrated against pure black.
+        #expect(ThemeColors.shadowColor == .black)
+    }
 }

--- a/Tests/AIBatteryCoreTests/Views/LinkActionButtonTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/LinkActionButtonTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import SwiftUI
+@testable import AIBatteryCore
+
+/// Pins the v2.3.1 LinkActionButton size-variant typography contract.
+///
+/// Four ad-hoc inline-action button implementations across the popover were
+/// collapsed onto this component. The Size variants encode the visual scale
+/// that each context expects:
+///
+///   - `.standard` is for settings rows (Add Account): caption text + tinyLabel icon
+///   - `.compact`  is for in-banner actions (Test / Download / Install Update):
+///                 tinyLabel text + monoTiny icon
+///
+/// If a future change flips these mappings, the four call sites will silently
+/// drift in opposite directions — these tests fail loudly instead.
+@Suite("LinkActionButton")
+struct LinkActionButtonTests {
+    @Test func standard_labelFont_isCaption() {
+        #expect(LinkActionButton.labelFont(for: .standard) == Typography.caption)
+    }
+
+    @Test func standard_iconFont_isTinyLabel() {
+        #expect(LinkActionButton.iconFont(for: .standard) == Typography.tinyLabel)
+    }
+
+    @Test func compact_labelFont_isTinyLabel() {
+        #expect(LinkActionButton.labelFont(for: .compact) == Typography.tinyLabel)
+    }
+
+    @Test func compact_iconFont_isMonoTiny() {
+        #expect(LinkActionButton.iconFont(for: .compact) == Typography.monoTiny)
+    }
+
+    @Test func compact_textIsSmallerThanStandard() {
+        // Variants must scale in the same direction — compact text must not
+        // accidentally become the same size as standard, or larger.
+        let standardLabel = LinkActionButton.labelFont(for: .standard)
+        let compactLabel = LinkActionButton.labelFont(for: .compact)
+        #expect(standardLabel != compactLabel,
+                "compact and standard must use distinct label fonts")
+    }
+}

--- a/Tests/AIBatteryCoreTests/Views/MoveTransitionBanTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/MoveTransitionBanTests.swift
@@ -22,10 +22,10 @@ struct MoveTransitionBanTests {
     private static var viewsDirectory: URL {
         let testFile = URL(fileURLWithPath: #filePath)
         return testFile
-            .deletingLastPathComponent()   // Views/
-            .deletingLastPathComponent()   // AIBatteryCoreTests/
-            .deletingLastPathComponent()   // Tests/
-            .deletingLastPathComponent()   // package root
+            .deletingLastPathComponent() // Views/
+            .deletingLastPathComponent() // AIBatteryCoreTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // package root
             .appendingPathComponent("AIBattery")
             .appendingPathComponent("Views")
     }
@@ -36,7 +36,7 @@ struct MoveTransitionBanTests {
     /// doesn't trigger the NSPanel resize race.
     private static let allowList: Set<String> = []
 
-    @Test func noViewFile_usesMoveEdgeTransition() throws {
+    @Test func noViewFile_usesMoveEdgeTransition() {
         let fm = FileManager.default
         let viewsDir = Self.viewsDirectory.path
 

--- a/Tests/AIBatteryCoreTests/Views/MoveTransitionBanTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/MoveTransitionBanTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+
+/// Pins the v2.3.1 "no `.move(edge:)` inside the popover" rule.
+///
+/// The popover is an NSPanel whose top edge is re-anchored to the menu bar
+/// button on every height change. A `.move(edge:)` transition translates the
+/// inserting/removing view in roughly the same direction the panel itself is
+/// moving, and the two motions fight each other — the user reads it as a
+/// "jump". Fixed in v2.3.1 by switching every site to `.opacity` and locking
+/// `MotionConstants.expandTransition` to plain `.opacity` with a doc-comment
+/// banning the regression.
+///
+/// This test walks the actual `AIBattery/Views/` source tree and fails if any
+/// view file reintroduces `.move(edge:`. New views can opt-in by editing the
+/// allow list below with an explicit rationale.
+@Suite("MoveTransitionBan")
+struct MoveTransitionBanTests {
+    /// Absolute path to the source tree we're auditing. Tests run from the
+    /// package root (`swift test` working directory), so we can derive it from
+    /// the current file. `#filePath` is the canonical path of this test source.
+    private static var viewsDirectory: URL {
+        let testFile = URL(fileURLWithPath: #filePath)
+        return testFile
+            .deletingLastPathComponent()   // Views/
+            .deletingLastPathComponent()   // AIBatteryCoreTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // package root
+            .appendingPathComponent("AIBattery")
+            .appendingPathComponent("Views")
+    }
+
+    /// Relative paths inside Views/ that are explicitly allowed to use
+    /// `.move(edge:)`. Empty by design — add an entry with a comment if a
+    /// future feature genuinely needs the slide AND has demonstrated it
+    /// doesn't trigger the NSPanel resize race.
+    private static let allowList: Set<String> = []
+
+    @Test func noViewFile_usesMoveEdgeTransition() throws {
+        let fm = FileManager.default
+        let viewsDir = Self.viewsDirectory.path
+
+        guard fm.fileExists(atPath: viewsDir) else {
+            Issue.record("Views/ directory not found at \(viewsDir); test path resolution drifted")
+            return
+        }
+
+        let enumerator = fm.enumerator(atPath: viewsDir)
+        var offenders: [String] = []
+
+        while let relativePath = enumerator?.nextObject() as? String {
+            guard relativePath.hasSuffix(".swift") else { continue }
+            if Self.allowList.contains(relativePath) { continue }
+
+            let fullPath = (viewsDir as NSString).appendingPathComponent(relativePath)
+            guard let contents = try? String(contentsOfFile: fullPath, encoding: .utf8) else {
+                continue
+            }
+
+            // Match `.move(edge:` even with whitespace variations. The pattern
+            // is intentionally permissive — any literal use anywhere in the
+            // file triggers, including inside comments. If you really need to
+            // discuss .move in a comment, rephrase or move it to a Markdown
+            // doc.
+            if contents.contains(".move(edge:") {
+                offenders.append(relativePath)
+            }
+        }
+
+        #expect(offenders.isEmpty, """
+        Views/ files reintroduced `.move(edge:)`. The popover's NSPanel resizes \
+        around inserting views and any directional translate reads as a "jump". \
+        Use `.transition(.opacity)` or `MotionConstants.expandTransition`. \
+        If your case is a deliberate exception, document why and add the path \
+        to MoveTransitionBanTests.allowList.
+
+        Offending files: \(offenders.joined(separator: ", "))
+        """)
+    }
+}

--- a/Tests/AIBatteryCoreTests/Views/PopoverFooterStatusSymbolTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/PopoverFooterStatusSymbolTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import AIBatteryCore
+
+/// Pins the v2.3.1 colorblind-safe status-dot mapping. Each non-operational
+/// state must carry a distinguishing SF Symbol overlay so severity is readable
+/// without color. Operational and unknown stay plain.
+@Suite("PopoverFooterStatusSymbol")
+struct PopoverFooterStatusSymbolTests {
+    @Test func operational_hasNoSymbol() {
+        #expect(PopoverFooterView.statusSymbol(for: .operational) == nil)
+    }
+
+    @Test func unknown_hasNoSymbol() {
+        #expect(PopoverFooterView.statusSymbol(for: .unknown) == nil)
+    }
+
+    @Test func nilIndicator_hasNoSymbol() {
+        // Loading / first-paint state — no overlay either.
+        #expect(PopoverFooterView.statusSymbol(for: nil) == nil)
+    }
+
+    @Test func degradedPerformance_isExclamationmark() {
+        #expect(PopoverFooterView.statusSymbol(for: .degradedPerformance) == "exclamationmark")
+    }
+
+    @Test func partialOutage_isXmark() {
+        #expect(PopoverFooterView.statusSymbol(for: .partialOutage) == "xmark")
+    }
+
+    @Test func majorOutage_isXmark() {
+        // Partial and major outage share the xmark glyph — color (orange vs red)
+        // distinguishes them, and the symbol carries the "down" semantic.
+        #expect(PopoverFooterView.statusSymbol(for: .majorOutage) == "xmark")
+    }
+
+    @Test func maintenance_isWrench() {
+        #expect(PopoverFooterView.statusSymbol(for: .maintenance) == "wrench.adjustable")
+    }
+
+    @Test func everyNonOperationalIndicator_yieldsSymbol() {
+        // Belt-and-suspenders: any future StatusIndicator case that's added and
+        // intended to surface in the popover should also map to a symbol; if a
+        // new case slips in without a mapping, this test catches it via the
+        // default-nil branch.
+        let nonOperational: [StatusIndicator] = [
+            .degradedPerformance, .partialOutage, .majorOutage, .maintenance,
+        ]
+        for state in nonOperational {
+            #expect(PopoverFooterView.statusSymbol(for: state) != nil,
+                    "\(state) should overlay a symbol so it reads without color")
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "2.3.0"
-        CURRENT_PROJECT_VERSION: "2.3.0"
+        MARKETING_VERSION: "2.3.1"
+        CURRENT_PROJECT_VERSION: "2.3.1"
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -123,6 +123,8 @@ AIBattery/
     TutorialOverlay.swift         — First-launch 3-step walkthrough overlay
     Components/
       GaugeBar.swift              — Reusable progress gauge bar (single GeometryReader, clamps percent 0–100, uses Layout + ThemeColors)
+      GaugeRow.swift              — Shared "labelled gauge row" shell: VStack[Header HStack + GaugeBar + TimelineView footer]. Accepts headerLeading / headerTrailing / footer ViewBuilders. Owns accessibility wiring and timeline schedule. Backs UsageBar (5h/7d) and StandardLimitBar.
+      LinkActionButton.swift      — Inline link-styled action button (Size.standard for settings, .compact for in-banner). One canonical implementation for Add Account, Test, Download, Install Update — all routed through ThemeColors.action with consistent icon/label spacing.
     UsageBarsSection.swift        — FiveHourBarSection + SevenDayBarSection rate limit bars
     LocalEstimateSection.swift    — Local token estimate display when unified headers unavailable
     StandardLimitsSection.swift   — Standard per-model API rate limit display (fallback)

--- a/spec/CONSTANTS.md
+++ b/spec/CONSTANTS.md
@@ -286,7 +286,7 @@ See also: Design Tokens section for the Swift enum constants (`MotionConstants.s
 | Constant | Value |
 |----------|-------|
 | Settings toggle | `.easeOut(duration: 0.15)` — `MotionConstants.standard` |
-| Settings transition | `.opacity.combined(with: .move(edge: .top))` |
+| Settings / collapsible expand transition | `.opacity` — plain cross-fade. `.move(edge:)` is banned in the popover; the NSPanel resizes around the inserting view and the slide reads as a "jump". |
 | Metric mode change | `.easeOut(duration: 0.1)` — `MotionConstants.snappy` |
 | Account switch | `.easeOut(duration: 0.15)` — `MotionConstants.standard` |
 | Copy clipboard icon display | 1.2 seconds, `.easeOut(duration: 0.12)` show / `.easeIn(duration: 0.2)` hide |
@@ -374,7 +374,17 @@ Canonical Swift constants backing the numeric values in the tables above. Define
 | `MotionConstants.standard` | `.easeOut(duration: 0.15)` | Standard section expand/collapse, settings toggle, account switch |
 | `MotionConstants.snappy` | `.easeOut(duration: 0.1)` | Session navigation, metric mode change |
 | `MotionConstants.smooth` | `.easeInOut(duration: 0.4)` | Gauge bar fill, chart transitions |
-| `MotionConstants.expandTransition` | `.opacity + .move(edge: .top)` | Section expand/collapse content transition |
+| `MotionConstants.expandTransition` | `.opacity` (plain cross-fade) | Section / settings expand-collapse content transition. `.move(edge:)` is banned inside the popover — see token doc-comment for the NSPanel resize-race rationale. |
+| `MotionConstants.fadeIn` | `.easeIn(duration: 0.3)` | Marquee text fade-in, generic incoming-content fade |
+| `MotionConstants.marqueePauseSeconds` | `0.5` seconds | Pause at each end of a marquee scroll; also initial geometry-settle delay |
+| `MotionConstants.marqueeHoldSeconds` | `3.0` seconds | Hold a non-scrolling marquee text before cycling to the next |
+| `MotionConstants.marqueeRestartSeconds` | `0.1` seconds | Delay after `texts` array changes before restarting cycle |
+| `MotionConstants.marqueeFadeSettleSeconds` | `0.6` seconds | Settle delay after fade-in before starting next scroll |
+| `MotionConstants.marqueeScrollSpeed` | `30.0` points/second | Horizontal scroll speed for marquee text |
+| `MotionConstants.marqueeScroll(travelPoints:)` | `.linear(duration: travelPoints / marqueeScrollSpeed)` | Builder for the marquee scroll animation |
+| `MotionConstants.clipboardFeedbackNs` | `1_500_000_000` (state timing, non-animation) | Clipboard "copied" feedback icon display duration |
+| `MotionConstants.logoutConfirmNs` | `3_000_000_000` (state timing, non-animation) | Logout confirmation auto-revert timeout |
+| `MotionConstants.updateCheckMessageNs` | `2_500_000_000` (state timing, non-animation) | Update check "Up to date" message display duration |
 
 ## Security Guards
 

--- a/spec/QA-v2.3.1.md
+++ b/spec/QA-v2.3.1.md
@@ -1,0 +1,228 @@
+# v2.3.1 — Manual QA Checklist
+
+A deliberate manual walkthrough of every popover state touched by the v2.3.1
+polish sprint. Run before tagging. Anything that fails blocks the release.
+
+**Build to test:** `.build/AIBattery.app` produced by `./scripts/build-app.sh`
+on `fix/popover-polish-v2.3.1`.
+
+**Setup:**
+
+```bash
+pkill -f "AIBattery.app" 2>/dev/null
+SPARKLE_EDDSA_PUBLIC_KEY="6OMshMFo6tpWjrJHcDa1xKK4N0xqgT+gery+xnGJrOU=" ./scripts/build-app.sh
+open .build/AIBattery.app
+```
+
+> Tester records pass/fail/notes inline. Anything not pass = blocker until
+> resolved or explicitly waived.
+
+---
+
+## 1. Header row — alignment + content
+
+Click the menu-bar icon. Look at the top row of the popover.
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 1.1 | Title alignment | "AI Battery" baseline ≈ visual center of "User N" picker. Picker is NOT visibly lower than title. | |
+| 1.2 | Version | `vX.Y.Z` text reads `v2.3.1` |  |
+| 1.3 | Update-check icon | Sits at same visual height as gear icon |  |
+| 1.4 | Gear icon | Visually centered with title row |  |
+| 1.5 | Hover gear | Hovering brightens gear from .secondary → .primary |  |
+| 1.6 | Click gear | Settings panel cross-fades in (no slide-down, no jump) |  |
+| 1.7 | Click gear again | Settings cross-fades out, popover height changes smoothly |  |
+
+## 2. Settings panel
+
+Open settings (click gear).
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 2.1 | "Add Account" link | Renders with plus.circle icon at `Typography.tinyLabel` size, text at `Typography.caption`, ThemeColors.action blue. Identical visual to before. |  |
+| 2.2 | Click "Add Account" | AuthView slides in (this is intentional cross-view, not cross-fade) |  |
+| 2.3 | AuthView "Sign in" CTA | Uses `ThemeColors.action` tint (not generic `.accentColor` — should match Add Account blue exactly) |  |
+| 2.4 | AuthView cancel | Cancel button works, returns to popover with settings still open |  |
+| 2.5 | Refresh slider | Slider still labelled, ticks every 30s/1m/2m/3m/4m/5m |  |
+| 2.6 | Hide-idle slider | Six positions: 30m, 1h, 2h, 4h, 8h, ∞ |  |
+| 2.7 | "Test" alert button | Renders as a LinkActionButton compact (tinyLabel + action color, no icon) |  |
+| 2.8 | Tab between settings controls | Each focusable control receives a visible focus ring (CollapsibleSectionHeader sites at minimum) |  |
+
+## 3. Account picker
+
+With ≥1 account configured, click the picker label.
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 3.1 | Menu opens | Each account row shows display name or "Account N" + checkmark on active |  |
+| 3.2 | Switch account | Picker label updates, snapshot refreshes |  |
+| 3.3 | "Add Account" menu item | Visible when canAddAccount; triggers AuthView |  |
+| 3.4 | VoiceOver picker | Reads "Switch account, Select which Claude account to display" (no missing hint) |  |
+
+## 4. Update banner (only verifiable if an update is published)
+
+If `viewModel.availableUpdate` is non-nil:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 4.1 | Banner cross-fades in | Pure opacity, no slide |  |
+| 4.2 | "Install Update" button | LinkActionButton compact style with arrow.down.circle icon |  |
+| 4.3 | "Download" button | LinkActionButton compact style, no icon |  |
+| 4.4 | Dismiss x | xmark.circle.fill at `Typography.bodyLabel` size — NOT visibly larger than sibling icons |  |
+| 4.5 | Click dismiss | Banner cross-fades out (no jump) |  |
+| 4.6 | Click update-check icon (top right) | Banner re-shows by cross-fade |  |
+| 4.7 | VoiceOver Install Update | Reads "Install update version X.Y.Z, Downloads and installs the update" |  |
+
+## 5. Usage / rate-limit sections
+
+In default state (5h selected):
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 5.1 | 5h gauge renders | Bar fills proportionally, percent text on right |  |
+| 5.2 | Reset countdown ticks | "Resets in Xm Ys" updates every 10s, or every 1s if <60s away |  |
+| 5.3 | Switch to 7d | Cross-fade only, no slide; new gauge renders |  |
+| 5.4 | Switch to Context Health | Cross-fade only |  |
+| 5.5 | Auto-mode toggle | "A" button transitions to/from active state; ring color matches |  |
+
+## 6. Context Health — session navigation
+
+With ≥2 sessions visible:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 6.1 | Click right chevron | Session info cross-fades to next session (NO horizontal slide) |  |
+| 6.2 | Click left chevron | Cross-fades back (NO slide) |  |
+| 6.3 | Swipe right on row | Drag gesture navigates same way as chevron |  |
+| 6.4 | Last session | Right chevron disabled |  |
+| 6.5 | First session | Left chevron disabled |  |
+| 6.6 | VoiceOver prev/next | Each reads label + hint (e.g. "Previous session, Browses to the previous recent session") |  |
+
+## 7. Footer
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 7.1 | Status dot — operational | Plain green circle, no glyph inside |  |
+| 7.2 | Status dot — degraded | Yellow circle with white "!" SF Symbol inside |  |
+| 7.3 | Status dot — partial outage | Orange circle with white "x" inside |  |
+| 7.4 | Status dot — major outage | Red circle with white "x" inside |  |
+| 7.5 | Status dot — maintenance | Blue circle with white wrench glyph inside |  |
+| 7.6 | Usage link hover | Underline appears AND text brightens (.secondary → .primary) |  |
+| 7.7 | Usage link focus (Tab key) | Same dual signal as hover |  |
+| 7.8 | Status link hover/focus | Same dual signal |  |
+| 7.9 | Logout idle | "Logout" in .secondary |  |
+| 7.10 | Click Logout once | Text becomes "Confirm?" in ThemeColors.danger red |  |
+| 7.11 | Wait 3s after first click | Reverts to "Logout" automatically |  |
+| 7.12 | Click Logout twice within 3s | Signs out active account |  |
+| 7.13 | Logout hover | Underline + slightly brighter |  |
+| 7.14 | Quit hover/focus | Underline + brighter; text uses ThemeColors.secondaryLabel |  |
+| 7.15 | Click Quit | App terminates |  |
+| 7.16 | Incident banner | If active incident: triangle icon + cycling MarqueeText replaces "Updated Xs ago" |  |
+
+> **States 7.2–7.5 require a degraded/down Anthropic status to verify against
+> real data.** If status.claude.com is healthy, mock by temporarily setting
+> a fake `ClaudeSystemStatus` in DEBUG. Otherwise capture screenshots once
+> a real incident occurs and attach to this checklist.
+
+## 8. Local-estimate fallback
+
+When `snapshot.rateLimits == nil && snapshot.isUsingLocalEstimate`:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 8.1 | Local estimate header renders | Info button beside label with caution-yellow tint |  |
+| 8.2 | VoiceOver info button | Reads "Why usage is estimated locally, Opens an explanation in your browser" |  |
+| 8.3 | Percent text VoiceOver | Reads with metric anchor: "5-Hour usage X percent" (NOT bare "X percent") |  |
+
+## 9. Insights — cost rows
+
+With Insights section expanded:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 9.1 | Per-model rows render | Model name, optional ▶ for active, cost ~$X, token count |  |
+| 9.2 | Active model glyph | ▶ in success-green |  |
+| 9.3 | Throttle warning glyph | If throttled count > 0, exclamationmark.triangle.fill appears beside "Throttled: N×" |  |
+| 9.4 | VoiceOver per-model row | Reads as ONE combined element: "Sonnet 4.6, active, ~$0.42, 18.3K tokens" |  |
+| 9.5 | VoiceOver throttle row | Reads "Throttled: 3×" — does NOT separately announce the warning glyph |  |
+
+## 10. Tutorial overlay (first launch only)
+
+If you've never dismissed the tutorial OR you reset `tutorialShown`:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 10.1 | Backdrop renders | Dim black overlay over popover content |  |
+| 10.2 | Step indicators | 3 dots — active = action blue, inactive = secondary at 0.45 opacity |  |
+| 10.3 | Tap step indicator | Advances to that step |  |
+| 10.4 | "Got it" closes overlay | Popover content visible again |  |
+
+## 11. Light mode / dark mode
+
+System Settings → Appearance → toggle between Light, Dark, Auto.
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 11.1 | Popover background | Adapts (panelBackground token) |  |
+| 11.2 | Status dot SF Symbol contrast | White glyph still readable in both modes |  |
+| 11.3 | FooterLink hover/focus brightening | Visible in both modes |  |
+| 11.4 | Metric toggle pill shadow | Visible in both modes (ThemeColors.shadowColor on selected tab) |  |
+
+## 12. Keyboard
+
+With popover open:
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 12.1 | `1` | Switches to 5h mode |  |
+| 12.2 | `2` | Switches to 7d mode |  |
+| 12.3 | `3` | Switches to Context Health mode |  |
+| 12.4 | `r` | Refreshes |  |
+| 12.5 | `←` / `→` | In Context Health mode, navigates sessions |  |
+| 12.6 | `esc` | Closes popover |  |
+| 12.7 | `Tab` through controls | Focus ring visible on each step on CollapsibleSectionHeader sites |  |
+
+## 13. Accessibility — VoiceOver smoke test
+
+Enable VoiceOver (Cmd+F5). Open the popover. Navigate with VO+→ from top to bottom.
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 13.1 | Title | "AI Battery" |  |
+| 13.2 | Account picker | "Switch account, Select which Claude account to display" |  |
+| 13.3 | Update icon | "Check for updates" OR "Version X.Y.Z available" |  |
+| 13.4 | Gear icon | "Settings, Open settings" (or "Close settings" when open) |  |
+| 13.5 | Each FooterLink | Reads label + hint, NEVER falls back to generic "button" |  |
+| 13.6 | Status dot | Reads the tooltip text (e.g. "All systems operational") |  |
+| 13.7 | Cost row | One combined utterance per model |  |
+| 13.8 | No double-announcements | Decorative glyphs (throttle triangle, active arrow already labelled separately) don't get spoken twice |  |
+
+## 14. Stress / edge cases
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 14.1 | Open and close popover 20× rapidly | No crash, no detached panel, no leaked window |  |
+| 14.2 | Toggle settings 10× rapidly | Smooth cross-fade each time, panel height settles correctly |  |
+| 14.3 | Resize Dynamic Type (System Settings → Display → Text Size) | Header still .center-aligns; popover stays within 1.3× width cap |  |
+| 14.4 | Colorblind mode on (Settings) | Bar colors switch to colorblind-safe palette; status-dot SF Symbols still visible |  |
+| 14.5 | Two accounts, one auth-expired | Active-account snapshot still renders for the valid one |  |
+| 14.6 | No data state | "No Claude Code data found" empty view renders |  |
+
+## 15. Build / install
+
+| # | Check | Pass criteria | Result |
+|---|-------|---------------|:------:|
+| 15.1 | `swift build -c release` clean | Exit 0, zero warnings |  |
+| 15.2 | `swift test` clean | All 980+ tests pass (954 from v2.3.0 + new pins) |  |
+| 15.3 | `swiftlint --quiet` | No new warnings from v2.3.1 files (12 force_unwrapping pre-existing in Services/ + Tests/, all from earlier releases) |  |
+| 15.4 | `./scripts/build-app.sh` | Produces .build/AIBattery.app + .dmg + .zip cleanly |  |
+| 15.5 | Bundle launches | `open .build/AIBattery.app` → menu bar icon appears in <2s |  |
+
+---
+
+## Sign-off
+
+- [ ] Every row marked pass OR has an explicit waiver note
+- [ ] CHANGELOG entry matches what was actually verified
+- [ ] Tester: ____________________
+- [ ] Date: ____________________

--- a/spec/UI_SPEC.md
+++ b/spec/UI_SPEC.md
@@ -98,8 +98,8 @@ All font sizes, spacing values, layout dimensions, and animation durations are d
 - **Typography** — 24 named font styles (e.g., `Typography.sectionHeader`, `Typography.monoValue`, `Typography.tinyLabel`, `Typography.trendSymbol`, `Typography.autoModeLabel`)
 - **Spacing** — 11 spacing constants (`micro` 1pt, `tight` 2pt, `xsmall` 3pt, `inner` 4pt, `small` 4pt, `gap` 6pt, `section` 8pt, `medium` 10pt, `authGap` 12pt, `sectionHorizontal` 16pt, `overlay` 24pt)
 - **Layout** — 35 dimension constants (`popoverWidth` 275pt, `chartHeight` 50pt, `barHeight` 8pt, `barCornerRadius` 3pt, `chevronFrame` 22pt, `dotSize` 8pt, `dotSizeSmall` 6pt, `tabCornerRadius` 4pt, `smallCornerRadius` 4pt, `bannerCornerRadius` 6pt, `iconClipRadius` 10pt, `cardCornerRadius` 12pt, `autoModeSize` 20pt, `chartSymbolSize` 12pt, `shadowSmall` 1pt, `glowRadius` 4pt, `borderWidth` 1.5pt, `subtleBorderWidth` 1pt, `costColumn` 46pt, `tokenColumn` 42pt, `insightLabel` 55pt, `marqueeHeight` 14pt, `spinnerSize` 10pt, `stateHeightLoading` 40pt, `stateHeightEmpty` 80pt, `stateHeightError` 100pt, `iconSize` 22pt, `settingsLabel` 50pt, `sliderValueLabel` 28pt, `appIconSize` 48pt, `activityModePickerWidth` 120pt, `indexColumn` 14pt, `tutorialCardMaxWidth` 280pt, `accountPickerMaxWidth` 100pt, `clipboardIconOffset` 13pt)
-- **ThemeColors** — surface elevation (`surfaceLevel1`, `surfaceLevel2`), interactive states (`hoverFill`, `copyableHoverFill`), opacity tokens (`dividerOpacity` 0.3, `overlayBackdropOpacity` 0.4, `inactiveIndicatorOpacity` 0.45, `subtleBorderOpacity` 0.2, `hoverBorderOpacity` 0.4, `activeLabelOpacity` 0.5, `focusRingOpacity` 0.6, `shadowOpacity` 0.25, `disabledOpacity` 0.55, `disabledDeepOpacity` 0.25, `subtleElementOpacity` 0.12, `subtleStrokeOpacity` 0.35, `chartGradientStartOpacity` 0.3, `chartGradientEndOpacity` 0.1, `activeAccentOpacity` 0.6, `activeElementFillOpacity` 0.15, `enabledControlOpacity` 0.6)
-- **MotionConstants** — 7 animation/transition tokens (`standard` 0.15s easeOut, `snappy` 0.1s easeOut, `smooth` 0.4s easeInOut, `fadeOut` 0.3s, `dialog` 0.2s, `spin` 0.5s, `expandTransition` opacity+move)
+- **ThemeColors** — surface elevation (`surfaceLevel1`, `surfaceLevel2`), semantic strokes (`inactiveStroke` for unselected/idle outlines, `shadowColor` for elevated-control shadows), interactive states (`hoverFill`, `copyableHoverFill`), opacity tokens (`dividerOpacity` 0.3, `overlayBackdropOpacity` 0.4, `inactiveIndicatorOpacity` 0.45, `subtleBorderOpacity` 0.2, `hoverBorderOpacity` 0.4, `activeLabelOpacity` 0.5, `focusRingOpacity` 0.6, `shadowOpacity` 0.25, `disabledOpacity` 0.55, `disabledDeepOpacity` 0.25, `subtleElementOpacity` 0.12, `subtleStrokeOpacity` 0.35, `chartGradientStartOpacity` 0.3, `chartGradientEndOpacity` 0.1, `activeAccentOpacity` 0.6, `activeElementFillOpacity` 0.15, `enabledControlOpacity` 0.6)
+- **MotionConstants** — animation/transition tokens (`standard` 0.15s easeOut, `snappy` 0.1s easeOut, `smooth` 0.4s easeInOut, `fadeOut` 0.3s, `fadeIn` 0.3s, `dialog` 0.2s, `spin` 0.5s, `expandTransition` plain `.opacity` — `.move(edge:)` is forbidden inside the popover because the NSPanel resizes around the inserting view and the slide reads as a "jump"). Marquee timing tokens: `marqueePauseSeconds` 0.5, `marqueeHoldSeconds` 3.0, `marqueeRestartSeconds` 0.1, `marqueeFadeSettleSeconds` 0.6, `marqueeScrollSpeed` 30 pts/s, `marqueeScroll(travelPoints:)` builder.
 
 Full token values are listed in `CONSTANTS.md > Design Tokens`.
 
@@ -109,6 +109,7 @@ All visual section dividers use `StyledDivider` — a shared component rendering
 
 ### ❶ Header (`PopoverHeaderView`)
 
+- Header HStack alignment: `.center` (not `.firstTextBaseline`). The title (`Typography.sectionHeader`) and the account picker (`Typography.caption`) are different sizes; baseline-aligning them put the picker visibly below the title cap. `.center` aligns their visual centers.
 - Title: `"✦ AI Battery"` (.headline)
 - **Account picker**: always-visible dropdown Menu next to title
   - Label: display name if set, otherwise `"Account N"` for multi-account / `"Account"` for single (.caption, ThemeColors.secondaryLabel)
@@ -125,7 +126,8 @@ All visual section dividers use `StyledDivider` — a shared component rendering
   - Background: `RoundedRectangle(cornerRadius: 6)` with `Color.yellow.opacity(0.08)` fill and `Color.yellow.opacity(0.25)` 1pt stroke, 8pt padding
   - Yellow circle icon + **"vX.Y.Z ↗"** (.caption2, ThemeColors.secondaryLabel) — clickable, opens GitHub release page
   - **"↓ Install Update"** (.caption2, .blue) — tries Sparkle in-app update; falls back to opening GitHub release if Sparkle not ready
-  - **"✕"** dismiss button (xmark.circle.fill, 14pt, ThemeColors.secondaryLabel) — hides banner, yellow icon stays yellow; clicking icon re-shows banner
+  - **"✕"** dismiss button (xmark.circle.fill, `Typography.bodyLabel`, ThemeColors.secondaryLabel) — hides banner, yellow icon stays yellow; clicking icon re-shows banner
+  - Install Update and Download buttons inside the banner use `LinkActionButton(size: .compact)` so they share font and spacing with every other inline action in the popover (Add Account, Test).
   - State: `@State updateBannerDismissed` (resets when yellow icon clicked)
 - Padding: H 16, V 6
 
@@ -248,6 +250,7 @@ Takes `sessions: [TokenHealthStatus]` array (top 5 by highest context usage). Ba
   - Left/right chevrons with `MotionConstants.snappy` animation (`.easeOut(duration: 0.1)`)
   - Counter: monospaced caption2, e.g. `"1/3"`
 - **Swipe gesture**: `DragGesture(minimumDistance: 20)` on main VStack — horizontal drag >50pt or fast flick (velocity >300pt/s) navigates prev/next session (same animation as chevron buttons)
+- **Session-swap transition**: `.transition(.opacity)` on the session info container — plain cross-fade only. `.move(edge:)` is banned for the same panel-resize reason called out for the expand transition: the row's height varies by model-name length and band hint, so a horizontal slide collides with the NSPanel re-anchor and reads as panel jitter.
 - **VoiceOver**: `.accessibilityAdjustableAction` on section — increment/decrement maps to next/previous session
 - **Stale session badge** (if lastActivity > 30 min and band != .green): amber dot (6pt) + `"Idle Xm"` (.caption2, .orange)
 - **Expanded tooltip**: `.help()` on session info label with full details — session ID, model, context window, all timestamps, all token counts, warnings
@@ -390,7 +393,7 @@ Links row in HStack (spacing 10):
 4. **Logout**: rectangle.portrait.and.arrow.right icon (9pt) + "Logout" → two-tap confirmation (first tap shows "Confirm?" in red, auto-reverts after 3s, second tap clears OAuth tokens)
 5. **Quit**: xmark.circle icon (9pt) + "Quit" → terminates app (also via Cmd+Q keyboard shortcut)
 
-Each button's inner HStack uses `.fixedSize()` to prevent text wrapping. Links row spacing: 10pt.
+All five entries are `FooterLink`s. External links (Usage, Status) pass `showsExternalArrow: true`; action links (Logout, Quit) pass `false`. Logout supplies `foregroundOverride: ThemeColors.danger` while `showLogoutConfirm` is true; Quit pins `foregroundOverride: ThemeColors.secondaryLabel`. Hover and `@FocusState` are unified — both cue an underline + brightened foreground so mouse and keyboard users get the same affordance. Each button's inner HStack uses `.fixedSize()` to prevent text wrapping. Links row spacing: 10pt.
 
 **Incident banner / timestamp** (mutually exclusive):
 - **Active incidents** (if `incidentNames` non-empty): triangle icon + `MarqueeText(texts:, color: statusColor)` cycling through all active incidents with cross-fade transitions (color matches incident severity). Replaces timestamp.
@@ -398,7 +401,7 @@ Each button's inner HStack uses `.fixedSize()` to prevent text wrapping. Links r
 
 All text: .caption2, ThemeColors.secondaryLabel. Padding: H 16, V 8 (section).
 
-Status colors: operational=green, degraded=yellow, partial=orange, major=red, maintenance=blue, unknown=gray
+Status colors: operational=green, degraded=yellow, partial=orange, major=red, maintenance=blue, unknown=gray. Non-operational dots overlay a small white SF Symbol inside the circle so severity is distinguishable without color (`exclamationmark` for degraded, `xmark` for partial/major outage, `wrench.adjustable` for maintenance). Operational and unknown stay plain dots. Symbol size scales off `Layout.dotSizeSmall * 0.72`.
 
 ### Loading / Error / Empty States
 


### PR DESCRIPTION
## Summary

Popover polish sweep on top of v2.3.0. Two visible bug fixes plus a deep sweep through design tokens, component reuse, and accessibility. No data-flow, auth, or feature changes.

**Visible fixes**

- **Header alignment** — the account picker no longer sits visibly below \"AI Battery\". The header HStack used `.firstTextBaseline`, which baseline-aligned the larger title (`sectionHeader`) with the smaller picker (`caption`) and pushed the picker's visual center down. Switched to `.center`.
- **Settings toggle no longer \"jumps down\"** — clicking the gear used to combine `.opacity + .move(edge: .top)` with an NSPanel that re-anchors to the menu bar while resizing. The slide and the panel resize fought each other and the whole popover read as jumping. Root-cause: switched `MotionConstants.expandTransition` (the token) to plain `.opacity`. Same pattern was applied across every collapsible (update banner, project usage, activity chart, token health) and TokenHealthSection's session swap.
- **Colorblind-safe status dot** — the footer status dot encoded operational vs degraded vs partial-outage vs major-outage with color only on a 6pt circle. Non-operational dots now overlay a small white SF Symbol (`exclamationmark`, `xmark`, `wrench.adjustable`) so severity is distinguishable without color.
- **Update-banner dismiss icon** dropped from oversized `Typography.heroTitle` to `Typography.bodyLabel`, matching sibling banner glyphs.

**Accessibility — 10 fixes**

- VoiceOver labels added to every icon-only button that was previously announced as a generic \"button\": local-estimate info, Sparkle Download, Sparkle-error dismiss, update-check icon, release-notes link, Install Update, banner dismiss, SettingsRow remove-account x, project sort/clear-search, AuthView cancel buttons, TokenHealthSection prev/next chevrons.
- `.accessibilityHint` paired with every label so VoiceOver describes the effect, not just the name.
- LocalEstimateSection percent text now reads with metric anchor (\"5-Hour usage 73 percent\" instead of bare \"73 percent\").
- InsightsTrendCostSection per-model rows combine into a single VoiceOver utterance with active-state context; decorative throttle glyph hidden from a11y; active-model ▶ gets explicit \"Active model\" label; copyText includes \"active\" suffix.

**Design system**

- **Extracted `GaugeRow`** — `UsageBar` (5h/7d) and `StandardLimitBar` (per-minute fallback) shared the same VStack[Header HStack + GaugeBar + TimelineView footer] shape with subtle drift. Both now build on the same shell via `headerLeading` / `headerTrailing` / `footer` ViewBuilders.
- **Extracted `LinkActionButton`** — four ad-hoc \"small text-styled link button\" implementations (Add Account / Test / Download / Install Update) collapsed into one component with `Size.standard` (settings) and `Size.compact` (in-banner) variants. Standardizes color, font, icon-to-label spacing, a11y-label fallback.
- **`FooterLink` carries Logout and Quit** — both buttons used to re-implement FooterLink's hover-underline pattern inline. `FooterLink` now accepts `showsExternalArrow` and `foregroundOverride`; ~30 lines of duplicate styling removed.
- **`FooterLink` hover and focus unified** — previously mouse users saw an underline-only signal and keyboard users saw a color-only signal. Both modalities now produce both cues.
- **New `ThemeColors` tokens**: `inactiveStroke` (= `.secondary`) for unselected outlines, `shadowColor` (= `.black`) for elevated controls. Replaces raw color refs in MetricToggleView, TutorialOverlay.
- **MarqueeText tokenized** — pause/hold/restart/fade-settle durations, scroll speed, and animation curve all moved out of inline literals into `MotionConstants.marquee*` tokens. Default font/color now `Typography.tinyLabel` / `ThemeColors.secondaryLabel`.
- **`MotionConstants.expandTransition` documented** — token doc-comment explains why `.move(edge:)` is banned inside the popover (NSPanel resize race), so the slide isn't re-added later.
- **`CollapsibleSectionHeader` focus ring** routed through `ThemeColors.action` (was `Color.accentColor`).
- **`AuthView` prominent buttons** routed through `ThemeColors.action` (was `.tint(.accentColor)`).

**Spec realignment** — `spec/ARCHITECTURE.md`, `spec/UI_SPEC.md`, `spec/CONSTANTS.md` updated to reflect the new component list, ThemeColors / MotionConstants tokens, header alignment, session-swap transition, FooterLink contract, status-dot SF Symbol overlay. Per CLAUDE.md, spec must match code before push — done.

**Regression coverage — 28 new tests** pinning every observable invariant the sprint introduced:

- 12 `MotionConstants` pins: `expandTransition` is `.opacity` (not `.move`), `fadeIn`/`fadeOut` symmetry, every `marquee*` constant, `marqueeScroll(travelPoints:)` math, negative-travel clamp.
- 2 `ThemeColors` pins: `inactiveStroke == .secondary`, `shadowColor == .black`.
- 8 `PopoverFooterStatusSymbol` pins: every indicator → symbol mapping, plus a sentinel for new non-operational states.
- 5 `LinkActionButton` pins: size-variant font choices.
- 1 structural ban test that walks `Views/` and fails if any source file contains `.move(edge:` — codifies the rule.

Plus `spec/QA-v2.3.1.md` — a 15-section, ~80-row manual QA checklist covering every popover state touched by this release. Designed to be executed against `.build/AIBattery.app` and signed off before tagging.

**Deferred to v2.3.2** — two pre-existing HIGH bugs found by codex audit, scoped out of this PR with explicit decision: MenuBarIcon `pulseStep` hardcoded to 0 (red-band breathing never animates); InsightsTrendCostSection 5H cost uses \"today\" data instead of trailing 5h window (wrong after midnight). Both are correctness bugs in data flow, not UI polish — warrant their own investigation cycles.

## Test plan

- [ ] CI green on `macos-15` (build + test + verify)
- [ ] Execute `spec/QA-v2.3.1.md` checklist against `.build/AIBattery.app`
- [ ] Manual VoiceOver smoke (section 13 of checklist)
- [ ] Visual verify in both light and dark mode
- [ ] Status-dot SF Symbol overlays on at least one non-operational state (mock or wait for real incident)
- [ ] Confirm CHANGELOG entry matches what shipped before tagging