### PR TITLE
ci: switch runners to macos-14 (fix release flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,12 @@ jobs:
   build-and-test:
     name: Build, Test & Verify
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft != true
-    runs-on: macos-15
+    # Switched from macos-15 → macos-14: the macos-15 image's Xcode/swift-testing
+    # combination produces 70%+ flake rate on this suite (SIGSEGV in
+    # swiftpm-testing-helper's parallel scheduler, or 6-min hangs). Locally the
+    # same 980-test suite runs in ~2.6s. macos-14 ships Xcode 15.x which is the
+    # stable baseline for Swift 5.9 / Swift Testing.
+    runs-on: macos-14
     # Bumped from 10 → 22: the test step has 3 × 6-minute retry attempts for
     # macos-15 swiftpm-testing-helper hangs. At 10 minutes the job timeout
     # cancelled before the retry logic could try a second attempt — observed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   release:
     name: Build & Publish
-    runs-on: macos-15
+    # See ci.yml for rationale on macos-14 vs macos-15.
+    runs-on: macos-14
     timeout-minutes: 15
     env:
       HAS_SPARKLE_KEY: ${{ secrets.SPARKLE_EDDSA_KEY != '' }}


### PR DESCRIPTION
## Why

The macos-15 runner image's swift-testing combo has a ~70% flake rate on this suite. Failures split between:

- SIGSEGV at test startup (instant crash in the parallel scheduler)
- 6-min hangs that never produce a summary

Both made v2.3.1 unable to release. The PR for the prior fix (#162) tried bumping retries 3→5 and `--no-parallel` — none of it worked.

## Evidence the code is fine

Locally on the same commit (`058fd0e`):

```
✔ Test run with 980 tests in 69 suites passed after 2.599 seconds.
```

Clean. So the issue is purely the runner image.

## Change

`runs-on: macos-15` → `macos-14` in both `ci.yml` and `release.yml`.

macos-14 ships Xcode 15.x — the stable baseline for Swift 5.9 / Swift Testing. v2.1–2.2 shipped on macos-15 without issue, but the image's flake rate has climbed since.

## Test plan

- [ ] CI green on this PR (proves macos-14 runs the suite cleanly)
- [ ] Merge → retag v2.3.1 from updated main → release.yml runs green on macos-14 → publishes