### PR TITLE
ci: bump pinned GitHub Actions to current SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
     # /cleanup overhead.
     timeout-minutes: 22
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache SPM
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       HAS_SPARKLE_KEY: ${{ secrets.SPARKLE_EDDSA_KEY != '' }}
       HAS_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache SPM
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
@@ -107,7 +107,7 @@ jobs:
           cat checksums-sha256.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             .build/AIBattery.zip


### PR DESCRIPTION
## Summary

Routine CI dependency hygiene — bumps the SHA-pinned GitHub Actions to their current releases. No application code changes.

| Action | Was | Now | Notes |
|---|---|---|---|
| `actions/checkout` | v5 | **v6.0.2** | Node 20 → Node 24 runtime; no input/behavior changes |
| `actions/cache` | older v5 commit | **v5.0.5** | pin had drifted behind the v5 tag tip; same major |
| `softprops/action-gh-release` | v2 | **v3.0.0** | Node 20 → Node 24 runtime; no input/behavior changes |

Both major bumps are pure runtime moves to **Node 24** (no API/input changes), `macos-15` supports the Node 24 Actions runtime, and they get the repo off the soon-to-be-deprecated Node 20 actions. All pins remain commit SHAs with the version in a trailing comment.

**Sparkle** (the only SPM dependency) is already at **2.9.2**, the latest stable — no change.

## Verification

- Diff is exactly 6 `uses:` lines (SHA + version comment); no structural workflow changes.
- CI (lint, and build/test once ready-for-review) exercises `checkout` + `cache`; `release.yml` exercises `action-gh-release` on the next tag push.

## Test plan

- [ ] CI lint green on this PR
- [ ] CI build + test green (mark ready-for-review)
- [ ] Next release tag publishes cleanly via `action-gh-release` v3