### PR TITLE
test: widen deadlock-detection timeout to stop CI flake

### DIFF
--- a/Tests/AIBatteryCoreTests/Services/SessionLogReaderTests.swift
+++ b/Tests/AIBatteryCoreTests/Services/SessionLogReaderTests.swift
@@ -530,8 +530,11 @@ struct SessionLogReaderTests {
             }
         }
 
-        // Must complete well within 5 seconds — any deadlock would hang here.
-        let result = group.wait(timeout: .now() + 5)
+        // A genuine deadlock hangs *forever*, so the timeout only needs to be large
+        // enough to never trip on a slow/loaded CI runner (e.g. a release build
+        // sharing the macos-15 box). 30s is generous margin — a real deadlock still
+        // fails the test, but legitimate slowness under contention does not flake it.
+        let result = group.wait(timeout: .now() + 30)
         #expect(result == .success)
     }
 


### PR DESCRIPTION
The README CI badge went red after the v2.5.1 main-push run (`27536476445`, commit 82dc5c5) — but the failure was a **flaky timing test**, not a regression: `concurrent_readAndInvalidate_noDeadlock` (`SessionLogReaderTests.swift`) waited only 5s for 20 concurrent read/invalidate ops and timed out while the v2.5.1 `release.yml` build shared the macos-15 runner. The same code passed on the PR and on #187's main-push.

A genuine deadlock hangs *forever*, so the timeout only needs to outlast a slow/loaded runner. Widened 5s → 30s: a real deadlock still fails the test; legitimate contention no longer flakes it. Test-only change, no behavior/version change.