### PR TITLE
ci: gate Homebrew cask on brew style to block deprecated syntax

### DIFF
--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -27,6 +27,25 @@ sed -i '' "s/sha256 \".*\"/sha256 \"${SHA256}\"/" "$CASK_FILE"
 echo "Updated cask formula:"
 head -5 "$CASK_FILE"
 
+# Validation gate: the cask must pass `brew style` before we publish it, so
+# deprecated syntax (e.g. the `depends_on macos: ">= :ventura"` string-comparison
+# form) can never reach users through the tap again. Auto-correct what Homebrew
+# can fix, then hard-fail the release if any offense remains.
+if command -v brew >/dev/null 2>&1; then
+  echo "Validating cask with brew style..."
+  brew style --fix "$CASK_FILE" || true
+  if ! brew style "$CASK_FILE"; then
+    echo "ERROR: brew style reported offenses in ${CASK_FILE} — aborting release." >&2
+    echo "Fix the cask in KyleNesium/homebrew-tap (or the generator) and re-run." >&2
+    exit 1
+  fi
+  echo "brew style: clean."
+else
+  echo "ERROR: brew not found on PATH — cannot validate cask. Aborting." >&2
+  echo "The release runner must have Homebrew installed to gate cask style." >&2
+  exit 1
+fi
+
 cd "$WORKDIR"
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

Users hit a deprecation warning installing/upgrading via the tap:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :ventura` instead.
  .../kylenesium/homebrew-tap/Casks/aibattery.rb:10
```

Root cause: `scripts/update-homebrew.sh` rewrites only `version`/`sha256` and commits whatever else is in the cask — so deprecated/invalid syntax ships silently with no gate.

## Fix

- **Live cask hotfixed** in `KyleNesium/homebrew-tap` (`99b193b`): `depends_on macos: ">= :ventura"` → `:ventura`, plus two other `brew style` offenses it surfaced (over-long `desc`, single-element `zap trash` array). Cask now passes `brew style` with **0 offenses** — warning stops on next `brew update`.
- **This PR** adds a `brew style` gate to the release script: auto-corrects what Homebrew can fix, then **hard-fails the release** if any offense remains (and fails if `brew` is missing on the runner). A deprecated cask can never reach the tap again.

## Test plan

- [x] `bash -n scripts/update-homebrew.sh` — syntax OK
- [x] `brew style Casks/aibattery.rb` on fixed cask — 1 file inspected, no offenses
- [ ] CI green