### PR TITLE
ci: restrict triggers + fix README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,26 @@
 name: CI
 
 on:
+  # Run on every push to main so the README badge tracks integration-branch
+  # health. Without this, the badge stays frozen on whatever the most-recent
+  # workflow run was — even when that was a cancelled manual dispatch from
+  # weeks ago — and shows red despite main being green.
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'spec/**'
+      - 'LICENSE'
+      - '.github/*.md'
+  # On PRs, only fire when the PR transitions out of draft. We deliberately do
+  # NOT include `synchronize` (= every push to the PR branch) because that
+  # produces dozens of skipped runs per feature-branch life and clutters the
+  # Actions tab. The flow is: develop in draft → mark ready when you want a
+  # validation pass → CI runs once. Use `workflow_dispatch` to force a re-run
+  # without leaving and re-entering draft.
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
+    types: [ready_for_review]
     paths-ignore:
       - '**.md'
       - 'spec/**'
@@ -18,7 +35,10 @@ concurrency:
 jobs:
   build-and-test:
     name: Build, Test & Verify
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft != true
+    # Defensive: with the triggers above, drafts never reach this workflow at
+    # all (only `ready_for_review` is wired). Keeping the check belt-and-braces
+    # in case the trigger config gets relaxed later.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: macos-15
     # Bumped from 10 → 22: the test step has 3 × 6-minute retry attempts for
     # macos-15 swiftpm-testing-helper hangs. At 10 minutes the job timeout

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Monitor rate limits, context health, and token usage — always visible in your 
 [![Swift](https://img.shields.io/badge/Swift-5.9-orange?logo=swift&logoColor=white)](https://swift.org)
 [![macOS](https://img.shields.io/badge/macOS-13%2B-blue?logo=apple&logoColor=white)](https://www.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![CI](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml/badge.svg)](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml)
+[![CI](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![GitHub stars](https://img.shields.io/github/stars/KyleNesium/AIBattery?style=social&cacheSeconds=3600)](https://github.com/KyleNesium/AIBattery/stargazers)
 [![Downloads](https://img.shields.io/github/downloads/KyleNesium/AIBattery/total?logo=github&label=Downloads&cacheSeconds=3600)](https://github.com/KyleNesium/AIBattery/releases)
 


### PR DESCRIPTION
## Summary

Two CI-hygiene fixes that hit at the same time.

### Fix 1 — Drop per-push CI noise on feature branches

`pull_request.types` was `[opened, synchronize]`, firing CI on every push to every PR branch. Drafts hit the skip-clause and exit in 1-2s, but they still clutter the Actions tab — PR #165 alone produced ~10 "skipped" runs across its commits.

Now `pull_request.types: [ready_for_review]` only. The flow becomes:

- Open PR as draft (default for `gh pr create --draft`).
- Push commits while iterating — no CI fires.
- Mark PR ready when you want a validation pass — CI runs once.
- Need a re-run without re-drafting? `gh workflow run ci.yml --ref <branch>`.

### Fix 2 — Track main in the README badge

The badge URL was `ci.yml/badge.svg` — defaults to the most-recent workflow run on the default branch, regardless of event type. The most recent run on main was a `cancelled` manual dispatch from 2026-05-11. The badge has shown red ever since despite every merged release shipping cleanly.

Two changes:
- Added `push: branches: [main]` trigger so post-merge CI runs land on main.
- Pinned the badge to `?branch=main&event=push` so it only reflects those runs (manual dispatches and PR ready-for-review runs no longer affect badge state).

## Behavior comparison

| Event | Before | After |
|---|---|---|
| Open PR (any draft state) | CI runs, skipped on draft via `if` | No CI fires until ready |
| Push to draft PR | CI runs, skipped via `if` | No CI fires |
| Mark draft PR ready | No event fires | **CI runs once** ✓ |
| Push to ready PR | CI runs | No CI fires (must `workflow_dispatch`) |
| Merge PR to main | No CI on main | **CI runs on push to main** ✓ |
| Push directly to main | No CI | **CI runs** ✓ |
| Manual dispatch | CI runs | CI runs (unchanged) |
| Tag `v*` push | Triggers `release.yml`, not this | Same, unchanged |

The "push to ready PR doesn't auto-rerun" is intentional. If you push fixes after CI fails, decide explicitly whether to re-run (dispatch) — avoids a feedback loop where every fix attempt burns macos-15 minutes.

## Verification

Can't really test this PR's behavior on itself without merging first — `pull_request` events evaluate the workflow file on the BASE branch (main) at event time, so until this lands on main, the OLD triggers apply to this PR. Once merged, future PRs use the new triggers.

To validate after merge:
1. Open a test PR as draft → confirm no CI runs.
2. Push commits → confirm no CI runs.
3. Mark ready → confirm one CI run.
4. Push more commits → confirm no auto re-run.
5. Merge → confirm CI runs on the resulting main push.
6. Confirm README badge state matches the main run's outcome.

## Test plan

- [x] YAML syntax — `gh workflow view` would parse this; the workflow loaded by GitHub on push confirms shape.
- [ ] CI behavior validation per the steps above (post-merge).
- [ ] README badge — visual check after the next push to main.

## Notes

- `release.yml` is untouched. It fires on `v*` tag push with its own test step. The pre-merge gate (this workflow) plus the release gate remain independent.
- The `if: github.event_name != 'pull_request' || github.event.pull_request.draft != true` clause is now defensive — with the new triggers, drafts can't reach this workflow. Kept the check belt-and-braces in case triggers get relaxed later.