### PR TITLE
feat: enable Swift 6 language mode (.v6) on all targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+
+Completes the Swift 6 migration started in 2.4.0.
+
+### Tooling
+- **Swift 6 language mode (`.swiftLanguageMode(.v6)`) enabled** across all three
+  SPM targets — the flip that 2.4.0 deferred. Production code builds with **zero
+  warnings, zero errors** under full Swift 6 enforcement. Because `.v6` enables
+  strict concurrency by default, the now-redundant `.enableUpcomingFeature("StrictConcurrency")`
+  flag was dropped from each target.
+- **The 2.4.0 deferral is retired.** The deadlock that blocked the flip — adopting
+  `isolated deinit` on the three `@MainActor` classes owning `Timer` / observer
+  state — turned out not to be required: the existing `nonisolated(unsafe)`
+  annotations on the deinit-touched stored properties are sufficient under the
+  Swift 6.3.2 toolchain, and `.v6` builds clean without touching `deinit`.
+- **Test target made `@MainActor`-clean under `.v6`.** Test suites that exercise
+  `@MainActor`-isolated statics (`MenuBarIcon`, `GaugeBar`, `InsightsViewFormatter`,
+  `PopoverFooterStatusSymbol`, `LinkActionButton`, `ActivityChartIsEmpty`,
+  `RateLimitFetcher`, `TokenHealthStatus`, `UsageSnapshot`) are now annotated
+  `@MainActor`, eliminating ~997 `#ActorIsolatedCall` warnings. Incidental cleanups
+  along the way: `@discardableResult` on two `SessionLogReaderDiscoveryTests`
+  helpers, two dead `let` bindings discarded, and two ambiguous `#require` checks
+  rewritten as `== true`. All 1015 tests in 69 suites pass.
+
 ## [2.4.1] — 2026-05-27
 
 Throttle-accuracy fixes plus UI polish.

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,7 @@ let package = Package(
             swiftSettings: [
                 .define("ENABLE_SPARKLE"),
                 .define("ENABLE_VERSION_CHECKER"),
-                .swiftLanguageMode(.v5),
-                .enableUpcomingFeature("StrictConcurrency")
+                .swiftLanguageMode(.v6)
             ]
         ),
         .executableTarget(
@@ -33,8 +32,7 @@ let package = Package(
             swiftSettings: [
                 .define("ENABLE_SPARKLE"),
                 .define("ENABLE_VERSION_CHECKER"),
-                .swiftLanguageMode(.v5),
-                .enableUpcomingFeature("StrictConcurrency")
+                .swiftLanguageMode(.v6)
             ]
         ),
         .testTarget(
@@ -44,8 +42,7 @@ let package = Package(
             swiftSettings: [
                 .define("ENABLE_SPARKLE"),
                 .define("ENABLE_VERSION_CHECKER"),
-                .swiftLanguageMode(.v5),
-                .enableUpcomingFeature("StrictConcurrency")
+                .swiftLanguageMode(.v6)
             ]
         )
     ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Monitor rate limits, context health, and token usage — always visible in your macOS menu bar.
 
-[![Swift](https://img.shields.io/badge/Swift-5.9-orange?logo=swift&logoColor=white)](https://swift.org)
+[![Swift](https://img.shields.io/badge/Swift-6.0-orange?logo=swift&logoColor=white)](https://swift.org)
 [![macOS](https://img.shields.io/badge/macOS-13%2B-blue?logo=apple&logoColor=white)](https://www.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![CI](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/KyleNesium/AIBattery/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)

--- a/Tests/AIBatteryCoreTests/Models/TokenHealthStatusTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/TokenHealthStatusTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import AIBatteryCore
 
 @Suite("TokenHealthStatus")
+@MainActor
 struct TokenHealthStatusTests {
     // MARK: - HealthBand raw values
 
@@ -20,16 +21,16 @@ struct TokenHealthStatusTests {
         #expect(status.suggestedAction == nil)
     }
 
-    @Test func suggestedAction_orange() throws {
+    @Test func suggestedAction_orange() {
         let status = makeStatus(band: .orange)
         #expect(status.suggestedAction != nil)
-        #expect(try #require(status.suggestedAction?.contains("trimming")))
+        #expect(status.suggestedAction?.contains("trimming") == true)
     }
 
-    @Test func suggestedAction_red() throws {
+    @Test func suggestedAction_red() {
         let status = makeStatus(band: .red)
         #expect(status.suggestedAction != nil)
-        #expect(try #require(status.suggestedAction?.contains("new conversation")))
+        #expect(status.suggestedAction?.contains("new conversation") == true)
     }
 
     @Test func suggestedAction_unknown() {

--- a/Tests/AIBatteryCoreTests/Models/UsageSnapshotTests.swift
+++ b/Tests/AIBatteryCoreTests/Models/UsageSnapshotTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import AIBatteryCore
 
 @Suite("UsageSnapshot")
+@MainActor
 struct UsageSnapshotTests {
     private func makeSnapshot(
         modelTokens: [ModelTokenSummary] = [],
@@ -639,7 +640,7 @@ struct UsageSnapshotTests {
             overallStatus: "allowed"
         )
         let snapshot = makeSnapshot(rateLimits: limits)
-        let candidate = snapshot.autoResolvedMode // .fiveHour (Tier 2, RL >=80%)
+        _ = snapshot.autoResolvedMode // .fiveHour (Tier 2, RL >=80%)
         // previous is also .fiveHour but from Tier 4 — same mode, so no conflict
         // Test a case where candidate differs: previous was .sevenDay binding, now .fiveHour escalation
         let result = UsageSnapshot.applyHysteresis(

--- a/Tests/AIBatteryCoreTests/Services/RateLimitFetcherTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/RateLimitFetcherTests.swift
@@ -3,10 +3,11 @@ import Foundation
 @testable import AIBatteryCore
 
 @Suite("RateLimitFetcher")
+@MainActor
 struct RateLimitFetcherTests {
     // MARK: - Fetch with no token returns empty
 
-    @Test @MainActor func fetch_emptyToken_returnsEmptyResult() async {
+    @Test func fetch_emptyToken_returnsEmptyResult() async {
         let fetcher = RateLimitFetcher()
         let result = await fetcher.fetch(accessToken: "", accountId: "test-account")
 
@@ -17,7 +18,7 @@ struct RateLimitFetcherTests {
 
     // MARK: - Multiple accounts use separate caches
 
-    @Test @MainActor func fetch_differentAccounts_separateResults() {
+    @Test func fetch_differentAccounts_separateResults() {
         // Previously this test did real `fetch(accessToken: "invalid-N", ...)` calls
         // and asserted both returned nil — which doesn't actually verify the
         // "separate caches" contract the test name claims. The real-network calls
@@ -68,7 +69,7 @@ struct RateLimitFetcherTests {
 
     // MARK: - Cached result marked as stale
 
-    @Test @MainActor func cachedOrEmpty_withinMaxAge_returnsCachedWithFlag() {
+    @Test func cachedOrEmpty_withinMaxAge_returnsCachedWithFlag() {
         let fetcher = RateLimitFetcher()
 
         // Inject a cached result
@@ -99,7 +100,7 @@ struct RateLimitFetcherTests {
         #expect(result.profile?.organizationId == "org-test")
     }
 
-    @Test @MainActor func cachedOrEmpty_staleCache_returnsStaleData() {
+    @Test func cachedOrEmpty_staleCache_returnsStaleData() {
         let fetcher = RateLimitFetcher()
 
         // Inject an old cached result (2 hours ago) — stale data is better than empty bars
@@ -127,7 +128,7 @@ struct RateLimitFetcherTests {
         #expect(result.isCached == true)
     }
 
-    @Test @MainActor func cachedOrEmpty_noCache_returnsEmpty() {
+    @Test func cachedOrEmpty_noCache_returnsEmpty() {
         let fetcher = RateLimitFetcher()
         let result = fetcher.cachedOrEmpty(accountId: "nonexistent")
 
@@ -140,7 +141,7 @@ struct RateLimitFetcherTests {
     /// window so the menu bar doesn't render a stale "100%" + broken star
     /// until a fresh fetch lands. Previously the cache was returned verbatim
     /// and only `restorePersistedRateLimits` (also at init) ran the normalizer.
-    @Test @MainActor func cachedOrEmpty_expiredFiveHourWindow_isCleared() {
+    @Test func cachedOrEmpty_expiredFiveHourWindow_isCleared() {
         let fetcher = RateLimitFetcher()
         let rateLimits = RateLimitUsage(
             representativeClaim: "five_hour",
@@ -266,7 +267,7 @@ struct RateLimitFetcherTests {
 
     // MARK: - Dynamic observed models
 
-    @Test @MainActor func observedModels_defaultsToEmpty() {
+    @Test func observedModels_defaultsToEmpty() {
         // Test parallelism + shared UserDefaults means other tests in this suite
         // can leave `aibattery_observedModels_*` keys behind even with `defer`
         // cleanup (the prefix scan in `restoreWorkingModels` may also pick up
@@ -281,7 +282,7 @@ struct RateLimitFetcherTests {
         #expect(fetcher.observedModels.isEmpty)
     }
 
-    @Test @MainActor func setObservedModels_updatesInMemoryList() {
+    @Test func setObservedModels_updatesInMemoryList() {
         let accountId = "test-updates-\(UUID().uuidString)"
         let key = "aibattery_observedModels_\(accountId)"
         defer { UserDefaults.standard.removeObject(forKey: key) }
@@ -291,7 +292,7 @@ struct RateLimitFetcherTests {
         #expect(fetcher.observedModels == ["model-a", "model-b"])
     }
 
-    @Test @MainActor func setObservedModels_persistsToUserDefaults() {
+    @Test func setObservedModels_persistsToUserDefaults() {
         let accountId = "test-persist-\(UUID().uuidString)"
         let key = "aibattery_observedModels_\(accountId)"
         defer { UserDefaults.standard.removeObject(forKey: key) }
@@ -303,7 +304,7 @@ struct RateLimitFetcherTests {
         #expect(stored == ["model-x", "model-y"])
     }
 
-    @Test @MainActor func observedModels_restoredOnInit() {
+    @Test func observedModels_restoredOnInit() {
         let accountId = "test-restore-\(UUID().uuidString)"
         let key = "aibattery_observedModels_\(accountId)"
         UserDefaults.standard.set(["restored-model-a", "restored-model-b"], forKey: key)
@@ -314,7 +315,7 @@ struct RateLimitFetcherTests {
         #expect(fetcher.observedModels == ["restored-model-a", "restored-model-b"])
     }
 
-    @Test @MainActor func setObservedModels_emptyList_fallsBackToUltimateFallback() {
+    @Test func setObservedModels_emptyList_fallsBackToUltimateFallback() {
         let fetcher = RateLimitFetcher()
         // No observed models set — fetch should still attempt the ultimate fallback
         // (We can't fully test network behavior, but we verify observedModels is empty)
@@ -323,12 +324,12 @@ struct RateLimitFetcherTests {
         // (verified by the hardcoded constant existing in the implementation)
     }
 
-    @Test @MainActor func ultimateFallback_isSingleHardcodedModel() {
+    @Test func ultimateFallback_isSingleHardcodedModel() {
         // Verify ultimateFallback constant exists and is the newest Sonnet
         #expect(RateLimitFetcher.ultimateFallback == "claude-sonnet-4-6-20250929")
     }
 
-    @Test @MainActor func hardcodedFallbackModels_noLongerExists() {
+    @Test func hardcodedFallbackModels_noLongerExists() {
         // This test documents that the 5-model hardcoded list is replaced.
         // We verify via observedModels being the dynamic source now.
         let fetcher = RateLimitFetcher()
@@ -341,7 +342,7 @@ struct RateLimitFetcherTests {
 
     /// Verifies that saveWorkingModel (called from fetch success paths) persists to UserDefaults
     /// and that restoreWorkingModels (called on init) rehydrates the in-memory map.
-    @Test @MainActor func workingModel_persistsAndRestores() {
+    @Test func workingModel_persistsAndRestores() {
         let accountId = "test-working-model-\(UUID().uuidString)"
         let key = "aibattery_probeModel_\(accountId)"
         defer { UserDefaults.standard.removeObject(forKey: key) }
@@ -351,7 +352,7 @@ struct RateLimitFetcherTests {
         UserDefaults.standard.set("claude-opus-4-5", forKey: key)
 
         // A fresh fetcher should restore the working model from UserDefaults on init
-        let fetcher = RateLimitFetcher()
+        _ = RateLimitFetcher() // restoreWorkingModels runs in init
 
         // The working model should be loaded into the in-memory map.
         // We verify indirectly: setCachedResult + cachedOrEmpty confirm the fetcher is
@@ -362,7 +363,7 @@ struct RateLimitFetcherTests {
 
     /// Verifies that the working model key prefix constant is stable.
     /// If this prefix changes, persisted probeModel UserDefaults keys would be orphaned.
-    @Test @MainActor func workingModelKeyPrefix_isStable() {
+    @Test func workingModelKeyPrefix_isStable() {
         // Construct a key the same way saveWorkingModel does and verify format
         let accountId = "acct-123"
         let expectedKey = "aibattery_probeModel_\(accountId)"
@@ -377,11 +378,11 @@ struct RateLimitFetcherTests {
     /// Documents that saveWorkingModel is called on 4 distinct success paths in tryFetch:
     /// (1) 200 OK path (via fetch loop), (2) 429+headers path, (3) 400+headers path,
     /// (4) retry-after path. This test acts as a structural regression guard.
-    @Test @MainActor func saveWorkingModel_calledOnAllSuccessPaths_structuralCheck() {
+    @Test func saveWorkingModel_calledOnAllSuccessPaths_structuralCheck() {
         // This test verifies the UserDefaults key is written after a successful cache injection.
         // The full network paths (429, 400, retry-after) are verified by code inspection
         // and the structural acceptance criteria in the plan (grep saveWorkingModel count >= 5).
-        let fetcher = RateLimitFetcher()
+        _ = RateLimitFetcher() // restoreWorkingModels runs in init
         let accountId = "structural-check-\(UUID().uuidString)"
         let key = "aibattery_probeModel_\(accountId)"
         defer { UserDefaults.standard.removeObject(forKey: key) }

--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderDiscoveryTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderDiscoveryTests.swift
@@ -16,6 +16,7 @@ struct SessionLogReaderDiscoveryTests {
         return projectsDir
     }
 
+    @discardableResult
     private func addJSONLFile(to projectsDir: URL, name: String = "session.jsonl") throws -> URL {
         let projectDir = try FileManager.default.contentsOfDirectory(
             at: projectsDir,
@@ -34,6 +35,7 @@ struct SessionLogReaderDiscoveryTests {
     }
 
     /// Adds a JSONL file to a specific project directory.
+    @discardableResult
     private func addJSONLFileToProject(in projectDir: URL, name: String) throws -> URL {
         let file = projectDir.appendingPathComponent(name)
         try Data("{}".utf8).write(to: file)

--- a/Tests/AIBatteryCoreTests/Utilities/MenuBarIconTests.swift
+++ b/Tests/AIBatteryCoreTests/Utilities/MenuBarIconTests.swift
@@ -3,6 +3,7 @@ import AppKit
 @testable import AIBatteryCore
 
 @Suite("MenuBarIcon")
+@MainActor
 struct MenuBarIconTests {
     private let testColor: NSColor = .systemGreen
 

--- a/Tests/AIBatteryCoreTests/Views/ActivityChartIsEmptyTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/ActivityChartIsEmptyTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import AIBatteryCore
 
 @Suite("ActivityChartIsEmpty")
+@MainActor
 struct ActivityChartIsEmptyTests {
     // The old InsightsView.isHourlyEmpty() static method was removed.
     // Emptiness is now determined by snapshot token fields directly.

--- a/Tests/AIBatteryCoreTests/Views/GaugeBarTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/GaugeBarTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @testable import AIBatteryCore
 
 @Suite("GaugeBar")
+@MainActor
 struct GaugeBarTests {
     // MARK: - Clamping logic
 

--- a/Tests/AIBatteryCoreTests/Views/InsightsViewFormatterTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/InsightsViewFormatterTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import AIBatteryCore
 
 @Suite("InsightsViewFormatter")
+@MainActor
 struct InsightsViewFormatterTests {
     // MARK: - CHART-02: formatHourLabelFull
 

--- a/Tests/AIBatteryCoreTests/Views/LinkActionButtonTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/LinkActionButtonTests.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// If a future change flips these mappings, the four call sites will silently
 /// drift in opposite directions — these tests fail loudly instead.
 @Suite("LinkActionButton")
+@MainActor
 struct LinkActionButtonTests {
     @Test func standard_labelFont_isCaption() {
         #expect(LinkActionButton.labelFont(for: .standard) == Typography.caption)

--- a/Tests/AIBatteryCoreTests/Views/PopoverFooterStatusSymbolTests.swift
+++ b/Tests/AIBatteryCoreTests/Views/PopoverFooterStatusSymbolTests.swift
@@ -5,6 +5,7 @@ import Testing
 /// state must carry a distinguishing SF Symbol overlay so severity is readable
 /// without color. Operational and unknown stay plain.
 @Suite("PopoverFooterStatusSymbol")
+@MainActor
 struct PopoverFooterStatusSymbolTests {
     @Test func operational_hasNoSymbol() {
         #expect(PopoverFooterView.statusSymbol(for: .operational) == nil)

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -248,7 +248,7 @@ CHANGELOG.md                      — Release notes per version
 
 ## Build Configuration
 
-- **SPM**: swift-tools-version 5.9, 3 targets: AIBatteryCore (library), AIBattery (executable), AIBatteryCoreTests (tests)
+- **SPM**: swift-tools-version 6.0, Swift 6 language mode (`.swiftLanguageMode(.v6)`) on all targets, 3 targets: AIBatteryCore (library), AIBattery (executable), AIBatteryCoreTests (tests)
 - **Platform**: macOS 13+ (Ventura)
 - **Sandbox**: Disabled (needs Keychain + filesystem access)
 - **Codesigning**: Ad-hoc by default (`codesign --sign -`), parameterized via `CODE_SIGN_IDENTITY` env var for Developer ID signing. Hardened runtime (`--options runtime`), entitlements embedded, bundle identifier sealed — gives the app a stable identity for Keychain ACL whitelisting. Entitlements file selected automatically (`AIBattery-AppStore.entitlements` when `APP_STORE_BUILD` is set)


### PR DESCRIPTION
## Summary

Completes the Swift 6 migration that **2.4.0 deferred**. Flips `.swiftLanguageMode(.v5)` → `.v6` across all three SPM targets and drops the now-redundant `.enableUpcomingFeature("StrictConcurrency")` flag (`.v6` enables strict concurrency by default).

**The 2.4.0 deferral reason is obsolete.** That release deferred the flip because it believed `.v6` required adopting `isolated deinit` on the three `@MainActor` classes owning `Timer`/observer state (`UsageViewModel`, `FileWatcher`, `StatusBarManager`), which had deadlocked the Swift Testing parallel runner. Under the **Swift 6.3.2** toolchain that's no longer true: the existing `nonisolated(unsafe)` annotations on the deinit-touched stored properties are sufficient, and `.v6` builds clean **without touching `deinit`**.

## Changes

- **`Package.swift`** — `.v5` → `.v6` on all three targets; removed redundant `StrictConcurrency` upcoming-feature flag.
- **Test target made `@MainActor`-clean** — 9 suites exercising `@MainActor`-isolated statics are now annotated `@MainActor` at the suite level, eliminating ~997 `#ActorIsolatedCall` warnings:
  `MenuBarIcon`, `GaugeBar`, `InsightsViewFormatter`, `PopoverFooterStatusSymbol`, `LinkActionButton`, `ActivityChartIsEmpty`, `RateLimitFetcher`, `TokenHealthStatus`, `UsageSnapshot`.
- **Removed 16 now-redundant per-method `@MainActor`** in `RateLimitFetcherTests` (the suite is `@MainActor`), matching the single-annotation style of the other eight suites.
- **Incidental cleanups** (pre-existing warnings surfaced by the clean build) — `@discardableResult` on two `SessionLogReaderDiscovery` helpers, two dead `let` bindings discarded, two ambiguous `#require(...)` checks rewritten as `== true` (also dropped the now-redundant `throws`).
- **Docs** — `spec/ARCHITECTURE.md` (tools-version 5.9 → 6.0 + language-mode note), `CHANGELOG.md` (`[Unreleased]` section retiring the deferral), `README.md` Swift badge 5.9 → 6.0. `project.yml` `SWIFT_VERSION` was already `6.0`.

## Verification

- ✅ `swift build -c release` — **0 warnings, 0 errors** (production)
- ✅ `swift build --build-tests` — **0 warnings, 0 errors** (tests)
- ✅ `swift test` — **all 1015 tests in 69 suites pass**
- ✅ `swiftformat --lint AIBattery/ AIBatteryApp/ Tests/` — clean (0/165 files require formatting)

## Test plan

- [ ] CI build + test green on `macos-15`
- [ ] CI lint green