### PR TITLE
release: v2.5.1 — popover false 'Limit reached' hotfix

### DIFF
--- a/AIBattery/Info.plist
+++ b/AIBattery/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [2.5.0] — 2026-06-15
+## [2.5.1] — 2026-06-15
 
-Engineering-review hardening release: multi-account correctness (cross-account refresh race, per-account calibration), stale-data notification gating, Keychain migration safety, and faster auth-failure recovery.
+Hotfix for a false "Limit reached" that could appear in the popover on stale data.
 
 ### Fixed
 - **No more false "Limit reached" in the popover on stale data.** The menu bar already
@@ -16,6 +16,12 @@ Engineering-review hardening release: multi-account correctness (cross-account r
   7-day/throttled reading lingered in the cache and could surface that false alarm; the
   rate-limit cache now migrates on identity resolution and prunes orphans at launch,
   exactly as the token ledger does.
+
+## [2.5.0] — 2026-06-15
+
+Engineering-review hardening release: multi-account correctness (cross-account refresh race, per-account calibration), stale-data notification gating, Keychain migration safety, and faster auth-failure recovery.
+
+### Fixed
 - **Account switching mid-refresh can no longer mix up accounts' data.** A poll now
   requests the token for the exact account it started with (instead of whichever
   account is active by the time the request fires), and a fetch whose account was

--- a/project.yml
+++ b/project.yml
@@ -21,8 +21,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.KyleNesium.AIBattery
-        MARKETING_VERSION: "2.5.0"
-        CURRENT_PROJECT_VERSION: "2.5.0"
+        MARKETING_VERSION: "2.5.1"
+        CURRENT_PROJECT_VERSION: "2.5.1"
         SWIFT_VERSION: "6.0"
         MACOSX_DEPLOYMENT_TARGET: "13.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
v2.5.0 shipped (GitHub release + live Sparkle appcast) **before** the popover stale-alarm fix (#187) landed. Cutting **v2.5.1** is the auto-update-safe way to ship it — Sparkle never re-offers the same version string, so any client already on fix-less 2.5.0 only gets the fix via a higher version.

Changes (on top of main, which already contains #187):
- `Info.plist` + `project.yml`: 2.5.0 → 2.5.1
- `CHANGELOG.md`: move the popover/orphan-cache fix into a new `[2.5.1]` section (the shipped 2.5.0 did not contain it)

The fix itself (UsageBar.AlarmState confirmed-gate + RateLimitFetcher migrate/prune, 1088 tests) merged via #187. After this merges I'll tag v2.5.1 → release.yml builds/signs/publishes + updates appcast + Homebrew.